### PR TITLE
Support svg as input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ All notable changes to the Rimage library will be documented in this file.
 - load system fonts for SVG text and substitute missing fonts with a warning: CJK text falls back to Microsoft YaHei UI, everything else falls back to the default font families
 - declare `rust-version = "1.88"` to track the effective minimum supported Rust version
 
+### Bug Fixes
+
+- show warning-level logs by default without `RUST_LOG`; drop the spurious premultiply warning that fired on every run without `--premultiply` and demote the routine missing-ICC-profile notice to debug level
+
 # [0.13.0](https://github.com/SalOne22/rimage/compare/v0.12.4...v0.13.0) (2026-08-14)
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to the Rimage library will be documented in this file.
 ### Bug Fixes
 
 - show warning-level logs by default without `RUST_LOG`; drop the spurious premultiply warning that fired on every run without `--premultiply` and demote the routine missing-ICC-profile notice to debug level
+- reject SVG render targets above 268 MP (2^28 pixels) with a decode error instead of attempting unbounded multi-gigabyte allocations that could terminate the process through out-of-memory
 
 # [0.13.0](https://github.com/SalOne22/rimage/compare/v0.12.4...v0.13.0) (2026-08-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the Rimage library will be documented in this file.
 
+# Unreleased
+
+### Features
+
+- add SVG input support rendered through `resvg` (static SVG and gzipped SVGZ), usable with every output format
+- add `--svg-scale`, `--svg-width` and `--svg-height` options that rasterize the SVG directly at the target size, so upscaling keeps the vector quality of the source
+- load system fonts for SVG text and substitute missing fonts with a warning: CJK text falls back to Microsoft YaHei UI, everything else falls back to the default font families
+- declare `rust-version = "1.88"` to track the effective minimum supported Rust version
+
 # [0.13.0](https://github.com/SalOne22/rimage/compare/v0.12.4...v0.13.0) (2026-08-14)
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to the Rimage library will be documented in this file.
 ### Bug Fixes
 
 - show warning-level logs by default without `RUST_LOG`; drop the spurious premultiply warning that fired on every run without `--premultiply` and demote the routine missing-ICC-profile notice to debug level
-- reject SVG render targets above 268 MP (2^28 pixels) with a decode error instead of attempting unbounded multi-gigabyte allocations that could terminate the process through out-of-memory
+- reject SVG render targets whose three live pixel buffers would exceed a 512 MiB decode budget (currently 44,739,242 pixels) instead of attempting multi-gigabyte allocations that could terminate the process through out-of-memory
 
 # [0.13.0](https://github.com/SalOne22/rimage/compare/v0.12.4...v0.13.0) (2026-08-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Rimage library will be documented in this file.
 
 ### Features
 
+- replace the `libavif` AVIF decoder with a `dav1d`-based one (`dav1d` + `avif-parse` + `yuvutils-rs`); decoding now links a system-installed `dav1d` (>= 1.3.0) through pkg-config instead of building libaom from source with cmake. Still-image AVIF only: grid collages and animated sequences are rejected with a decode error, 10/12-bit sources are converted to 8-bit output, and ICC profiles are not applied
 - add SVG input support rendered through `resvg` (static SVG and gzipped SVGZ), usable with every output format
 - add `--svg-scale`, `--svg-width` and `--svg-height` options that rasterize the SVG directly at the target size, so upscaling keeps the vector quality of the source
 - load system fonts for SVG text and substitute missing fonts with a warning: CJK text falls back to Microsoft YaHei UI, everything else falls back to the default font families

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to the Rimage library will be documented in this file.
 ### Features
 
 - add SVG input support rendered through `resvg` (static SVG and gzipped SVGZ), usable with every output format
-- add `--svg-scale`, `--svg-width` and `--svg-height` options that rasterize the SVG directly at the target size, so upscaling keeps the vector quality of the source
+- resize SVG inputs through the existing `--resize` option by rendering the SVG vectorly with `resvg` directly at the final target size, so upscaling keeps the vector quality of the source; the SVG-specific `--svg-scale`, `--svg-width` and `--svg-height` options were removed
 - load system fonts for SVG text and substitute missing fonts with a warning: the serif default and the CJK fallback are resolved once at load time from platform-appropriate seeds (Times New Roman/Liberation Serif/DejaVu Serif, YaHei/PingFang/Noto CJK), the `serif` generic alias is pointed at a family that actually exists, and a text span is never dropped for the lack of a font — as a last resort it renders with whatever face the system has
 - declare `rust-version = "1.88"` to track the effective minimum supported Rust version
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,15 @@ All notable changes to the Rimage library will be documented in this file.
 
 # Unreleased
 
+### Breaking Changes
+
+- add SVG input support rendered through `resvg` (static SVG and gzipped SVGZ), usable with every output format
+
 ### Features
 
-- replace the `libavif` AVIF decoder with a `dav1d`-based one (`dav1d` + `avif-parse` + `yuvutils-rs`); decoding now links a system-installed `dav1d` (>= 1.3.0) through pkg-config instead of building libaom from source with cmake. Still-image AVIF only: grid collages and animated sequences are rejected with a decode error, 10/12-bit sources are converted to 8-bit output, and ICC profiles are not applied
-- add SVG input support rendered through `resvg` (static SVG and gzipped SVGZ), usable with every output format
-- resize SVG inputs through the existing `--resize` option by rendering the SVG vectorly with `resvg` directly at the final target size, so upscaling keeps the vector quality of the source; the SVG-specific `--svg-scale`, `--svg-width` and `--svg-height` options were removed
-- load system fonts for SVG text and substitute missing fonts with a warning: the serif default and the CJK fallback are resolved once at load time from platform-appropriate seeds (Times New Roman/Liberation Serif/DejaVu Serif, YaHei/PingFang/Noto CJK), the `serif` generic alias is pointed at a family that actually exists, and a text span is never dropped for the lack of a font — as a last resort it renders with whatever face the system has
-- declare `rust-version = "1.88"` to track the effective minimum supported Rust version
+- resize SVG inputs through the existing `--resize` option by rendering the SVG vectorly with `resvg` directly at the final target size, so upscaling keeps the vector quality of the source
+- load system fonts for SVG text and substitute missing fonts with a warning: the serif default and the CJK fallback are resolved once at load time from platform-appropriate seeds (Times New Roman/Liberation Serif/DejaVu Serif, etc., YaHei/PingFang/Noto CJK, etc.), the `serif` generic alias is pointed at a family that actually exists, and a text span is never dropped for the lack of a font — as a last resort it renders with whatever face the system has
+- declare `rust-version = "1.90"` to track the effective minimum supported Rust version
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to the Rimage library will be documented in this file.
 - replace the `libavif` AVIF decoder with a `dav1d`-based one (`dav1d` + `avif-parse` + `yuvutils-rs`); decoding now links a system-installed `dav1d` (>= 1.3.0) through pkg-config instead of building libaom from source with cmake. Still-image AVIF only: grid collages and animated sequences are rejected with a decode error, 10/12-bit sources are converted to 8-bit output, and ICC profiles are not applied
 - add SVG input support rendered through `resvg` (static SVG and gzipped SVGZ), usable with every output format
 - add `--svg-scale`, `--svg-width` and `--svg-height` options that rasterize the SVG directly at the target size, so upscaling keeps the vector quality of the source
-- load system fonts for SVG text and substitute missing fonts with a warning: CJK text falls back to Microsoft YaHei UI, everything else falls back to the default font families
+- load system fonts for SVG text and substitute missing fonts with a warning: the serif default and the CJK fallback are resolved once at load time from platform-appropriate seeds (Times New Roman/Liberation Serif/DejaVu Serif, YaHei/PingFang/Noto CJK), the `serif` generic alias is pointed at a family that actually exists, and a text span is never dropped for the lack of a font — as a last resort it renders with whatever face the system has
 - declare `rust-version = "1.88"` to track the effective minimum supported Rust version
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to the Rimage library will be documented in this file.
 
 - add SVG input support rendered through `resvg` (static SVG and gzipped SVGZ), usable with every output format
 - add `--svg-scale`, `--svg-width` and `--svg-height` options that rasterize the SVG directly at the target size, so upscaling keeps the vector quality of the source
-- load system fonts for SVG text and substitute missing fonts with a warning: CJK text falls back to Microsoft YaHei UI, everything else falls back to the default font families
+- load system fonts for SVG text and substitute missing fonts with a warning: the serif default and the CJK fallback are resolved once at load time from platform-appropriate seeds (Times New Roman/Liberation Serif/DejaVu Serif, YaHei/PingFang/Noto CJK), the `serif` generic alias is pointed at a family that actually exists, and a text span is never dropped for the lack of a font — as a last resort it renders with whatever face the system has
 - declare `rust-version = "1.88"` to track the effective minimum supported Rust version
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -195,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.22.1"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "bit_field"
@@ -270,6 +270,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
+]
 
 [[package]]
 name = "byteorder-lite"
@@ -353,15 +367,6 @@ dependencies = [
  "libc",
  "unicode-width",
  "windows-sys",
-]
-
-[[package]]
-name = "core_maths"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
-dependencies = [
- "libm",
 ]
 
 [[package]]
@@ -482,7 +487,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -563,6 +568,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 
 [[package]]
+name = "font-types"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64eb721ca85a34323425f4041adc5d82704d3782d5f8f03793bc012419dce23"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "fontconfig-parser"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -573,15 +587,14 @@ dependencies = [
 
 [[package]]
 name = "fontdb"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
+checksum = "2660c5e9157bf76d2db1294e4a9feba604ef610819a3b591088d0d8392a3290f"
 dependencies = [
  "fontconfig-parser",
  "log",
  "slotmap",
  "tinyvec",
- "ttf-parser",
 ]
 
 [[package]]
@@ -602,7 +615,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -681,6 +694,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "harfrust"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c03d949a14aa089bbb282f7dd76a498a7f684428e4257202efc119ec010376f9"
+dependencies = [
+ "bitflags",
+ "bytemuck",
+ "read-fonts",
+ "smallvec",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,9 +763,9 @@ dependencies = [
 
 [[package]]
 name = "imagesize"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09e54e57b4c48b40f7aec75635392b12b3421fa26fe8b4332e63138ed278459c"
+checksum = "65b27460c2c92b037f3f94c538ed9a3342f3fdf923606781629ccb35f82d042a"
 
 [[package]]
 name = "imgref"
@@ -800,7 +825,7 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1155,12 +1180,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
 name = "libwebp-sys"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1340,7 +1359,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1502,7 +1521,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1649,6 +1668,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "read-fonts"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046a7d674daf459825b32f5062056d6882db0d2f5a479fbd76ccfc870ac18709"
+dependencies = [
+ "bytemuck",
+ "font-types",
+ "once_cell",
+]
+
+[[package]]
 name = "regex"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1679,10 +1709,11 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "resvg"
-version = "0.47.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be183ad6a216aa96f33e4c8033b0988b8b3ea6fd2359d19af5bac4643fd8e81"
+checksum = "67e3803f97b999e80cbf7c6ecdd07a8102204d92e1633cf48783720c521196bd"
 dependencies = [
+ "bytemuck",
  "gif",
  "image-webp",
  "log",
@@ -1730,8 +1761,8 @@ dependencies = [
  "rgb",
  "serde",
  "serde_json",
+ "skrifa",
  "tiff",
- "ttf-parser",
  "webp",
  "winresource",
  "zune-core",
@@ -1767,24 +1798,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "rustybuzz"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
-dependencies = [
- "bitflags",
- "bytemuck",
- "core_maths",
- "log",
- "smallvec",
- "ttf-parser",
- "unicode-bidi-mirroring",
- "unicode-ccc",
- "unicode-properties",
- "unicode-script",
-]
-
-[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1811,7 +1824,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1871,6 +1884,16 @@ name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
+name = "skrifa"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819ab7d62b1d3e72d9d9dea5650bac30424f9111364bb94928dbf5ecad1baa68"
+dependencies = [
+ "bytemuck",
+ "read-fonts",
+]
 
 [[package]]
 name = "slab"
@@ -1936,6 +1959,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1967,7 +2001,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2090,43 +2124,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "ttf-parser"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
-dependencies = [
- "core_maths",
-]
-
-[[package]]
 name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
-name = "unicode-bidi-mirroring"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfa6e8c60bb66d49db113e0125ee8711b7647b5579dc7f5f19c42357ed039fe"
-
-[[package]]
-name = "unicode-ccc"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce61d488bcdc9bc8b5d1772c404828b17fc481c0a582b5581e95fb233aef503e"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-properties"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-script"
@@ -2154,26 +2161,25 @@ checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "usvg"
-version = "0.47.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d46cf96c5f498d36b7a9693bc6a7075c0bb9303189d61b2249b0dc3d309c07de"
+checksum = "977d0a4abdef933f424a99fe09f95576e089b90aebc6f016a3bc813762493e91"
 dependencies = [
  "base64",
  "data-url",
- "flate2",
  "fontdb",
+ "harfrust",
  "imagesize",
  "kurbo",
  "log",
  "pico-args",
  "roxmltree 0.21.1",
- "rustybuzz",
  "simplecss",
  "siphasher",
+ "skrifa",
  "strict-num",
  "svgtypes",
  "tiny-skia-path",
- "ttf-parser",
  "unicode-bidi",
  "unicode-script",
  "unicode-vo",
@@ -2244,7 +2250,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -2366,7 +2372,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,18 +311,18 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -522,9 +522,9 @@ dependencies = [
 
 [[package]]
 name = "fast_image_resize"
-version = "6.0.0"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12dd43e5011e8d8411a3215a0d57a2ec5c68282fb90eb5d7221fab0113442174"
+checksum = "e9c50201dc184ba6553da1695aac20a042efffbe2d84542cee31917c86c3ab1e"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -1089,9 +1089,9 @@ dependencies = [
 
 [[package]]
 name = "lcms2"
-version = "6.1.1"
+version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75877b724685dd49310bdbadbf973fc69b1d01992a6d4a861b928fc3943f87b"
+checksum = "80205450f4d8b4de92f18111de879f3df4a6b728915e89b73c38f7a59a81ad90"
 dependencies = [
  "bytemuck",
  "foreign-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -43,9 +43,9 @@ checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
 
 [[package]]
 name = "alloc-stdlib"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
 dependencies = [
  "alloc-no-stdlib",
 ]
@@ -102,9 +102,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arbitrary"
@@ -120,7 +120,7 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -131,9 +131,9 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "as-slice"
@@ -146,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "av-scenechange"
@@ -186,9 +186,9 @@ dependencies = [
 
 [[package]]
 name = "avif-serialize"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375082f007bd67184fb9c0374614b29f9aaa604ec301635f72338bb65386a53d"
+checksum = "e7178fe5f7d460b13895ebb9dcb28a3a6216d2df2574a0806cb51b555d297f38"
 dependencies = [
  "arrayvec",
 ]
@@ -221,22 +221,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
 name = "brotli"
-version = "8.0.2"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -245,9 +233,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.0"
+version = "5.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -255,21 +243,21 @@ dependencies = [
 
 [[package]]
 name = "built"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
+checksum = "5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9"
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -293,9 +281,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "005ec2760ca554fae18df7a11195552ec576cd665632a881bc011d5bb2fd4d80"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -386,18 +374,18 @@ checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -405,18 +393,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -447,9 +435,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "encode_unicode"
@@ -487,7 +475,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -507,14 +495,16 @@ dependencies = [
 
 [[package]]
 name = "exr"
-version = "1.74.0"
+version = "1.74.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4300e043a56aa2cb633c01af81ca8f699a321879a7854d3896a0ba89056363be"
+checksum = "711fe42c9964295e01ee3fba3f9fe0e1d24b98886950d68efe81b1c76e21adf3"
 dependencies = [
  "bit_field",
  "half",
  "lebe",
  "miniz_oxide 0.8.9",
+ "num-complex",
+ "pulp",
  "rayon-core",
  "smallvec",
  "zune-inflate",
@@ -546,9 +536,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
 
 [[package]]
 name = "flate2"
@@ -609,13 +599,13 @@ dependencies = [
 
 [[package]]
 name = "foreign-types-macros"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+checksum = "ea5190182e6915eb873ddbc16e23b711b6eb1f9c00a0d0a3a91b5f6228475225"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -625,28 +615,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -662,8 +646,19 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
 ]
 
 [[package]]
@@ -678,9 +673,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "half"
@@ -701,27 +696,27 @@ checksum = "c03d949a14aa089bbb282f7dd76a498a7f684428e4257202efc119ec010376f9"
 dependencies = [
  "bitflags",
  "bytemuck",
- "read-fonts",
+ "read-fonts 0.41.0",
  "smallvec",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+checksum = "e17592d60ebacc7d5e169f4663c5f84f9161cc90328abcfe8456f41e4dfcb284"
 
 [[package]]
 name = "humantime"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
 
 [[package]]
 name = "image"
@@ -769,15 +764,15 @@ checksum = "65b27460c2c92b037f3f94c538ed9a3342f3fdf923606781629ccb35f82d042a"
 
 [[package]]
 name = "imgref"
-version = "1.12.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40fac9d56ed6437b198fddba683305e8e2d651aa42647f00f5ae542e7f5c94a2"
+checksum = "6e44b0a4eaa4c82f441d50a963f2d5f05a787240aeee097597033e72accfd22f"
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "cc4e190f5d26ca7051642629da2c52fc03bde85a03197c99408dcd291734c855"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -825,7 +820,7 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -862,29 +857,28 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom",
+ "getrandom 0.4.3",
  "libc",
 ]
 
 [[package]]
 name = "jpeg-encoder"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b0b36cbb4e6704f12f5b5d7b01dac593982c6550859ebd5a66fb15c9ea27fd5"
+checksum = "a0370574b86f7eca156b9f298392b5e69a23f8c86f3f865add60bbc2e79467a6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "ce57d20d1ea864ce2ac172ab472d409214f4fd359f0b2a2775abdf522e2af99e"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1100,9 +1094,9 @@ dependencies = [
 
 [[package]]
 name = "lcms2-sys"
-version = "4.0.6"
+version = "4.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c2604b23848ca80b2add60f0fb2270fd980e622c25029b6597fa01cfd5f8d5f"
+checksum = "264db0b78119c5a37d78bb41fb355daab29b3b29430b53cd92e3da51f0ab06cc"
 dependencies = [
  "cc",
  "dunce",
@@ -1147,37 +1141,43 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libdeflate-sys"
-version = "1.25.2"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72753e0008ea87963d2f0770042d0df7abe51fafbb8dcaf618ac440f2f1fec0a"
+checksum = "6949d73714ba8c32d2757405b89c94e427f64f078a4041debe07e1b8e9e850e9"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "libdeflater"
-version = "1.25.2"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1ee41cf6fb1bb6030dfb59ffb7bc01ab26aade44142084c87f0fc7a1658fe71"
+checksum = "0b72b274104f747cb65358c918e38c6cd4a69937937a36c8ad3cfd516c9c471e"
 dependencies = [
  "libdeflate-sys",
 ]
 
 [[package]]
 name = "libfuzzer-sys"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d"
+checksum = "a9fd2f41a1cba099f79a0b6b6c35656cf7c03351a7bae8ff0f28f25270f929d2"
 dependencies = [
  "arbitrary",
  "cc",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libwebp-sys"
@@ -1211,9 +1211,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "loop9"
@@ -1236,9 +1236,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miniz_oxide"
@@ -1319,9 +1319,9 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "no_std_io2"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b51ed7824b6e07d354605f4abb3d9d300350701299da96642ee084f5ce631550"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
 dependencies = [
  "memchr",
 ]
@@ -1343,11 +1343,21 @@ checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "bytemuck",
  "num-traits",
 ]
 
@@ -1359,14 +1369,14 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
  "num-traits",
 ]
@@ -1405,11 +1415,10 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oxipng"
-version = "10.1.1"
+version = "10.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eaaaa67c73558edaf5270e28abdf8d0663d88e8e7570cf894eff25305f4ed2"
+checksum = "52a88e3e5c2ad82e691b219e2b45a90eb5a51d26a434c7e191563e957a48e07a"
 dependencies = [
- "bitvec",
  "indexmap",
  "libdeflater",
  "log",
@@ -1445,9 +1454,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "png"
@@ -1473,9 +1482,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "ppv-lite86"
@@ -1498,37 +1507,60 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "profiling"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
 dependencies = [
  "profiling-procmacros",
 ]
 
 [[package]]
 name = "profiling-procmacros"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
+checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
-name = "pxfm"
-version = "0.1.29"
+name = "pulp"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+checksum = "046aa45b989642ec2e4717c8e72d677b13edd831a4d3b6cf37d9a3e54912496a"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "libm",
+ "num-complex",
+ "paste",
+ "pulp-wasm-simd-flag",
+ "raw-cpuid",
+ "reborrow",
+ "version_check",
+]
+
+[[package]]
+name = "pulp-wasm-simd-flag"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d8f70e07b9c3962945a74e59ca1c511bba65b6419468acc217c457d93f3c740"
+
+[[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
 
 [[package]]
 name = "quick-error"
@@ -1547,9 +1579,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -1561,16 +1593,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "radium"
-version = "0.7.0"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -1592,7 +1624,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1648,6 +1680,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1679,6 +1720,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "read-fonts"
+version = "0.43.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "005c8acf251756c478b0bf402885bfd88a1476020c4c7e6060edc1aa68da38ea"
+dependencies = [
+ "bytemuck",
+ "font-types",
+ "once_cell",
+]
+
+[[package]]
+name = "reborrow"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
+
+[[package]]
 name = "regex"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1692,9 +1750,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1761,7 +1819,7 @@ dependencies = [
  "rgb",
  "serde",
  "serde_json",
- "skrifa",
+ "skrifa 0.46.2",
  "tiff",
  "webp",
  "winresource",
@@ -1787,21 +1845,21 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -1809,29 +1867,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.5",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -1851,15 +1909,15 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simd_helpers"
@@ -1892,7 +1950,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819ab7d62b1d3e72d9d9dea5650bac30424f9111364bb94928dbf5ecad1baa68"
 dependencies = [
  "bytemuck",
- "read-fonts",
+ "read-fonts 0.41.0",
+]
+
+[[package]]
+name = "skrifa"
+version = "0.46.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4febebda507fb889c545a37a135517769d1391941013561292897961d1887d6"
+dependencies = [
+ "bytemuck",
+ "read-fonts 0.43.3",
 ]
 
 [[package]]
@@ -1912,9 +1980,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 
 [[package]]
 name = "stable_deref_trait"
@@ -1949,9 +2017,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1970,12 +2038,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1986,29 +2048,29 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.5",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
@@ -2067,9 +2129,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -2091,18 +2153,18 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tracing"
@@ -2176,7 +2238,7 @@ dependencies = [
  "roxmltree 0.21.1",
  "simplecss",
  "siphasher",
- "skrifa",
+ "skrifa 0.44.0",
  "strict-num",
  "svgtypes",
  "tiny-skia-path",
@@ -2211,18 +2273,18 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "aecb87a33d3b0c5e3b7aa46336eaf486cffafbd281b195e4c8b80d50df2351bf"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2233,9 +2295,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "a690d511e3c1a8b3a55e33511e3c2c00c78415cd23650f32b808627f5696b9ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2243,22 +2305,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "411e4887f0071ef2d2164a9d5fdf2d20efbef78fccd3a78b0c10a1dc5295e48a"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.5",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "81941cd78d0c92026c33e5e01312845a4cb1e9af3407f9134b100dd03144103e"
 dependencies = [
  "unicode-ident",
 ]
@@ -2314,9 +2376,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "winresource"
@@ -2335,15 +2397,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
-]
-
-[[package]]
 name = "xmlwriter"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2357,22 +2410,22 @@ checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2383,9 +2436,9 @@ checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zopfli"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1731,6 +1731,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tiff",
+ "ttf-parser",
  "webp",
  "winresource",
  "zune-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,10 +194,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bit_field"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+
+[[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bitstream-io"
@@ -314,6 +332,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -329,6 +353,15 @@ dependencies = [
  "libc",
  "unicode-width",
  "windows-sys",
+]
+
+[[package]]
+name = "core_maths"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
 ]
 
 [[package]]
@@ -385,6 +418,12 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "data-url"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
 name = "document-features"
@@ -453,6 +492,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "exr"
 version = "1.74.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,7 +509,7 @@ dependencies = [
  "bit_field",
  "half",
  "lebe",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
  "rayon-core",
  "smallvec",
  "zune-inflate",
@@ -483,10 +531,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide 0.9.1",
+ "zlib-rs",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+
+[[package]]
+name = "fontconfig-parser"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
+dependencies = [
+ "roxmltree 0.20.0",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser",
+]
 
 [[package]]
 name = "foreign-types"
@@ -555,6 +651,16 @@ dependencies = [
  "libc",
  "r-efi",
  "wasip2",
+]
+
+[[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
 ]
 
 [[package]]
@@ -629,6 +735,12 @@ dependencies = [
  "rgb",
  "thread_local",
 ]
+
+[[package]]
+name = "imagesize"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09e54e57b4c48b40f7aec75635392b12b3421fa26fe8b4332e63138ed278459c"
 
 [[package]]
 name = "imgref"
@@ -939,6 +1051,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "kurbo"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b60dfc32f652b926df6192e55525b16d186c69d47876c3ead4da5cc9f8450e2"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "polycool",
+ "smallvec",
+]
+
+[[package]]
 name = "lcms2"
 version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1031,6 +1155,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libwebp-sys"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1055,7 +1185,7 @@ dependencies = [
  "brotli",
  "crc",
  "log",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
  "paste",
  "quick-xml",
 ]
@@ -1098,6 +1228,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
+dependencies = [
+ "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1272,6 +1413,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1282,6 +1429,28 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide 0.8.9",
+]
+
+[[package]]
+name = "polycool"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50596ddc09eb5ad5f75cacd40209568e66df71baf86e1499a0e99c4cff12a5a6"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -1509,6 +1678,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "resvg"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9be183ad6a216aa96f33e4c8033b0988b8b3ea6fd2359d19af5bac4643fd8e81"
+dependencies = [
+ "gif",
+ "image-webp",
+ "log",
+ "pico-args",
+ "rgb",
+ "svgtypes",
+ "tiny-skia",
+ "usvg",
+ "zune-jpeg",
+]
+
+[[package]]
 name = "rgb"
 version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1540,6 +1726,7 @@ dependencies = [
  "ravif",
  "rayon",
  "regex",
+ "resvg",
  "rgb",
  "serde",
  "serde_json",
@@ -1549,6 +1736,21 @@ dependencies = [
  "zune-core",
  "zune-image",
  "zune-imageprocs",
+]
+
+[[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
+name = "roxmltree"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1562,6 +1764,24 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rustybuzz"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
+dependencies = [
+ "bitflags",
+ "bytemuck",
+ "core_maths",
+ "log",
+ "smallvec",
+ "ttf-parser",
+ "unicode-bidi-mirroring",
+ "unicode-ccc",
+ "unicode-properties",
+ "unicode-script",
+]
 
 [[package]]
 name = "serde"
@@ -1637,10 +1857,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "simplecss"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "smallvec"
@@ -1655,10 +1899,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+dependencies = [
+ "float-cmp",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "svgtypes"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "695b5790b3131dafa99b3bbfd25a216edb3d216dad9ca208d4657bfb8f2abc3d"
+dependencies = [
+ "kurbo",
+ "siphasher",
+]
 
 [[package]]
 name = "syn"
@@ -1727,6 +1990,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-skia"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47ffee5eaaf5527f630fb0e356b90ebdec84d5d18d937c5e440350f88c5a91ea"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "png",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca365c3faccca67d06593c5980fa6c57687de727a03131735bb85f01fdeeb9"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf0ded5c4e56918d8f8a339e1bb67d038d3bc6d144ac407904015ba2e4cde9b"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1785,10 +2089,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+dependencies = [
+ "core_maths",
+]
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
+name = "unicode-bidi-mirroring"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfa6e8c60bb66d49db113e0125ee8711b7647b5579dc7f5f19c42357ed039fe"
+
+[[package]]
+name = "unicode-ccc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce61d488bcdc9bc8b5d1772c404828b17fc481c0a582b5581e95fb233aef503e"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-script"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
+
+[[package]]
+name = "unicode-vo"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
 
 [[package]]
 name = "unicode-width"
@@ -1801,6 +2150,34 @@ name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
+name = "usvg"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d46cf96c5f498d36b7a9693bc6a7075c0bb9303189d61b2249b0dc3d309c07de"
+dependencies = [
+ "base64",
+ "data-url",
+ "flate2",
+ "fontdb",
+ "imagesize",
+ "kurbo",
+ "log",
+ "pico-args",
+ "roxmltree 0.21.1",
+ "rustybuzz",
+ "simplecss",
+ "siphasher",
+ "strict-num",
+ "svgtypes",
+ "tiny-skia-path",
+ "ttf-parser",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode-vo",
+ "xmlwriter",
+]
 
 [[package]]
 name = "utf8parse"
@@ -1960,6 +2337,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "xmlwriter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
+
+[[package]]
 name = "y4m"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1984,6 +2367,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,18 +297,18 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -517,9 +517,9 @@ dependencies = [
 
 [[package]]
 name = "fast_image_resize"
-version = "6.0.0"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12dd43e5011e8d8411a3215a0d57a2ec5c68282fb90eb5d7221fab0113442174"
+checksum = "e9c50201dc184ba6553da1695aac20a042efffbe2d84542cee31917c86c3ab1e"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -1064,9 +1064,9 @@ dependencies = [
 
 [[package]]
 name = "lcms2"
-version = "6.1.1"
+version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75877b724685dd49310bdbadbf973fc69b1d01992a6d4a861b928fc3943f87b"
+checksum = "80205450f4d8b4de92f18111de879f3df4a6b728915e89b73c38f7a59a81ad90"
 dependencies = [
  "bytemuck",
  "foreign-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name          = "rimage"
 version       = "0.13.0"
 edition       = "2024"
-rust-version  = "1.87.0"
+rust-version  = "1.96.0"
 description   = "Optimize images natively with best-in-class codecs"
 license       = "MIT OR Apache-2.0"
 readme        = "README.md"
@@ -93,7 +93,7 @@ avif = ["dep:ravif", "dep:libavif", "dep:rgb"]
 # Enables tiff codec
 tiff    = ["dep:tiff"]
 # Enables SVG input support (rendered via resvg)
-svg     = ["dep:resvg"]
+svg = ["dep:resvg", "dep:ttf-parser"]
 icc     = ["dep:lcms2"]
 console = ["dep:console"]
 
@@ -124,6 +124,7 @@ resvg = { version = "0.47.0", default-features = false, features = [
     "system-fonts",
     "raster-images",
 ], optional = true }
+ttf-parser = { version = "0.25.1", optional = true }
 
 # cli
 anyhow = { version = "1.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ avif = ["dep:ravif", "dep:libavif", "dep:rgb"]
 # Enables tiff codec
 tiff    = ["dep:tiff"]
 # Enables SVG input support (rendered via resvg)
-svg = ["dep:resvg", "dep:ttf-parser"]
+svg = ["dep:resvg", "dep:skrifa"]
 icc     = ["dep:lcms2"]
 console = ["dep:console"]
 
@@ -119,12 +119,14 @@ lcms2 = { version = "6.1", optional = true }
 tiff = { version = "0.11.3", default-features = false, features = [
     "lzw",
 ], optional = true }
-resvg = { version = "0.47.0", default-features = false, features = [
+resvg = { version = "0.48.1", default-features = false, features = [
     "text",
     "system-fonts",
     "raster-images",
 ], optional = true }
-ttf-parser = { version = "0.25.1", optional = true }
+skrifa = { version = "0.44", default-features = false, features = [
+    "std",
+], optional = true }
 
 # cli
 anyhow = { version = "1.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ console = ["dep:console"]
 log = "0.4"
 zune-core = { version = "0.5.1", features = ["std"] }
 zune-image = { version = "0.5.0", features = ["simd"] }
-fast_image_resize = { version = "6.0", optional = true }
+fast_image_resize = { version = "6.1", optional = true }
 imagequant = { version = "4.4", default-features = false, optional = true }
 rgb = { version = "0.8", optional = true }
 mozjpeg = { version = "0.10.13", default-features = false, features = [
@@ -115,7 +115,7 @@ ravif = { version = "0.13.0", optional = true }
 libavif = { version = "0.14.0", default-features = false, features = [
     "codec-aom",
 ], optional = true }
-lcms2 = { version = "6.1", optional = true }
+lcms2 = { version = "6.2", optional = true }
 tiff = { version = "0.11.3", default-features = false, features = [
     "lzw",
 ], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name          = "rimage"
 version       = "0.13.0"
 edition       = "2024"
-rust-version  = "1.96.0"
+rust-version  = "1.88.0"
 description   = "Optimize images natively with best-in-class codecs"
 license       = "MIT OR Apache-2.0"
 readme        = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,9 @@ console = ["dep:console"]
 
 [dependencies]
 log = "0.4"
-zune-core = { version = "0.5.1", features = ["std"] }
+# zune-core 0.5.3 would cause build error.
+# REF: https://github.com/etemesi254/zune-image/issues/439
+zune-core = { version = "=0.5.1", features = ["std"] }
 zune-image = { version = "0.5.0", features = ["simd"] }
 fast_image_resize = { version = "6.1", optional = true }
 imagequant = { version = "4.4", default-features = false, optional = true }
@@ -124,7 +126,7 @@ resvg = { version = "0.48.1", default-features = false, features = [
     "system-fonts",
     "raster-images",
 ], optional = true }
-skrifa = { version = "0.44", default-features = false, features = [
+skrifa = { version = "0.46.2", default-features = false, features = [
     "std",
 ], optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name          = "rimage"
 version       = "0.13.0"
 edition       = "2024"
+rust-version  = "1.87.0"
 description   = "Optimize images natively with best-in-class codecs"
 license       = "MIT OR Apache-2.0"
 readme        = "README.md"
@@ -41,6 +42,7 @@ default = [
     "webp",
     "avif",
     "tiff",
+    "svg",
     "threads",
     "metadata",
 ]
@@ -90,6 +92,8 @@ webp = ["dep:webp"]
 avif = ["dep:ravif", "dep:libavif", "dep:rgb"]
 # Enables tiff codec
 tiff    = ["dep:tiff"]
+# Enables SVG input support (rendered via resvg)
+svg     = ["dep:resvg"]
 icc     = ["dep:lcms2"]
 console = ["dep:console"]
 
@@ -114,6 +118,11 @@ libavif = { version = "0.14.0", default-features = false, features = [
 lcms2 = { version = "6.1", optional = true }
 tiff = { version = "0.11.3", default-features = false, features = [
     "lzw",
+], optional = true }
+resvg = { version = "0.47.0", default-features = false, features = [
+    "text",
+    "system-fonts",
+    "raster-images",
 ], optional = true }
 
 # cli

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ avif = ["dep:ravif", "dep:libavif", "dep:rgb"]
 # Enables tiff codec
 tiff    = ["dep:tiff"]
 # Enables SVG input support (rendered via resvg)
-svg = ["dep:resvg", "dep:ttf-parser"]
+svg = ["dep:resvg", "dep:skrifa"]
 icc     = ["dep:lcms2"]
 console = ["dep:console"]
 
@@ -119,12 +119,14 @@ lcms2 = { version = "6.2", optional = true }
 tiff = { version = "0.11.3", default-features = false, features = [
     "lzw",
 ], optional = true }
-resvg = { version = "0.47.0", default-features = false, features = [
+resvg = { version = "0.48.1", default-features = false, features = [
     "text",
     "system-fonts",
     "raster-images",
 ], optional = true }
-ttf-parser = { version = "0.25.1", optional = true }
+skrifa = { version = "0.44", default-features = false, features = [
+    "std",
+], optional = true }
 
 # cli
 anyhow = { version = "1.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -110,15 +110,15 @@ run before encoding. Operations execute in CLI argument order.
 `--resize` accepts one of the following value forms. Unless a fixed `WxH` is
 given, the aspect ratio is preserved:
 
-| Form  | Meaning                                                     | Example   | Result on 800x400 |
-| ----- | ----------------------------------------------------------- | --------- | ----------------- |
-| `WxH` | Fixed width and height, aspect ratio is not preserved       | `100x300` | `100x300`         |
-| `Ww`  | Anchor on the width, height follows the aspect ratio        | `100w`    | `100x50`          |
-| `hH`  | Anchor on the height, width follows the aspect ratio        | `200h`    | `400x200`         |
-| `Ll`  | Longest side becomes `L`, the other side follows            | `1000l`   | `1000x500`        |
-| `Ss`  | Shortest side becomes `S`, the other side follows           | `500s`    | `1000x500`        |
-| `@M`  | Scale by the multiplier `M`                                 | `@1.5`    | `1200x600`        |
-| `P%`  | Scale to `P` percent of the source                          | `50%`     | `400x200`         |
+| Form  | Meaning                                               | Example   | Result on 800x400 |
+| ----- | ----------------------------------------------------- | --------- | ----------------- |
+| `WxH` | Fixed width and height, aspect ratio is not preserved | `100x300` | `100x300`         |
+| `Ww`  | Anchor on the width, height follows the aspect ratio  | `100w`    | `100x50`          |
+| `hH`  | Anchor on the height, width follows the aspect ratio  | `200h`    | `400x200`         |
+| `Ll`  | Longest side becomes `L`, the other side follows      | `1000l`   | `1000x500`        |
+| `Ss`  | Shortest side becomes `S`, the other side follows     | `500s`    | `1000x500`        |
+| `@M`  | Scale by the multiplier `M`                           | `@1.5`    | `1200x600`        |
+| `P%`  | Scale to `P` percent of the source                    | `50%`     | `400x200`         |
 
 ```sh
 # Fixed dimensions: the image is resized to exactly 100x200

--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ For library usage check [Docs.rs](https://docs.rs/rimage/latest/rimage/)
 | ppm          | zune-ppm      | zune-ppm                |                                                      |
 | psd          | zune-psd      | ❌                      | Input only                                           |
 | qoi          | zune-qoi      | zune-qoi                |                                                      |
+| svg          | resvg         | ❌                      | Input only                                           |
 | tiff         | tiff          | ❌                      | Input only                                           |
 | webp         | webp          | webp                    | Static only                                          |
 

--- a/README.md
+++ b/README.md
@@ -215,6 +215,40 @@ rimage mozjpeg --resize 64x64 --filter nearest --quantization 80 ./image.jpg
 Note that `--filter` applies to all `--resize` invocations, and `--dithering`
 applies to all `--quantization` invocations.
 
+### SVG input
+
+SVG files (and gzipped `.svgz`) are rendered through `resvg` before encoding,
+so an SVG can be fed to any output format. By default the SVG renders at its
+intrinsic size — taken from its `width`/`height`, falling back to the
+`viewBox`.
+
+Because the source is vector data, sizing is **lossless at any scale**: the
+SVG is rasterized directly at the requested size instead of resampling an
+already-rendered bitmap, so edges, gradients and text stay exactly as sharp
+when you enlarge it. Do not use `--resize` to upscale an SVG — it would
+resample the rendered bitmap — use the options below to control the
+rasterization size instead.
+
+| Option                | Meaning                                                            | Example on a 100x50 SVG |
+| --------------------- | ------------------------------------------------------------------ | ----------------------- |
+| `--svg-scale <SCALE>` | Multiply both sides by `SCALE`                                     | `--svg-scale 2` → 200x100 |
+| `--svg-width <PIX>`   | Render at exactly this width; height follows the aspect ratio      | `--svg-width 400` → 400x200 |
+| `--svg-height <PIX>`  | Render at exactly this height; width follows the aspect ratio      | `--svg-height 200` → 400x100 |
+
+`--svg-scale` conflicts with `--svg-width`/`--svg-height`; `--svg-width` and
+`--svg-height` may be combined for a non-proportional fit.
+
+```sh
+# Render a 100x50 SVG at 2x and encode it as PNG
+rimage png --svg-scale 2 ./logo.svg
+
+# Render at a fixed width for a 2x-density asset, height follows
+rimage mozjpeg --svg-width 800 ./logo.svg
+```
+
+The options only affect `.svg`/`.svgz` inputs: raster images in the same batch
+ignore them and keep their own size.
+
 ### Advanced options
 
 If you want customize optimization you can provide additional options to encoders. For mozjpeg this options are valid:

--- a/README.md
+++ b/README.md
@@ -182,6 +182,15 @@ rimage mozjpeg --resize 2000l --resize 50% --reduce-only ./image.jpg  # 800x400 
 rimage mozjpeg --resize 1000l --filter nearest ./image.jpg
 ```
 
+SVG inputs are resized through the same `--resize` parameter. Instead of
+rasterizing the SVG at its intrinsic size and then resampling with
+`fast_image_resize`, the SVG is rendered vectorly with `resvg` directly at the
+final target size. Upscaling therefore keeps the vector quality of the source,
+and chained `--resize` values compose for SVG exactly as they do for raster
+images. `--filter` selects the raster resampling filter used by
+`fast_image_resize`; it is still accepted for SVG inputs (when `--resize` is
+present) but has no effect on vector SVG rendering.
+
 #### Quantization (color palette reduction)
 
 `--quantization` reduces the number of distinct colors in the image. It is **not** a

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,23 +14,23 @@ pub fn cli() -> Command {
         .arg_required_else_help(true)
         .after_help(indoc! {r#"
 List of supported codecs
-| Image Format  | Input | Output | Note            |
-| ------------- | ----- | ------ | --------------- |
-| avif          | O     | O      | Static only     |
-| bmp           | O     | X      |                 |
-| farbfeld      | O     | O      |                 |
-| hdr           | O     | O      |                 |
-| jpeg          | O     | O      |                 |
-| jpeg_xl(jxl)  | O     | O      |                 |
-| mozjpeg(moz)  | O     | O      |                 |
-| oxipng(oxi)   | O     | O      | Static only     |
-| png           | O     | O      | Static only     |
-| ppm           | O     | O      |                 |
-| psd           | O     | X      |                 |
-| qoi           | O     | O      |                 |
-| svg           | O     | X      | Rendered via resvg |
-| tiff          | O     | X      |                 |
-| webp          | O     | O      | Static only     |
+| Image Format  | Input | Output | Note              |
+| ------------- | ----- | ------ | ----------------- |
+| avif          | O     | O      | Static only       |
+| bmp           | O     | X      |                   |
+| farbfeld      | O     | O      |                   |
+| hdr           | O     | O      |                   |
+| jpeg          | O     | O      |                   |
+| jpeg_xl(jxl)  | O     | O      |                   |
+| mozjpeg(moz)  | O     | O      |                   |
+| oxipng(oxi)   | O     | O      | Static only       |
+| png           | O     | O      | Static only       |
+| ppm           | O     | O      |                   |
+| psd           | O     | X      |                   |
+| qoi           | O     | O      |                   |
+| svg           | O     | X      | Resize losslessly |
+| tiff          | O     | X      |                   |
+| webp          | O     | O      | Static only       |
 
 List of supported preprocessing options
 - Resize

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -28,6 +28,7 @@ List of supported codecs
 | ppm           | O     | O      |                 |
 | psd           | O     | X      |                 |
 | qoi           | O     | O      |                 |
+| svg           | O     | X      | Rendered via resvg |
 | tiff          | O     | X      |                 |
 | webp          | O     | O      | Static only     |
 

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -7,7 +7,7 @@ use super::{preprocessors::Preprocessors, utils::threads};
 
 impl CommonArgs for Command {
     fn common_args(self) -> Self {
-        self
+        let cmd = self
         .next_help_heading("General").args([
             arg!(files: <FILES> ... "Input file(s) to process.")
                 .long_help(indoc! {r#"Input file(s) to process.
@@ -58,8 +58,37 @@ impl CommonArgs for Command {
 
                 This will output the metadata of the processed image(s) in JSON format."#})
                 .value_parser(value_parser!(PathBuf)),
-        ])
-        .preprocessors()
+        ]);
+
+        #[cfg(feature = "svg")]
+        let cmd = cmd.next_help_heading("SVG").args([
+            arg!(--"svg-scale" <SCALE> "Uniform scale factor applied when rendering SVG input(s).")
+                .long_help(indoc! {r#"Uniform scale factor applied when rendering SVG input(s).
+
+                The SVG is rasterized directly at the scaled size, so upscaling keeps the vector quality of the source instead of resampling a smaller image.
+
+                For example, --svg-scale 2 renders a 100x100 SVG at 200x200.
+
+                Conflicts with --svg-width and --svg-height."#})
+                .value_parser(value_parser!(f32))
+                .conflicts_with_all(["svg-width", "svg-height"]),
+            arg!(--"svg-width" <PIXELS> "Target width in pixels when rendering SVG input(s).")
+                .long_help(indoc! {r#"Target width in pixels when rendering SVG input(s).
+
+                The SVG is rasterized directly at the target size, so upscaling keeps the vector quality of the source.
+
+                When provided without --svg-height, the height is derived while keeping the aspect ratio of the SVG."#})
+                .value_parser(value_parser!(u32).range(1..)),
+            arg!(--"svg-height" <PIXELS> "Target height in pixels when rendering SVG input(s).")
+                .long_help(indoc! {r#"Target height in pixels when rendering SVG input(s).
+
+                The SVG is rasterized directly at the target size, so upscaling keeps the vector quality of the source.
+
+                When provided without --svg-width, the width is derived while keeping the aspect ratio of the SVG."#})
+                .value_parser(value_parser!(u32).range(1..)),
+        ]);
+
+        cmd.preprocessors()
     }
 }
 

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -60,34 +60,6 @@ impl CommonArgs for Command {
                 .value_parser(value_parser!(PathBuf)),
         ]);
 
-        #[cfg(feature = "svg")]
-        let cmd = cmd.next_help_heading("SVG").args([
-            arg!(--"svg-scale" <SCALE> "Uniform scale factor applied when rendering SVG input(s).")
-                .long_help(indoc! {r#"Uniform scale factor applied when rendering SVG input(s).
-
-                The SVG is rasterized directly at the scaled size, so upscaling keeps the vector quality of the source instead of resampling a smaller image.
-
-                For example, --svg-scale 2 renders a 100x100 SVG at 200x200.
-
-                Conflicts with --svg-width and --svg-height."#})
-                .value_parser(value_parser!(f32))
-                .conflicts_with_all(["svg-width", "svg-height"]),
-            arg!(--"svg-width" <PIXELS> "Target width in pixels when rendering SVG input(s).")
-                .long_help(indoc! {r#"Target width in pixels when rendering SVG input(s).
-
-                The SVG is rasterized directly at the target size, so upscaling keeps the vector quality of the source.
-
-                When provided without --svg-height, the height is derived while keeping the aspect ratio of the SVG."#})
-                .value_parser(value_parser!(u32).range(1..)),
-            arg!(--"svg-height" <PIXELS> "Target height in pixels when rendering SVG input(s).")
-                .long_help(indoc! {r#"Target height in pixels when rendering SVG input(s).
-
-                The SVG is rasterized directly at the target size, so upscaling keeps the vector quality of the source.
-
-                When provided without --svg-width, the width is derived while keeping the aspect ratio of the SVG."#})
-                .value_parser(value_parser!(u32).range(1..)),
-        ]);
-
         cmd.preprocessors()
     }
 }

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -62,29 +62,31 @@ impl CommonArgs for Command {
 
         #[cfg(feature = "svg")]
         let cmd = cmd.next_help_heading("SVG").args([
-            arg!(--"svg-scale" <SCALE> "Uniform scale factor applied when rendering SVG input(s).")
+            arg!(--"svg-scale" <SCALE> "Uniform scale factor for SVG input(s); rendering is lossless at any size.")
                 .long_help(indoc! {r#"Uniform scale factor applied when rendering SVG input(s).
 
-                The SVG is rasterized directly at the scaled size, so upscaling keeps the vector quality of the source instead of resampling a smaller image.
+SVG is rendered straight from the vector data at the requested size, so enlarging is lossless: edges, gradients and text stay exactly as sharp as at the original size. This differs from --resize on a raster image, which resamples an already-rendered bitmap and softens it when upscaling.
 
-                For example, --svg-scale 2 renders a 100x100 SVG at 200x200.
+Without any of --svg-scale, --svg-width or --svg-height, the SVG renders at its intrinsic size (from its width/height or viewBox).
 
-                Conflicts with --svg-width and --svg-height."#})
+For example, --svg-scale 2 renders a 100x50 SVG at 200x100.
+
+Conflicts with --svg-width and --svg-height. Only applies to .svg and .svgz files; raster images in the same batch are not affected."#})
                 .value_parser(value_parser!(f32))
                 .conflicts_with_all(["svg-width", "svg-height"]),
-            arg!(--"svg-width" <PIXELS> "Target width in pixels when rendering SVG input(s).")
+            arg!(--"svg-width" <PIXELS> "Target width in pixels for SVG input(s); rendering is lossless at any size.")
                 .long_help(indoc! {r#"Target width in pixels when rendering SVG input(s).
 
-                The SVG is rasterized directly at the target size, so upscaling keeps the vector quality of the source.
+SVG is rendered straight from the vector data at the requested size, so enlarging is lossless: edges, gradients and text stay exactly as sharp as at the original size. This differs from --resize on a raster image, which resamples an already-rendered bitmap and softens it when upscaling.
 
-                When provided without --svg-height, the height is derived while keeping the aspect ratio of the SVG."#})
+When provided without --svg-height, the height is derived while keeping the aspect ratio of the SVG. Conflicts with --svg-scale. Only applies to .svg and .svgz files."#})
                 .value_parser(value_parser!(u32).range(1..)),
-            arg!(--"svg-height" <PIXELS> "Target height in pixels when rendering SVG input(s).")
+            arg!(--"svg-height" <PIXELS> "Target height in pixels for SVG input(s); rendering is lossless at any size.")
                 .long_help(indoc! {r#"Target height in pixels when rendering SVG input(s).
 
-                The SVG is rasterized directly at the target size, so upscaling keeps the vector quality of the source.
+SVG is rendered straight from the vector data at the requested size, so enlarging is lossless: edges, gradients and text stay exactly as sharp as at the original size. This differs from --resize on a raster image, which resamples an already-rendered bitmap and softens it when upscaling.
 
-                When provided without --svg-width, the width is derived while keeping the aspect ratio of the SVG."#})
+When provided without --svg-width, the width is derived while keeping the aspect ratio of the SVG. Conflicts with --svg-scale. Only applies to .svg and .svgz files."#})
                 .value_parser(value_parser!(u32).range(1..)),
         ]);
 

--- a/src/cli/pipeline.rs
+++ b/src/cli/pipeline.rs
@@ -8,6 +8,8 @@ use rimage::codecs::avif::AvifEncoder;
 use rimage::codecs::mozjpeg::MozJpegEncoder;
 #[cfg(feature = "oxipng")]
 use rimage::codecs::oxipng::OxiPngEncoder;
+#[cfg(feature = "svg")]
+use rimage::codecs::svg::{SvgDecoder, SvgOptions};
 #[cfg(feature = "webp")]
 use rimage::codecs::webp::WebPEncoder;
 use zune_core::{bytestream::ZByteWriterTrait, options::EncoderOptions};
@@ -23,11 +25,28 @@ use zune_image::{
 };
 use zune_imageprocs::premul_alpha::PremultiplyAlpha;
 
-pub fn decode<P: AsRef<Path>>(f: P) -> Result<Image, ImageErrors> {
+#[allow(unused_variables)]
+#[allow(unused_mut)]
+pub fn decode<P: AsRef<Path>>(f: P, matches: &ArgMatches) -> Result<Image, ImageErrors> {
     Image::open(f.as_ref()).or_else(|e| {
         if matches!(e, ImageErrors::ImageDecoderNotImplemented(_)) {
-            #[cfg(any(feature = "avif", feature = "webp"))]
+            #[cfg(any(feature = "avif", feature = "webp", feature = "svg"))]
             let mut file = File::open(f.as_ref())?;
+
+            #[cfg(feature = "svg")]
+            {
+                if f.as_ref()
+                    .extension()
+                    .is_some_and(|f| f.eq_ignore_ascii_case("svg") | f.eq_ignore_ascii_case("svgz"))
+                {
+                    let options = svg_options(matches, f.as_ref());
+                    let decoder = SvgDecoder::try_new_with_options(file, options)?;
+
+                    return Image::from_decoder(decoder);
+                }
+
+                file.seek(SeekFrom::Start(0))?;
+            }
 
             #[cfg(feature = "avif")]
             {
@@ -85,6 +104,16 @@ pub fn decode<P: AsRef<Path>>(f: P) -> Result<Image, ImageErrors> {
             Err(e)
         }
     })
+}
+
+#[cfg(feature = "svg")]
+fn svg_options(matches: &ArgMatches, path: &Path) -> SvgOptions {
+    SvgOptions {
+        resources_dir: path.parent().map(Path::to_path_buf),
+        scale: matches.get_one::<f32>("svg-scale").copied().unwrap_or(1.0),
+        width: matches.get_one::<u32>("svg-width").copied(),
+        height: matches.get_one::<u32>("svg-height").copied(),
+    }
 }
 
 #[allow(unused_variables)]

--- a/src/cli/pipeline.rs
+++ b/src/cli/pipeline.rs
@@ -206,6 +206,13 @@ pub fn operations(matches: &ArgMatches, img: &Image) -> BTreeMap<usize, Box<dyn 
             .into_iter()
             .zip(matches.indices_of("premultiply").unwrap())
             .for_each(|(value, idx)| {
+                // Position-sensitive flags inject a trailing default `false`
+                // occurrence when the flag is absent from the command line,
+                // which must stay silent.
+                if !*value {
+                    return;
+                }
+
                 if let Some(op) = map.get(&(idx + 2)) {
                     log::trace!("setup alpha premultiply for {}", op.name());
 

--- a/src/cli/pipeline.rs
+++ b/src/cli/pipeline.rs
@@ -1,10 +1,5 @@
 use std::io::{Seek, SeekFrom};
-use std::{
-    collections::BTreeMap,
-    fs::File,
-    io::Read,
-    path::{Path, PathBuf},
-};
+use std::{collections::BTreeMap, fs::File, io::Read, path::Path};
 
 #[cfg(feature = "resize")]
 use crate::cli::preprocessors::ResizeValue;
@@ -16,7 +11,9 @@ use rimage::codecs::mozjpeg::MozJpegEncoder;
 #[cfg(feature = "oxipng")]
 use rimage::codecs::oxipng::OxiPngEncoder;
 #[cfg(feature = "svg")]
-use rimage::codecs::svg::{SvgDecoder, SvgOptions};
+use rimage::codecs::svg::SvgDecoder;
+#[cfg(all(feature = "svg", not(feature = "resize")))]
+use rimage::codecs::svg::SvgOptions;
 #[cfg(feature = "webp")]
 use rimage::codecs::webp::WebPEncoder;
 use zune_core::{bytestream::ZByteWriterTrait, options::EncoderOptions};
@@ -46,9 +43,21 @@ pub fn decode<P: AsRef<Path>>(f: P, matches: &ArgMatches) -> Result<Image, Image
                     .extension()
                     .is_some_and(|f| f.eq_ignore_ascii_case("svg") | f.eq_ignore_ascii_case("svgz"))
                 {
-                    let options = svg_options(matches, f.as_ref(), &mut file)?;
-                    file.seek(SeekFrom::Start(0))?;
-                    let decoder = SvgDecoder::try_new_with_options(file, options)?;
+                    let resources_dir = f.as_ref().parent().map(Path::to_path_buf);
+
+                    #[cfg(feature = "resize")]
+                    let decoder = SvgDecoder::try_new_with_resize(file, resources_dir, |size| {
+                        svg_target_size(matches, size)
+                    })?;
+
+                    #[cfg(not(feature = "resize"))]
+                    let decoder = SvgDecoder::try_new_with_options(
+                        file,
+                        SvgOptions {
+                            resources_dir,
+                            target_size: None,
+                        },
+                    )?;
 
                     return Image::from_decoder(decoder);
                 }
@@ -114,42 +123,16 @@ pub fn decode<P: AsRef<Path>>(f: P, matches: &ArgMatches) -> Result<Image, Image
     })
 }
 
-#[cfg(feature = "svg")]
-fn svg_options(
-    matches: &ArgMatches,
-    path: &Path,
-    file: &mut File,
-) -> Result<SvgOptions, ImageErrors> {
-    let resources_dir = path.parent().map(Path::to_path_buf);
-
-    #[cfg(feature = "resize")]
-    let target_size = svg_target_size(matches, file, resources_dir.clone())?;
-    #[cfg(not(feature = "resize"))]
-    let target_size = None;
-
-    Ok(SvgOptions {
-        resources_dir,
-        target_size,
-    })
-}
-
 #[cfg(all(feature = "svg", feature = "resize"))]
 fn svg_target_size(
     matches: &ArgMatches,
-    file: &mut File,
-    resources_dir: Option<PathBuf>,
+    size: (usize, usize),
 ) -> Result<Option<(u32, u32)>, ImageErrors> {
     use crate::cli::preprocessors::ResizeValue;
 
     let Some(values) = matches.get_many::<ResizeValue>("resize") else {
         return Ok(None);
     };
-
-    let (intrinsic_width, intrinsic_height) = SvgDecoder::probe_size(file, resources_dir)?;
-    let size = (
-        (intrinsic_width.round() as usize).max(1),
-        (intrinsic_height.round() as usize).max(1),
-    );
 
     let downscale = matches.get_flag("downscale") && !matches.get_flag("no-downscale");
     let upscale = matches.get_flag("upscale") && !matches.get_flag("no-upscale");
@@ -162,12 +145,27 @@ fn svg_target_size(
         upscale,
     );
 
-    let final_size = plan.last().map(|(_, size)| *size).unwrap_or(size);
     if plan.is_empty() {
-        Ok(None)
-    } else {
-        Ok(Some((final_size.0 as u32, final_size.1 as u32)))
+        return Ok(None);
     }
+
+    let final_size = plan.last().map(|(_, size)| *size).unwrap_or(size);
+    let width = u32::try_from(final_size.0).map_err(|_| {
+        ImageErrors::ImageDecodeErrors(format!(
+            "SVG target width {} exceeds the maximum supported dimension of {}",
+            final_size.0,
+            u32::MAX
+        ))
+    })?;
+    let height = u32::try_from(final_size.1).map_err(|_| {
+        ImageErrors::ImageDecodeErrors(format!(
+            "SVG target height {} exceeds the maximum supported dimension of {}",
+            final_size.1,
+            u32::MAX
+        ))
+    })?;
+
+    Ok(Some((width, height)))
 }
 
 /// Plans a chain of resize operations, returning only the steps that are not
@@ -876,56 +874,65 @@ mod tests {
 
     #[cfg(feature = "svg")]
     mod svg_target_size_tests {
-        use std::fs::File;
+        use zune_image::errors::ImageErrors;
 
         use super::super::svg_target_size;
         use super::matches_from;
 
-        fn target_size(args: &[&str]) -> Option<(u32, u32)> {
+        fn target_size(args: &[&str]) -> Result<Option<(u32, u32)>, ImageErrors> {
             let mut file_args = vec!["rimage", "farbfeld"];
             file_args.extend_from_slice(args);
             file_args.push("tests/files/svg/rect.svg");
 
             let matches = matches_from(&file_args);
-            let mut file = File::open("tests/files/svg/rect.svg").unwrap();
-
-            svg_target_size(&matches, &mut file, None).unwrap()
+            svg_target_size(&matches, (100, 50))
         }
 
         #[test]
         fn multiplier_uses_vector_render_target() {
-            assert_eq!(target_size(&["--resize", "@2"]), Some((200, 100)));
+            assert_eq!(target_size(&["--resize", "@2"]).unwrap(), Some((200, 100)));
         }
 
         #[test]
         fn chained_resize_composes_for_svg() {
             assert_eq!(
-                target_size(&["--resize", "@2", "--resize", "50%"]),
+                target_size(&["--resize", "@2", "--resize", "50%"]).unwrap(),
                 Some((100, 50))
             );
         }
 
         #[test]
         fn intrinsic_size_returns_no_target() {
-            assert_eq!(target_size(&["--resize", "100x50"]), None);
+            assert_eq!(target_size(&["--resize", "100x50"]).unwrap(), None);
         }
 
         #[test]
         fn no_upscale_skips_growth_for_svg() {
-            assert_eq!(target_size(&["--resize", "200l", "--no-upscale"]), None);
+            assert_eq!(
+                target_size(&["--resize", "200l", "--no-upscale"]).unwrap(),
+                None
+            );
         }
 
         #[test]
         fn longest_side_upscales_svg_vectorly() {
-            assert_eq!(target_size(&["--resize", "200l"]), Some((200, 100)));
+            assert_eq!(
+                target_size(&["--resize", "200l"]).unwrap(),
+                Some((200, 100))
+            );
         }
 
         #[test]
         fn filter_is_accepted_but_ignored_for_svg_vector_resize() {
             assert_eq!(
-                target_size(&["--resize", "@2", "--filter", "nearest"]),
+                target_size(&["--resize", "@2", "--filter", "nearest"]).unwrap(),
                 Some((200, 100))
             );
+        }
+
+        #[test]
+        fn oversized_dimensions_are_rejected() {
+            assert!(target_size(&["--resize", "4294967396x4294967396"]).is_err());
         }
     }
 }

--- a/src/cli/pipeline.rs
+++ b/src/cli/pipeline.rs
@@ -928,6 +928,9 @@ mod tests {
             );
         }
 
+        // `usize` cannot exceed `u32::MAX` on 32-bit targets, so the
+        // overflow path this test guards only exists on 64-bit platforms.
+        #[cfg(target_pointer_width = "64")]
         #[test]
         fn oversized_dimensions_are_rejected() {
             assert!(target_size(&["--resize", "4294967396x4294967396"]).is_err());

--- a/src/cli/pipeline.rs
+++ b/src/cli/pipeline.rs
@@ -874,4 +874,58 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "svg")]
+    mod svg_target_size_tests {
+        use std::fs::File;
+
+        use super::super::svg_target_size;
+        use super::matches_from;
+
+        fn target_size(args: &[&str]) -> Option<(u32, u32)> {
+            let mut file_args = vec!["rimage", "farbfeld"];
+            file_args.extend_from_slice(args);
+            file_args.push("tests/files/svg/rect.svg");
+
+            let matches = matches_from(&file_args);
+            let mut file = File::open("tests/files/svg/rect.svg").unwrap();
+
+            svg_target_size(&matches, &mut file, None).unwrap()
+        }
+
+        #[test]
+        fn multiplier_uses_vector_render_target() {
+            assert_eq!(target_size(&["--resize", "@2"]), Some((200, 100)));
+        }
+
+        #[test]
+        fn chained_resize_composes_for_svg() {
+            assert_eq!(
+                target_size(&["--resize", "@2", "--resize", "50%"]),
+                Some((100, 50))
+            );
+        }
+
+        #[test]
+        fn intrinsic_size_returns_no_target() {
+            assert_eq!(target_size(&["--resize", "100x50"]), None);
+        }
+
+        #[test]
+        fn no_upscale_skips_growth_for_svg() {
+            assert_eq!(target_size(&["--resize", "200l", "--no-upscale"]), None);
+        }
+
+        #[test]
+        fn longest_side_upscales_svg_vectorly() {
+            assert_eq!(target_size(&["--resize", "200l"]), Some((200, 100)));
+        }
+
+        #[test]
+        fn filter_is_accepted_but_ignored_for_svg_vector_resize() {
+            assert_eq!(
+                target_size(&["--resize", "@2", "--filter", "nearest"]),
+                Some((200, 100))
+            );
+        }
+    }
 }

--- a/src/cli/pipeline.rs
+++ b/src/cli/pipeline.rs
@@ -137,9 +137,13 @@ fn svg_target_size(
     let downscale = matches.get_flag("downscale") && !matches.get_flag("no-downscale");
     let upscale = matches.get_flag("upscale") && !matches.get_flag("no-upscale");
 
+    let first_other = first_other_index(matches);
     let plan = resize_plan(
-        values,
-        matches.indices_of("resize").unwrap(),
+        values
+            .into_iter()
+            .zip(matches.indices_of("resize").unwrap())
+            .map(|(value, idx)| (idx, value))
+            .take_while(|(idx, _)| *idx < first_other),
         size,
         downscale,
         upscale,
@@ -168,6 +172,35 @@ fn svg_target_size(
     Ok(Some((width, height)))
 }
 
+/// Returns the index of the first non-resize preprocessing element.
+///
+/// SVG vector resizing can only be folded into the decode render target for
+/// the resize steps that come before every quantization operation and before
+/// every true `--premultiply` flag. Steps at or after this index must run as
+/// ordinary raster resize operations so command-line order is preserved.
+#[cfg(feature = "resize")]
+fn first_other_index(matches: &ArgMatches) -> usize {
+    let first_premultiply = matches.get_many::<bool>("premultiply").and_then(|values| {
+        values
+            .into_iter()
+            .zip(matches.indices_of("premultiply")?)
+            .find_map(|(value, idx)| if *value { Some(idx) } else { None })
+    });
+
+    #[cfg(feature = "quantization")]
+    let first_quantization = matches
+        .indices_of("quantization")
+        .and_then(|mut indices| indices.next());
+    #[cfg(not(feature = "quantization"))]
+    let first_quantization: Option<usize> = None;
+
+    [first_premultiply, first_quantization]
+        .into_iter()
+        .flatten()
+        .min()
+        .unwrap_or(usize::MAX)
+}
+
 /// Plans a chain of resize operations, returning only the steps that are not
 /// skipped by the direction flags or by already matching the current size.
 ///
@@ -176,17 +209,14 @@ fn svg_target_size(
 /// planned size as the vector render target).
 #[cfg(feature = "resize")]
 fn resize_plan<'a>(
-    values: impl Iterator<Item = &'a ResizeValue>,
-    indices: impl Iterator<Item = usize>,
+    values: impl Iterator<Item = (usize, &'a ResizeValue)>,
     mut size: (usize, usize),
     downscale: bool,
     upscale: bool,
 ) -> Vec<(usize, (usize, usize))> {
     let mut plan = Vec::new();
 
-    values.zip(indices).for_each(|(value, idx)| {
-        // Each value maps the size the previous resize left behind,
-        // so a chain composes instead of every value mapping the source dimensions.
+    values.for_each(|(idx, value)| {
         let (w, h) = value.map_dimensions(size.0, size.1);
         log::trace!("setup resize {value} on index {idx}");
 
@@ -229,7 +259,7 @@ pub fn operations(
         use fast_image_resize::ResizeAlg;
         use rimage::operations::resize::Resize;
 
-        if !skip_resize && let Some(values) = matches.get_many::<ResizeValue>("resize") {
+        if let Some(values) = matches.get_many::<ResizeValue>("resize") {
             let filter = matches.get_one::<ResizeFilter>("filter");
 
             let downscale = matches.get_flag("downscale") && !matches.get_flag("no-downscale");
@@ -237,9 +267,13 @@ pub fn operations(
 
             log::debug!("downscale: {downscale}, upscale: {upscale}");
 
+            let first_other = first_other_index(matches);
             let plan = resize_plan(
-                values,
-                matches.indices_of("resize").unwrap(),
+                values
+                    .into_iter()
+                    .zip(matches.indices_of("resize").unwrap())
+                    .map(|(value, idx)| (idx, value))
+                    .filter(|(idx, _)| !skip_resize || *idx >= first_other),
                 img.dimensions(),
                 downscale,
                 upscale,
@@ -870,6 +904,33 @@ mod tests {
         );
     }
 
+    #[test]
+    fn skip_resize_skips_only_leading_svg_steps() {
+        let matches = matches_from(&[
+            "rimage",
+            "farbfeld",
+            "--resize",
+            "@2",
+            "--quantization",
+            "80",
+            "--resize",
+            "50%",
+            "image.ff",
+        ]);
+
+        let img = test_image(200, 100);
+        let ops = operations(&matches, &img, true);
+
+        let resize_indices: Vec<usize> = ops
+            .iter()
+            .filter(|(_, op)| op.name() == "fast resize")
+            .map(|(idx, _)| *idx)
+            .collect();
+
+        let expected: Vec<usize> = matches.indices_of("resize").unwrap().skip(1).collect();
+        assert_eq!(resize_indices, expected);
+    }
+
     #[cfg(feature = "svg")]
     mod svg_target_size_tests {
         use zune_image::errors::ImageErrors;
@@ -908,6 +969,22 @@ mod tests {
         fn no_upscale_skips_growth_for_svg() {
             assert_eq!(
                 target_size(&["--resize", "200l", "--no-upscale"]).unwrap(),
+                None
+            );
+        }
+
+        #[test]
+        fn resize_after_quantization_is_not_preapplied() {
+            assert_eq!(
+                target_size(&["--quantization", "80", "--resize", "64x64"]).unwrap(),
+                None
+            );
+        }
+
+        #[test]
+        fn premultiply_before_resize_is_not_preapplied() {
+            assert_eq!(
+                target_size(&["--premultiply", "--resize", "64x64"]).unwrap(),
                 None
             );
         }

--- a/src/cli/pipeline.rs
+++ b/src/cli/pipeline.rs
@@ -1,6 +1,13 @@
 use std::io::{Seek, SeekFrom};
-use std::{collections::BTreeMap, fs::File, io::Read, path::Path};
+use std::{
+    collections::BTreeMap,
+    fs::File,
+    io::Read,
+    path::{Path, PathBuf},
+};
 
+#[cfg(feature = "resize")]
+use crate::cli::preprocessors::ResizeValue;
 use clap::ArgMatches;
 #[cfg(feature = "avif")]
 use rimage::codecs::avif::AvifEncoder;
@@ -39,7 +46,8 @@ pub fn decode<P: AsRef<Path>>(f: P, matches: &ArgMatches) -> Result<Image, Image
                     .extension()
                     .is_some_and(|f| f.eq_ignore_ascii_case("svg") | f.eq_ignore_ascii_case("svgz"))
                 {
-                    let options = svg_options(matches, f.as_ref());
+                    let options = svg_options(matches, f.as_ref(), &mut file)?;
+                    file.seek(SeekFrom::Start(0))?;
                     let decoder = SvgDecoder::try_new_with_options(file, options)?;
 
                     return Image::from_decoder(decoder);
@@ -107,62 +115,140 @@ pub fn decode<P: AsRef<Path>>(f: P, matches: &ArgMatches) -> Result<Image, Image
 }
 
 #[cfg(feature = "svg")]
-fn svg_options(matches: &ArgMatches, path: &Path) -> SvgOptions {
-    SvgOptions {
-        resources_dir: path.parent().map(Path::to_path_buf),
-        scale: matches.get_one::<f32>("svg-scale").copied().unwrap_or(1.0),
-        width: matches.get_one::<u32>("svg-width").copied(),
-        height: matches.get_one::<u32>("svg-height").copied(),
+fn svg_options(
+    matches: &ArgMatches,
+    path: &Path,
+    file: &mut File,
+) -> Result<SvgOptions, ImageErrors> {
+    let resources_dir = path.parent().map(Path::to_path_buf);
+
+    #[cfg(feature = "resize")]
+    let target_size = svg_target_size(matches, file, resources_dir.clone())?;
+    #[cfg(not(feature = "resize"))]
+    let target_size = None;
+
+    Ok(SvgOptions {
+        resources_dir,
+        target_size,
+    })
+}
+
+#[cfg(all(feature = "svg", feature = "resize"))]
+fn svg_target_size(
+    matches: &ArgMatches,
+    file: &mut File,
+    resources_dir: Option<PathBuf>,
+) -> Result<Option<(u32, u32)>, ImageErrors> {
+    use crate::cli::preprocessors::ResizeValue;
+
+    let Some(values) = matches.get_many::<ResizeValue>("resize") else {
+        return Ok(None);
+    };
+
+    let (intrinsic_width, intrinsic_height) = SvgDecoder::probe_size(file, resources_dir)?;
+    let size = (
+        (intrinsic_width.round() as usize).max(1),
+        (intrinsic_height.round() as usize).max(1),
+    );
+
+    let downscale = matches.get_flag("downscale") && !matches.get_flag("no-downscale");
+    let upscale = matches.get_flag("upscale") && !matches.get_flag("no-upscale");
+
+    let plan = resize_plan(
+        values,
+        matches.indices_of("resize").unwrap(),
+        size,
+        downscale,
+        upscale,
+    );
+
+    let final_size = plan.last().map(|(_, size)| *size).unwrap_or(size);
+    if plan.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some((final_size.0 as u32, final_size.1 as u32)))
     }
+}
+
+/// Plans a chain of resize operations, returning only the steps that are not
+/// skipped by the direction flags or by already matching the current size.
+///
+/// The same logic is used for raster images (which get a physical [`Resize`]
+/// operation for every planned step) and for SVG inputs (which use the final
+/// planned size as the vector render target).
+#[cfg(feature = "resize")]
+fn resize_plan<'a>(
+    values: impl Iterator<Item = &'a ResizeValue>,
+    indices: impl Iterator<Item = usize>,
+    mut size: (usize, usize),
+    downscale: bool,
+    upscale: bool,
+) -> Vec<(usize, (usize, usize))> {
+    let mut plan = Vec::new();
+
+    values.zip(indices).for_each(|(value, idx)| {
+        // Each value maps the size the previous resize left behind,
+        // so a chain composes instead of every value mapping the source dimensions.
+        let (w, h) = value.map_dimensions(size.0, size.1);
+        log::trace!("setup resize {value} on index {idx}");
+
+        // Skip if the image is already the desired size
+        // or if both downscale and upscale are disabled
+        if (!downscale && !upscale) || (w == size.0 && h == size.1) {
+            log::trace!("skip resize to {w}x{h} on index {idx}");
+            return;
+        }
+
+        if !downscale && (w <= size.0 || h <= size.1) {
+            log::trace!("downscaling disabled, skip resize to {w}x{h} on index {idx}");
+            return;
+        }
+
+        if !upscale && (w >= size.0 || h >= size.1) {
+            log::trace!("upscaling disabled, skip resize to {w}x{h} on index {idx}");
+            return;
+        }
+
+        plan.push((idx, (w, h)));
+        size = (w, h);
+    });
+
+    plan
 }
 
 #[allow(unused_variables)]
 #[allow(unused_mut)]
-pub fn operations(matches: &ArgMatches, img: &Image) -> BTreeMap<usize, Box<dyn OperationsTrait>> {
+pub fn operations(
+    matches: &ArgMatches,
+    img: &Image,
+    skip_resize: bool,
+) -> BTreeMap<usize, Box<dyn OperationsTrait>> {
     let mut map: BTreeMap<usize, Box<dyn OperationsTrait>> = BTreeMap::new();
 
     #[cfg(feature = "resize")]
     {
-        use crate::cli::preprocessors::{ResizeFilter, ResizeValue};
+        use crate::cli::preprocessors::ResizeFilter;
         use fast_image_resize::ResizeAlg;
         use rimage::operations::resize::Resize;
 
-        if let Some(values) = matches.get_many::<ResizeValue>("resize") {
-            let filter = matches.get_one::<ResizeFilter>("filter");
+        if !skip_resize {
+            if let Some(values) = matches.get_many::<ResizeValue>("resize") {
+                let filter = matches.get_one::<ResizeFilter>("filter");
 
-            let downscale = matches.get_flag("downscale") && !matches.get_flag("no-downscale");
-            let upscale = matches.get_flag("upscale") && !matches.get_flag("no-upscale");
+                let downscale = matches.get_flag("downscale") && !matches.get_flag("no-downscale");
+                let upscale = matches.get_flag("upscale") && !matches.get_flag("no-upscale");
 
-            log::debug!("downscale: {downscale}, upscale: {upscale}");
+                log::debug!("downscale: {downscale}, upscale: {upscale}");
 
-            let mut size = img.dimensions();
+                let plan = resize_plan(
+                    values,
+                    matches.indices_of("resize").unwrap(),
+                    img.dimensions(),
+                    downscale,
+                    upscale,
+                );
 
-            values
-                .into_iter()
-                .zip(matches.indices_of("resize").unwrap())
-                .for_each(|(value, idx)| {
-                    // Each value maps the size the previous resize left behind,
-                    // so a chain composes instead of every value mapping the source dimensions.
-                    let (w, h) = value.map_dimensions(size.0, size.1);
-                    log::trace!("setup resize {value} on index {idx}");
-
-                    // Skip if the image is already the desired size
-                    // or if both downscale and upscale are disabled
-                    if (!downscale && !upscale) || (w == size.0 && h == size.1) {
-                        log::trace!("skip resize to {w}x{h} on index {idx}");
-                        return;
-                    }
-
-                    if !downscale && (w <= size.0 || h <= size.1) {
-                        log::trace!("downscaling disabled, skip resize to {w}x{h} on index {idx}");
-                        return;
-                    }
-
-                    if !upscale && (w >= size.0 || h >= size.1) {
-                        log::trace!("upscaling disabled, skip resize to {w}x{h} on index {idx}");
-                        return;
-                    }
-
+                for (idx, (w, h)) in plan {
                     map.insert(
                         idx,
                         Box::new(Resize::new(
@@ -174,9 +260,8 @@ pub fn operations(matches: &ArgMatches, img: &Image) -> BTreeMap<usize, Box<dyn 
                                 .unwrap_or_default(),
                         )),
                     );
-
-                    size = (w, h);
-                })
+                }
+            }
         }
     }
 
@@ -536,7 +621,7 @@ mod tests {
         let matches = matches_from(&args);
         let mut img = test_image(width, height);
 
-        let ops = operations(&matches, &img);
+        let ops = operations(&matches, &img, false);
         let queued = ops.values().filter(|op| op.name() == "fast resize").count();
 
         for op in ops.values() {
@@ -788,4 +873,5 @@ mod tests {
             (1, (1000, 500))
         );
     }
+
 }

--- a/src/cli/pipeline.rs
+++ b/src/cli/pipeline.rs
@@ -229,36 +229,34 @@ pub fn operations(
         use fast_image_resize::ResizeAlg;
         use rimage::operations::resize::Resize;
 
-        if !skip_resize {
-            if let Some(values) = matches.get_many::<ResizeValue>("resize") {
-                let filter = matches.get_one::<ResizeFilter>("filter");
+        if !skip_resize && let Some(values) = matches.get_many::<ResizeValue>("resize") {
+            let filter = matches.get_one::<ResizeFilter>("filter");
 
-                let downscale = matches.get_flag("downscale") && !matches.get_flag("no-downscale");
-                let upscale = matches.get_flag("upscale") && !matches.get_flag("no-upscale");
+            let downscale = matches.get_flag("downscale") && !matches.get_flag("no-downscale");
+            let upscale = matches.get_flag("upscale") && !matches.get_flag("no-upscale");
 
-                log::debug!("downscale: {downscale}, upscale: {upscale}");
+            log::debug!("downscale: {downscale}, upscale: {upscale}");
 
-                let plan = resize_plan(
-                    values,
-                    matches.indices_of("resize").unwrap(),
-                    img.dimensions(),
-                    downscale,
-                    upscale,
+            let plan = resize_plan(
+                values,
+                matches.indices_of("resize").unwrap(),
+                img.dimensions(),
+                downscale,
+                upscale,
+            );
+
+            for (idx, (w, h)) in plan {
+                map.insert(
+                    idx,
+                    Box::new(Resize::new(
+                        w,
+                        h,
+                        filter
+                            .copied()
+                            .map(Into::<ResizeAlg>::into)
+                            .unwrap_or_default(),
+                    )),
                 );
-
-                for (idx, (w, h)) in plan {
-                    map.insert(
-                        idx,
-                        Box::new(Resize::new(
-                            w,
-                            h,
-                            filter
-                                .copied()
-                                .map(Into::<ResizeAlg>::into)
-                                .unwrap_or_default(),
-                        )),
-                    );
-                }
             }
         }
     }

--- a/src/codecs/mod.rs
+++ b/src/codecs/mod.rs
@@ -10,6 +10,10 @@ pub mod mozjpeg;
 #[cfg(feature = "oxipng")]
 pub mod oxipng;
 
+/// SVG input support
+#[cfg(feature = "svg")]
+pub mod svg;
+
 /// Tiff encoding support
 #[cfg(feature = "tiff")]
 pub mod tiff;

--- a/src/codecs/svg/decoder.rs
+++ b/src/codecs/svg/decoder.rs
@@ -1,0 +1,166 @@
+//! SVG decoder rendering vector images into raster pixels through `resvg`.
+
+use std::io::Read;
+use std::path::PathBuf;
+
+use resvg::tiny_skia;
+use resvg::usvg;
+use zune_core::colorspace::ColorSpace;
+use zune_image::errors::ImageErrors;
+use zune_image::image::Image;
+use zune_image::traits::DecoderTrait;
+
+use super::fonts;
+
+/// Options controlling how an SVG image is rendered into pixels.
+#[derive(Clone, Debug)]
+pub struct SvgOptions {
+    /// Directory used to resolve relative paths inside the SVG, such as the
+    /// `href` of an `<image>` element.
+    ///
+    /// Should be set to the directory containing the SVG file.
+    pub resources_dir: Option<PathBuf>,
+    /// Uniform scale factor applied to the SVG intrinsic size.
+    ///
+    /// Ignored when [`SvgOptions::width`] or [`SvgOptions::height`] is set.
+    /// Must be positive and finite. Defaults to `1.0`.
+    pub scale: f32,
+    /// Target width in pixels. When set without [`SvgOptions::height`], the
+    /// height is derived while keeping the aspect ratio of the SVG.
+    pub width: Option<u32>,
+    /// Target height in pixels. When set without [`SvgOptions::width`], the
+    /// width is derived while keeping the aspect ratio of the SVG.
+    pub height: Option<u32>,
+}
+
+impl Default for SvgOptions {
+    fn default() -> Self {
+        Self {
+            resources_dir: None,
+            scale: 1.0,
+            width: None,
+            height: None,
+        }
+    }
+}
+
+/// A decoder that renders SVG images into raster pixels using `resvg`.
+///
+/// Scaling happens while rendering, so any target size keeps the vector
+/// quality of the source instead of resampling a rasterized image.
+pub struct SvgDecoder {
+    tree: usvg::Tree,
+    intrinsic: (f32, f32),
+    target: (usize, usize),
+}
+
+impl SvgDecoder {
+    /// Create a new SVG decoder with default render options.
+    pub fn try_new<R: Read>(source: R) -> Result<Self, ImageErrors> {
+        Self::try_new_with_options(source, SvgOptions::default())
+    }
+
+    /// Create a new SVG decoder with custom render options.
+    pub fn try_new_with_options<R: Read>(
+        mut source: R,
+        options: SvgOptions,
+    ) -> Result<Self, ImageErrors> {
+        let mut data = Vec::new();
+        source.read_to_end(&mut data).map_err(|e| {
+            ImageErrors::ImageDecodeErrors(format!("Unable to read SVG data - {e}"))
+        })?;
+
+        let mut usvg_options = usvg::Options {
+            resources_dir: options.resources_dir.clone(),
+            font_resolver: fonts::font_resolver(),
+            ..usvg::Options::default()
+        };
+        usvg_options.fontdb = fonts::system_fontdb();
+
+        // `Tree::from_data` detects and decompresses gzip (SVGZ) automatically.
+        let tree = usvg::Tree::from_data(&data, &usvg_options)
+            .map_err(|e| ImageErrors::ImageDecodeErrors(format!("Unable to parse SVG - {e}")))?;
+
+        let size = tree.size();
+        let target = resolve_target_size(&options, size)?;
+
+        Ok(Self {
+            tree,
+            intrinsic: (size.width(), size.height()),
+            target,
+        })
+    }
+}
+
+/// Resolves the pixel size the SVG should be rendered at from the requested
+/// options and the intrinsic SVG size.
+fn resolve_target_size(
+    options: &SvgOptions,
+    size: usvg::Size,
+) -> Result<(usize, usize), ImageErrors> {
+    if !options.scale.is_finite() || options.scale <= 0.0 {
+        return Err(ImageErrors::ImageDecodeErrors(format!(
+            "Invalid SVG scale factor {}",
+            options.scale
+        )));
+    }
+
+    let scaled = match (options.width, options.height) {
+        (Some(width), Some(height)) => usvg::Size::from_wh(width as f32, height as f32),
+        (Some(width), None) => size.scale_to_width(width as f32),
+        (None, Some(height)) => size.scale_to_height(height as f32),
+        (None, None) => size.scale_by(options.scale),
+    }
+    .ok_or_else(|| ImageErrors::ImageDecodeErrors("Invalid SVG target size".to_string()))?;
+
+    // Rounds and clamps to at least 1x1.
+    let target = scaled.to_int_size();
+
+    Ok((target.width() as usize, target.height() as usize))
+}
+
+impl DecoderTrait for SvgDecoder {
+    fn decode(&mut self) -> Result<Image, ImageErrors> {
+        let (width, height) = self.target;
+
+        let mut pixmap = tiny_skia::Pixmap::new(width as u32, height as u32).ok_or_else(|| {
+            ImageErrors::ImageDecodeErrors(format!(
+                "Unable to allocate a {width}x{height} pixmap for SVG rendering"
+            ))
+        })?;
+
+        // Scaling happens here, so the vectors are rasterized directly at the
+        // target resolution instead of resampling a smaller image.
+        let transform = tiny_skia::Transform::from_scale(
+            width as f32 / self.intrinsic.0,
+            height as f32 / self.intrinsic.1,
+        );
+
+        resvg::render(&self.tree, transform, &mut pixmap.as_mut());
+
+        // tiny-skia stores premultiplied alpha while zune_image expects
+        // straight alpha.
+        let mut pixels = Vec::with_capacity(width * height * 4);
+        for pixel in pixmap.pixels() {
+            let color = pixel.demultiply();
+            pixels.extend_from_slice(&[color.red(), color.green(), color.blue(), color.alpha()]);
+        }
+
+        Ok(Image::from_u8(&pixels, width, height, ColorSpace::RGBA))
+    }
+
+    fn dimensions(&self) -> Option<(usize, usize)> {
+        Some(self.target)
+    }
+
+    fn out_colorspace(&self) -> ColorSpace {
+        ColorSpace::RGBA
+    }
+
+    fn name(&self) -> &'static str {
+        "svg-decoder"
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/codecs/svg/decoder.rs
+++ b/src/codecs/svg/decoder.rs
@@ -12,6 +12,14 @@ use zune_image::traits::DecoderTrait;
 
 use super::fonts;
 
+/// Maximum number of pixels an SVG render target may cover (2^28, ~268 MP).
+///
+/// At 4 bytes per pixel this bounds the render pixmap and the straight-alpha
+/// copy at ~1 GiB each, plus ~1 GiB of interleaved channels in the resulting
+/// [`Image`], which keeps worst-case transient memory bounded regardless of
+/// the SVG's declared size or the provided render options.
+pub const MAX_TARGET_PIXELS: u64 = 1 << 28;
+
 /// Options controlling how an SVG image is rendered into pixels.
 #[derive(Clone, Debug)]
 pub struct SvgOptions {
@@ -24,12 +32,18 @@ pub struct SvgOptions {
     ///
     /// Ignored when [`SvgOptions::width`] or [`SvgOptions::height`] is set.
     /// Must be positive and finite. Defaults to `1.0`.
+    ///
+    /// The resolved render target may not exceed [`MAX_TARGET_PIXELS`] pixels.
     pub scale: f32,
     /// Target width in pixels. When set without [`SvgOptions::height`], the
     /// height is derived while keeping the aspect ratio of the SVG.
+    ///
+    /// The resolved render target may not exceed [`MAX_TARGET_PIXELS`] pixels.
     pub width: Option<u32>,
     /// Target height in pixels. When set without [`SvgOptions::width`], the
     /// width is derived while keeping the aspect ratio of the SVG.
+    ///
+    /// The resolved render target may not exceed [`MAX_TARGET_PIXELS`] pixels.
     pub height: Option<u32>,
 }
 
@@ -115,6 +129,17 @@ fn resolve_target_size(
 
     // Rounds and clamps to at least 1x1.
     let target = scaled.to_int_size();
+
+    // The area is computed in u64 because width and height can each approach
+    // u32::MAX, whose product overflows usize.
+    let area = u64::from(target.width()) * u64::from(target.height());
+    if area > MAX_TARGET_PIXELS {
+        return Err(ImageErrors::ImageDecodeErrors(format!(
+            "SVG target size {}x{} ({area} pixels) exceeds the limit of {MAX_TARGET_PIXELS} pixels, reduce the SVG scale or the explicit dimensions",
+            target.width(),
+            target.height()
+        )));
+    }
 
     Ok((target.width() as usize, target.height() as usize))
 }

--- a/src/codecs/svg/decoder.rs
+++ b/src/codecs/svg/decoder.rs
@@ -12,13 +12,22 @@ use zune_image::traits::DecoderTrait;
 
 use super::fonts;
 
-/// Maximum number of pixels an SVG render target may cover (2^28, ~268 MP).
+/// Total bytes that may be live simultaneously while an SVG is decoded.
 ///
-/// At 4 bytes per pixel this bounds the render pixmap and the straight-alpha
-/// copy at ~1 GiB each, plus ~1 GiB of interleaved channels in the resulting
-/// [`Image`], which keeps worst-case transient memory bounded regardless of
-/// the SVG's declared size or the provided render options.
-pub const MAX_TARGET_PIXELS: u64 = 1 << 28;
+/// Decoding keeps three pixel-sized buffers alive at peak:
+/// the premultiplied `tiny_skia::Pixmap`, the straight-alpha interleaved
+/// copy built by [`SvgDecoder::decode`], and the deinterleaved channel
+/// buffers inside the resulting [`Image`]. The pixel limit is derived from
+/// this budget so a valid SVG cannot force an out-of-memory abort.
+const MAX_SVG_DECODE_BYTES: u64 = 512 * 1024 * 1024;
+
+const SVG_BYTES_PER_PIXEL: u64 = 4;
+
+const SVG_SIMULTANEOUS_PIXEL_BUFFERS: u64 = 3;
+
+/// Maximum number of pixels an SVG render target may cover.
+pub const MAX_TARGET_PIXELS: u64 =
+    MAX_SVG_DECODE_BYTES / (SVG_BYTES_PER_PIXEL * SVG_SIMULTANEOUS_PIXEL_BUFFERS);
 
 /// Options controlling how an SVG image is rendered into pixels.
 #[derive(Clone, Debug, Default)]
@@ -177,7 +186,7 @@ fn resolve_target_size(
     let area = (width as u64) * (height as u64);
     if area > MAX_TARGET_PIXELS {
         return Err(ImageErrors::ImageDecodeErrors(format!(
-            "SVG target size {width}x{height} ({area} pixels) exceeds the limit of {MAX_TARGET_PIXELS} pixels, reduce the --resize target or the intrinsic size",
+            "SVG target size {width}x{height} ({area} pixels) exceeds the limit of {MAX_TARGET_PIXELS} pixels ({MAX_SVG_DECODE_BYTES} byte decode budget), reduce the --resize target or the intrinsic size",
         )));
     }
 

--- a/src/codecs/svg/decoder.rs
+++ b/src/codecs/svg/decoder.rs
@@ -86,6 +86,44 @@ impl SvgDecoder {
         Self::try_new_with_options(source, SvgOptions::default())
     }
 
+    /// Parses the SVG once and resolves the render target through a caller
+    /// supplied callback.
+    ///
+    /// The callback receives the intrinsic SVG size as integer pixels and returns
+    /// the desired render target, or `Ok(None)` to render at the intrinsic size.
+    /// This avoids parsing the input twice when callers need to compute a resize
+    /// target from the intrinsic dimensions.
+    pub fn try_new_with_resize<R, F>(
+        source: R,
+        resources_dir: Option<PathBuf>,
+        target_for_size: F,
+    ) -> Result<Self, ImageErrors>
+    where
+        R: Read,
+        F: FnOnce((usize, usize)) -> Result<Option<(u32, u32)>, ImageErrors>,
+    {
+        let tree = parse_tree(source, resources_dir.clone())?;
+        let size = tree.size();
+        let intrinsic = (
+            (size.width().round() as usize).max(1),
+            (size.height().round() as usize).max(1),
+        );
+        let target_size = target_for_size(intrinsic)?;
+        let target = resolve_target_size(
+            &SvgOptions {
+                resources_dir,
+                target_size,
+            },
+            size,
+        )?;
+
+        Ok(Self {
+            tree,
+            intrinsic: (size.width(), size.height()),
+            target,
+        })
+    }
+
     /// Returns the intrinsic SVG size in pixels without rendering the image.
     ///
     /// Unlike [`SvgDecoder::try_new_with_options`], this does not validate

--- a/src/codecs/svg/decoder.rs
+++ b/src/codecs/svg/decoder.rs
@@ -21,7 +21,7 @@ use super::fonts;
 pub const MAX_TARGET_PIXELS: u64 = 1 << 28;
 
 /// Options controlling how an SVG image is rendered into pixels.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct SvgOptions {
     /// Directory used to resolve relative paths inside the SVG, such as the
     /// `href` of an `<image>` element.
@@ -33,15 +33,6 @@ pub struct SvgOptions {
     ///
     /// The resolved render target may not exceed [`MAX_TARGET_PIXELS`] pixels.
     pub target_size: Option<(u32, u32)>,
-}
-
-impl Default for SvgOptions {
-    fn default() -> Self {
-        Self {
-            resources_dir: None,
-            target_size: None,
-        }
-    }
 }
 
 /// A decoder that renders SVG images into raster pixels using `resvg`.
@@ -169,7 +160,7 @@ fn resolve_target_size(
                     "Invalid SVG target size {width}x{height}"
                 )));
             }
-            (width as u32, height as u32)
+            (width, height)
         }
         None => {
             let intrinsic = size.to_int_size();

--- a/src/codecs/svg/decoder.rs
+++ b/src/codecs/svg/decoder.rs
@@ -28,32 +28,18 @@ pub struct SvgOptions {
     ///
     /// Should be set to the directory containing the SVG file.
     pub resources_dir: Option<PathBuf>,
-    /// Uniform scale factor applied to the SVG intrinsic size.
-    ///
-    /// Ignored when [`SvgOptions::width`] or [`SvgOptions::height`] is set.
-    /// Must be positive and finite. Defaults to `1.0`.
+    /// Explicit render target in pixels. When `None`, the SVG is rendered
+    /// at its intrinsic size.
     ///
     /// The resolved render target may not exceed [`MAX_TARGET_PIXELS`] pixels.
-    pub scale: f32,
-    /// Target width in pixels. When set without [`SvgOptions::height`], the
-    /// height is derived while keeping the aspect ratio of the SVG.
-    ///
-    /// The resolved render target may not exceed [`MAX_TARGET_PIXELS`] pixels.
-    pub width: Option<u32>,
-    /// Target height in pixels. When set without [`SvgOptions::width`], the
-    /// width is derived while keeping the aspect ratio of the SVG.
-    ///
-    /// The resolved render target may not exceed [`MAX_TARGET_PIXELS`] pixels.
-    pub height: Option<u32>,
+    pub target_size: Option<(u32, u32)>,
 }
 
 impl Default for SvgOptions {
     fn default() -> Self {
         Self {
             resources_dir: None,
-            scale: 1.0,
-            width: None,
-            height: None,
+            target_size: None,
         }
     }
 }
@@ -68,32 +54,58 @@ pub struct SvgDecoder {
     target: (usize, usize),
 }
 
+/// Parses an SVG document into a `resvg` tree.
+///
+/// Reads the whole source, configures `resvg` with the SVG's resource
+/// directory and the process-wide system font database, and parses the
+/// document. `Tree::from_data` detects and decompresses gzip (SVGZ)
+/// automatically.
+fn parse_tree<R: Read>(
+    mut source: R,
+    resources_dir: Option<PathBuf>,
+) -> Result<usvg::Tree, ImageErrors> {
+    let mut data = Vec::new();
+    source
+        .read_to_end(&mut data)
+        .map_err(|e| ImageErrors::ImageDecodeErrors(format!("Unable to read SVG data - {e}")))?;
+
+    let mut usvg_options = usvg::Options {
+        resources_dir,
+        font_resolver: fonts::font_resolver(),
+        ..usvg::Options::default()
+    };
+    usvg_options.fontdb = fonts::system_fontdb();
+
+    usvg::Tree::from_data(&data, &usvg_options)
+        .map_err(|e| ImageErrors::ImageDecodeErrors(format!("Unable to parse SVG - {e}")))
+}
+
 impl SvgDecoder {
     /// Create a new SVG decoder with default render options.
     pub fn try_new<R: Read>(source: R) -> Result<Self, ImageErrors> {
         Self::try_new_with_options(source, SvgOptions::default())
     }
 
+    /// Returns the intrinsic SVG size in pixels without rendering the image.
+    ///
+    /// Unlike [`SvgDecoder::try_new_with_options`], this does not validate
+    /// [`MAX_TARGET_PIXELS`]; callers can use it to compute a resize target
+    /// before seeking back and constructing the real decoder.
+    pub fn probe_size<R: Read>(
+        source: R,
+        resources_dir: Option<PathBuf>,
+    ) -> Result<(f32, f32), ImageErrors> {
+        let tree = parse_tree(source, resources_dir)?;
+        let size = tree.size();
+        Ok((size.width(), size.height()))
+    }
+
     /// Create a new SVG decoder with custom render options.
     pub fn try_new_with_options<R: Read>(
-        mut source: R,
+        source: R,
         options: SvgOptions,
     ) -> Result<Self, ImageErrors> {
-        let mut data = Vec::new();
-        source.read_to_end(&mut data).map_err(|e| {
-            ImageErrors::ImageDecodeErrors(format!("Unable to read SVG data - {e}"))
-        })?;
-
-        let mut usvg_options = usvg::Options {
-            resources_dir: options.resources_dir.clone(),
-            font_resolver: fonts::font_resolver(),
-            ..usvg::Options::default()
-        };
-        usvg_options.fontdb = fonts::system_fontdb();
-
-        // `Tree::from_data` detects and decompresses gzip (SVGZ) automatically.
-        let tree = usvg::Tree::from_data(&data, &usvg_options)
-            .map_err(|e| ImageErrors::ImageDecodeErrors(format!("Unable to parse SVG - {e}")))?;
+        let tree = parse_tree(source, options.resources_dir.clone())?;
 
         let size = tree.size();
         let target = resolve_target_size(&options, size)?;
@@ -112,36 +124,35 @@ fn resolve_target_size(
     options: &SvgOptions,
     size: usvg::Size,
 ) -> Result<(usize, usize), ImageErrors> {
-    if !options.scale.is_finite() || options.scale <= 0.0 {
-        return Err(ImageErrors::ImageDecodeErrors(format!(
-            "Invalid SVG scale factor {}",
-            options.scale
-        )));
-    }
+    let target = match options.target_size {
+        Some((width, height)) => {
+            if width == 0 || height == 0 {
+                return Err(ImageErrors::ImageDecodeErrors(format!(
+                    "Invalid SVG target size {width}x{height}"
+                )));
+            }
+            (width as u32, height as u32)
+        }
+        None => {
+            let intrinsic = size.to_int_size();
+            (intrinsic.width(), intrinsic.height())
+        }
+    };
 
-    let scaled = match (options.width, options.height) {
-        (Some(width), Some(height)) => usvg::Size::from_wh(width as f32, height as f32),
-        (Some(width), None) => size.scale_to_width(width as f32),
-        (None, Some(height)) => size.scale_to_height(height as f32),
-        (None, None) => size.scale_by(options.scale),
-    }
-    .ok_or_else(|| ImageErrors::ImageDecodeErrors("Invalid SVG target size".to_string()))?;
-
-    // Rounds and clamps to at least 1x1.
-    let target = scaled.to_int_size();
+    // Clamp both dimensions to at least 1x1.
+    let width = target.0.max(1) as usize;
+    let height = target.1.max(1) as usize;
 
     // The area is computed in u64 because width and height can each approach
     // u32::MAX, whose product overflows usize.
-    let area = u64::from(target.width()) * u64::from(target.height());
+    let area = (width as u64) * (height as u64);
     if area > MAX_TARGET_PIXELS {
         return Err(ImageErrors::ImageDecodeErrors(format!(
-            "SVG target size {}x{} ({area} pixels) exceeds the limit of {MAX_TARGET_PIXELS} pixels, reduce the SVG scale or the explicit dimensions",
-            target.width(),
-            target.height()
+            "SVG target size {width}x{height} ({area} pixels) exceeds the limit of {MAX_TARGET_PIXELS} pixels, reduce the --resize target or the intrinsic size",
         )));
     }
 
-    Ok((target.width() as usize, target.height() as usize))
+    Ok((width, height))
 }
 
 impl DecoderTrait for SvgDecoder {

--- a/src/codecs/svg/decoder/tests.rs
+++ b/src/codecs/svg/decoder/tests.rs
@@ -130,3 +130,40 @@ fn decode_with_invalid_scale_errors() {
 
     assert!(decoder.is_err());
 }
+
+#[test]
+fn decode_with_huge_intrinsic_size_errors() {
+    let file = File::open("tests/files/svg/huge-canvas.svg").unwrap();
+
+    // Parsing succeeds, the oversized render target is rejected instead of
+    // attempting a multi-gigabyte allocation.
+    let decoder = SvgDecoder::try_new(file);
+
+    assert!(decoder.is_err());
+}
+
+#[test]
+fn decode_with_oversized_scale_errors() {
+    let file = File::open("tests/files/svg/rect.svg").unwrap();
+    let options = SvgOptions {
+        scale: 1e9,
+        ..Default::default()
+    };
+
+    let decoder = SvgDecoder::try_new_with_options(file, options);
+
+    assert!(decoder.is_err());
+}
+
+#[test]
+fn decode_with_oversized_width_errors() {
+    let file = File::open("tests/files/svg/rect.svg").unwrap();
+    let options = SvgOptions {
+        width: Some(u32::MAX),
+        ..Default::default()
+    };
+
+    let decoder = SvgDecoder::try_new_with_options(file, options);
+
+    assert!(decoder.is_err());
+}

--- a/src/codecs/svg/decoder/tests.rs
+++ b/src/codecs/svg/decoder/tests.rs
@@ -1,0 +1,132 @@
+use std::fs::File;
+
+use zune_core::colorspace::ColorSpace;
+use zune_image::image::Image;
+
+use super::{SvgDecoder, SvgOptions};
+
+#[test]
+fn decode_simple_rect() {
+    let file = File::open("tests/files/svg/rect.svg").unwrap();
+
+    let decoder = SvgDecoder::try_new(file).unwrap();
+    let img = Image::from_decoder(decoder).unwrap();
+
+    assert_eq!(img.dimensions(), (100, 50));
+    assert_eq!(img.colorspace(), ColorSpace::RGBA);
+
+    let red = img.channels_ref(false)[0].reinterpret_as::<u8>().unwrap();
+    assert_eq!(red[0], 255);
+
+    let green = img.channels_ref(false)[1].reinterpret_as::<u8>().unwrap();
+    assert_eq!(green[0], 0);
+
+    let alpha = img.channels_ref(false)[3].reinterpret_as::<u8>().unwrap();
+    assert_eq!(alpha[0], 255);
+}
+
+#[test]
+fn decode_scales_by_factor() {
+    let file = File::open("tests/files/svg/rect.svg").unwrap();
+    let options = SvgOptions {
+        scale: 2.0,
+        ..Default::default()
+    };
+
+    let decoder = SvgDecoder::try_new_with_options(file, options).unwrap();
+    let img = Image::from_decoder(decoder).unwrap();
+
+    assert_eq!(img.dimensions(), (200, 100));
+
+    // The scaled render keeps full opacity, a raster upscale would too, but
+    // the vector render has no resampling blur on the edges.
+    let red = img.channels_ref(false)[0].reinterpret_as::<u8>().unwrap();
+    assert_eq!(red[0], 255);
+}
+
+#[test]
+fn decode_with_target_width_keeps_aspect_ratio() {
+    let file = File::open("tests/files/svg/rect.svg").unwrap();
+    let options = SvgOptions {
+        width: Some(200),
+        ..Default::default()
+    };
+
+    let decoder = SvgDecoder::try_new_with_options(file, options).unwrap();
+    let img = Image::from_decoder(decoder).unwrap();
+
+    assert_eq!(img.dimensions(), (200, 100));
+}
+
+#[test]
+fn decode_with_target_height_keeps_aspect_ratio() {
+    let file = File::open("tests/files/svg/rect.svg").unwrap();
+    let options = SvgOptions {
+        height: Some(25),
+        ..Default::default()
+    };
+
+    let decoder = SvgDecoder::try_new_with_options(file, options).unwrap();
+    let img = Image::from_decoder(decoder).unwrap();
+
+    assert_eq!(img.dimensions(), (50, 25));
+}
+
+#[test]
+fn decode_with_exact_width_and_height() {
+    let file = File::open("tests/files/svg/rect.svg").unwrap();
+    let options = SvgOptions {
+        width: Some(120),
+        height: Some(40),
+        ..Default::default()
+    };
+
+    let decoder = SvgDecoder::try_new_with_options(file, options).unwrap();
+    let img = Image::from_decoder(decoder).unwrap();
+
+    assert_eq!(img.dimensions(), (120, 40));
+}
+
+#[test]
+fn decode_without_viewbox_uses_content_bbox() {
+    let file = File::open("tests/files/svg/no-viewbox.svg").unwrap();
+
+    let decoder = SvgDecoder::try_new(file).unwrap();
+    let img = Image::from_decoder(decoder).unwrap();
+
+    // The circle spans x 80..160 and y 40..120.
+    assert_eq!(img.dimensions(), (160, 120));
+}
+
+#[test]
+fn decode_text_renders_without_error() {
+    let file = File::open("tests/files/svg/text-cjk.svg").unwrap();
+
+    let decoder = SvgDecoder::try_new(file).unwrap();
+    let img = Image::from_decoder(decoder).unwrap();
+
+    assert_eq!(img.dimensions(), (100, 100));
+}
+
+#[test]
+fn decode_invalid_svg_errors() {
+    let file = File::open("tests/files/svg/invalid.svg").unwrap();
+
+    // Parsing happens eagerly when creating the decoder.
+    let decoder = SvgDecoder::try_new(file);
+
+    assert!(decoder.is_err());
+}
+
+#[test]
+fn decode_with_invalid_scale_errors() {
+    let file = File::open("tests/files/svg/rect.svg").unwrap();
+    let options = SvgOptions {
+        scale: 0.0,
+        ..Default::default()
+    };
+
+    let decoder = SvgDecoder::try_new_with_options(file, options);
+
+    assert!(decoder.is_err());
+}

--- a/src/codecs/svg/decoder/tests.rs
+++ b/src/codecs/svg/decoder/tests.rs
@@ -26,10 +26,19 @@ fn decode_simple_rect() {
 }
 
 #[test]
-fn decode_scales_by_factor() {
+fn probe_size_returns_intrinsic_size() {
+    let file = File::open("tests/files/svg/rect.svg").unwrap();
+
+    let size = SvgDecoder::probe_size(file, None).unwrap();
+
+    assert_eq!(size, (100.0, 50.0));
+}
+
+#[test]
+fn decode_with_target_size_renders_at_vector_quality() {
     let file = File::open("tests/files/svg/rect.svg").unwrap();
     let options = SvgOptions {
-        scale: 2.0,
+        target_size: Some((200, 100)),
         ..Default::default()
     };
 
@@ -38,31 +47,17 @@ fn decode_scales_by_factor() {
 
     assert_eq!(img.dimensions(), (200, 100));
 
-    // The scaled render keeps full opacity, a raster upscale would too, but
-    // the vector render has no resampling blur on the edges.
+    // The target-size render keeps full opacity and crisp vector edges, just
+    // like the old --svg-scale path did.
     let red = img.channels_ref(false)[0].reinterpret_as::<u8>().unwrap();
     assert_eq!(red[0], 255);
 }
 
 #[test]
-fn decode_with_target_width_keeps_aspect_ratio() {
+fn decode_with_target_aspect_ratio() {
     let file = File::open("tests/files/svg/rect.svg").unwrap();
     let options = SvgOptions {
-        width: Some(200),
-        ..Default::default()
-    };
-
-    let decoder = SvgDecoder::try_new_with_options(file, options).unwrap();
-    let img = Image::from_decoder(decoder).unwrap();
-
-    assert_eq!(img.dimensions(), (200, 100));
-}
-
-#[test]
-fn decode_with_target_height_keeps_aspect_ratio() {
-    let file = File::open("tests/files/svg/rect.svg").unwrap();
-    let options = SvgOptions {
-        height: Some(25),
+        target_size: Some((50, 25)),
         ..Default::default()
     };
 
@@ -73,11 +68,10 @@ fn decode_with_target_height_keeps_aspect_ratio() {
 }
 
 #[test]
-fn decode_with_exact_width_and_height() {
+fn decode_with_exact_target_size() {
     let file = File::open("tests/files/svg/rect.svg").unwrap();
     let options = SvgOptions {
-        width: Some(120),
-        height: Some(40),
+        target_size: Some((120, 40)),
         ..Default::default()
     };
 
@@ -121,10 +115,10 @@ fn decode_invalid_svg_errors() {
 }
 
 #[test]
-fn decode_with_invalid_scale_errors() {
+fn decode_with_zero_target_size_errors() {
     let file = File::open("tests/files/svg/rect.svg").unwrap();
     let options = SvgOptions {
-        scale: 0.0,
+        target_size: Some((0, 100)),
         ..Default::default()
     };
 
@@ -145,23 +139,10 @@ fn decode_with_huge_intrinsic_size_errors() {
 }
 
 #[test]
-fn decode_with_oversized_scale_errors() {
+fn decode_with_oversized_target_size_errors() {
     let file = File::open("tests/files/svg/rect.svg").unwrap();
     let options = SvgOptions {
-        scale: 1e9,
-        ..Default::default()
-    };
-
-    let decoder = SvgDecoder::try_new_with_options(file, options);
-
-    assert!(decoder.is_err());
-}
-
-#[test]
-fn decode_with_oversized_width_errors() {
-    let file = File::open("tests/files/svg/rect.svg").unwrap();
-    let options = SvgOptions {
-        width: Some(u32::MAX),
+        target_size: Some((u32::MAX, u32::MAX)),
         ..Default::default()
     };
 

--- a/src/codecs/svg/decoder/tests.rs
+++ b/src/codecs/svg/decoder/tests.rs
@@ -3,7 +3,13 @@ use std::fs::File;
 use zune_core::colorspace::ColorSpace;
 use zune_image::image::Image;
 
-use super::{SvgDecoder, SvgOptions};
+use super::{MAX_TARGET_PIXELS, SvgDecoder, SvgOptions};
+
+#[test]
+fn max_target_pixels_fits_the_decode_byte_budget() {
+    let max_bytes = MAX_TARGET_PIXELS * 4 * 3;
+    assert!(max_bytes <= 512 * 1024 * 1024);
+}
 
 #[test]
 fn decode_simple_rect() {

--- a/src/codecs/svg/decoder/tests.rs
+++ b/src/codecs/svg/decoder/tests.rs
@@ -35,6 +35,20 @@ fn probe_size_returns_intrinsic_size() {
 }
 
 #[test]
+fn decode_through_resize_callback() {
+    let file = File::open("tests/files/svg/rect.svg").unwrap();
+
+    let decoder = SvgDecoder::try_new_with_resize(file, None, |size| {
+        assert_eq!(size, (100, 50));
+        Ok(Some((200, 100)))
+    })
+    .unwrap();
+    let img = Image::from_decoder(decoder).unwrap();
+
+    assert_eq!(img.dimensions(), (200, 100));
+}
+
+#[test]
 fn decode_with_target_size_renders_at_vector_quality() {
     let file = File::open("tests/files/svg/rect.svg").unwrap();
     let options = SvgOptions {

--- a/src/codecs/svg/decoder/tests.rs
+++ b/src/codecs/svg/decoder/tests.rs
@@ -105,7 +105,9 @@ fn decode_text_renders_without_error() {
     let decoder = SvgDecoder::try_new(file).unwrap();
     let img = Image::from_decoder(decoder).unwrap();
 
-    assert_eq!(img.dimensions(), (100, 100));
+    // the canvas comes from the SVG's width/height (200x100), the text
+    // mixes simplified and traditional Han with kana and latin
+    assert_eq!(img.dimensions(), (200, 100));
 }
 
 #[test]

--- a/src/codecs/svg/fonts.rs
+++ b/src/codecs/svg/fonts.rs
@@ -10,6 +10,7 @@ use std::sync::{Arc, Mutex, OnceLock};
 
 use resvg::usvg;
 use resvg::usvg::fontdb;
+use skrifa::MetadataProvider;
 
 /// Font families used when the requested family cannot be found.
 const DEFAULT_FAMILIES: &[&str] = &["Times New Roman"];
@@ -134,14 +135,18 @@ fn log_missing_glyph(c: char, family: &str) {
     }
 }
 
-/// Checks whether the face supports the character, mirroring the semantics of
-/// the character check used inside `usvg` which is not exposed publicly.
+/// Checks whether the face supports the character.
+///
+/// Maps through the character map and rejects glyphs resolved to `.notdef`,
+/// mirroring the character check used inside `usvg` which is not exposed
+/// publicly.
 fn has_char(fontdb: &fontdb::Database, id: fontdb::ID, c: char) -> bool {
     fontdb
         .with_face_data(id, |font_data, face_index| {
-            ttf_parser::Face::parse(font_data, face_index)
+            skrifa::FontRef::from_index(font_data, face_index)
                 .ok()?
-                .glyph_index(c)
+                .charmap()
+                .map(c)
         })
         .is_some_and(|glyph| glyph.is_some())
 }

--- a/src/codecs/svg/fonts.rs
+++ b/src/codecs/svg/fonts.rs
@@ -1,0 +1,183 @@
+//! Font loading and fallback strategy for SVG rendering.
+//!
+//! System fonts are loaded once per process and shared across renders.
+//! Fonts missing from the SVG are substituted with system fonts while
+//! emitting a warning: CJK characters fall back to Microsoft YaHei UI,
+//! everything else falls back to the default font families.
+
+use std::collections::HashSet;
+use std::sync::{Arc, Mutex, OnceLock};
+
+use resvg::usvg;
+use resvg::usvg::fontdb;
+
+/// Font families used when the requested family cannot be found.
+const DEFAULT_FAMILIES: &[&str] = &["Times New Roman"];
+
+/// Font families used to substitute missing CJK glyphs, tried in order.
+const CJK_FALLBACK_FAMILIES: &[&str] = &["Microsoft YaHei UI", "Microsoft YaHei"];
+
+/// Creates a font resolver that warns about missing fonts and substitutes
+/// system fonts.
+pub(super) fn font_resolver() -> usvg::FontResolver<'static> {
+    usvg::FontResolver {
+        select_font: Box::new(select_font),
+        select_fallback: Box::new(select_fallback),
+    }
+}
+
+/// Loads system fonts once and shares the database across all renders.
+pub(super) fn system_fontdb() -> Arc<fontdb::Database> {
+    static DATABASE: OnceLock<Arc<fontdb::Database>> = OnceLock::new();
+
+    DATABASE
+        .get_or_init(|| {
+            let mut database = fontdb::Database::new();
+            database.load_system_fonts();
+            log::debug!("loaded {} font faces from the system", database.len());
+
+            Arc::new(database)
+        })
+        .clone()
+}
+
+fn select_font(font: &usvg::Font, fontdb: &mut Arc<fontdb::Database>) -> Option<fontdb::ID> {
+    let families: Vec<fontdb::Family> = font
+        .families()
+        .iter()
+        .map(|family| match family {
+            usvg::FontFamily::Serif => fontdb::Family::Serif,
+            usvg::FontFamily::SansSerif => fontdb::Family::SansSerif,
+            usvg::FontFamily::Cursive => fontdb::Family::Cursive,
+            usvg::FontFamily::Fantasy => fontdb::Family::Fantasy,
+            usvg::FontFamily::Monospace => fontdb::Family::Monospace,
+            usvg::FontFamily::Named(name) => fontdb::Family::Name(name.as_str()),
+        })
+        .collect();
+
+    let query = fontdb::Query {
+        families: &families,
+        weight: fontdb::Weight(font.weight()),
+        stretch: fontdb::Stretch::from(font.stretch()),
+        style: fontdb::Style::from(font.style()),
+    };
+
+    if let Some(id) = fontdb.query(&query) {
+        return Some(id);
+    }
+
+    log::warn!(
+        "No match for '{}' font-family, substituting the default font",
+        font.families()
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+
+    let mut fallback: Vec<fontdb::Family> = DEFAULT_FAMILIES
+        .iter()
+        .map(|name| fontdb::Family::Name(name))
+        .collect();
+    fallback.push(fontdb::Family::Serif);
+
+    fontdb.query(&fontdb::Query {
+        families: &fallback,
+        ..query
+    })
+}
+
+fn select_fallback(
+    c: char,
+    exclude_fonts: &[fontdb::ID],
+    fontdb: &mut Arc<fontdb::Database>,
+) -> Option<fontdb::ID> {
+    if is_cjk(c) {
+        for family in CJK_FALLBACK_FAMILIES {
+            let id = fontdb.query(&fontdb::Query {
+                families: &[fontdb::Family::Name(family)],
+                ..fontdb::Query::default()
+            });
+
+            if let Some(id) =
+                id.filter(|id| has_char(fontdb, *id, c) && !exclude_fonts.contains(id))
+            {
+                log_missing_glyph(c, family);
+                return Some(id);
+            }
+        }
+    }
+
+    (usvg::FontResolver::default_fallback_selector())(c, exclude_fonts, fontdb)
+}
+
+/// Warns about a substituted glyph once per character to avoid log flooding
+/// on long CJK texts, further occurrences are logged at debug level.
+fn log_missing_glyph(c: char, family: &str) {
+    static WARNED: OnceLock<Mutex<HashSet<u32>>> = OnceLock::new();
+
+    let warned = WARNED.get_or_init(|| Mutex::new(HashSet::new()));
+    let first_time = warned
+        .lock()
+        .map(|mut warned| warned.insert(u32::from(c)))
+        .unwrap_or(true);
+
+    let message = format!(
+        "No glyph for U+{:04X} in the selected fonts, substituted '{family}'",
+        u32::from(c)
+    );
+
+    if first_time {
+        log::warn!("{message}");
+    } else {
+        log::debug!("{message}");
+    }
+}
+
+/// Checks whether the face supports the character, mirroring the semantics of
+/// the character check used inside `usvg` which is not exposed publicly.
+fn has_char(fontdb: &fontdb::Database, id: fontdb::ID, c: char) -> bool {
+    fontdb
+        .with_face_data(id, |font_data, face_index| {
+            ttf_parser::Face::parse(font_data, face_index)
+                .ok()?
+                .glyph_index(c)
+        })
+        .is_some_and(|glyph| glyph.is_some())
+}
+
+/// Checks whether the character belongs to a CJK script (Han, Kana, Hangul
+/// and the CJK-specific punctuation and symbol blocks).
+fn is_cjk(c: char) -> bool {
+    matches!(u32::from(c),
+        0x2E80..=0x2EFF      // CJK Radicals Supplement
+        | 0x2F00..=0x2FDF    // Kangxi Radicals
+        | 0x3000..=0x303F    // CJK Symbols and Punctuation
+        | 0x3040..=0x30FF    // Hiragana and Katakana
+        | 0x3130..=0x318F    // Hangul Compatibility Jamo
+        | 0x3400..=0x4DBF    // CJK Unified Ideographs Extension A
+        | 0x4E00..=0x9FFF    // CJK Unified Ideographs
+        | 0xAC00..=0xD7AF    // Hangul Syllables
+        | 0xF900..=0xFAFF    // CJK Compatibility Ideographs
+        | 0xFE30..=0xFE4F    // CJK Compatibility Forms
+        | 0xFF00..=0xFFEF    // Halfwidth and Fullwidth Forms
+        | 0x20000..=0x2FA1F  // CJK Unified Ideographs Extensions B..F and Supplement
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_cjk;
+
+    #[test]
+    fn cjk_ranges() {
+        assert!(is_cjk('中'));
+        assert!(is_cjk('あ'));
+        assert!(is_cjk('한'));
+        assert!(is_cjk('，'));
+        assert!(is_cjk('Ａ')); // fullwidth latin
+        assert!(!is_cjk('A'));
+        assert!(!is_cjk('é'));
+        assert!(!is_cjk('😀'));
+    }
+}

--- a/src/codecs/svg/fonts.rs
+++ b/src/codecs/svg/fonts.rs
@@ -1,9 +1,11 @@
 //! Font loading and fallback strategy for SVG rendering.
 //!
-//! System fonts are loaded once per process and shared across renders.
+//! System fonts are loaded once per process, resolved into fallback faces
+//! (a serif default and a CJK-capable face) and shared across renders.
 //! Fonts missing from the SVG are substituted with system fonts while
-//! emitting a warning: CJK characters fall back to Microsoft YaHei UI,
-//! everything else falls back to the default font families.
+//! emitting a warning, and a text span is never dropped for the lack of a
+//! font: as a last resort the request falls back to whatever face the
+//! system has.
 
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex, OnceLock};
@@ -12,11 +14,54 @@ use resvg::usvg;
 use resvg::usvg::fontdb;
 use skrifa::MetadataProvider;
 
-/// Font families used when the requested family cannot be found.
-const DEFAULT_FAMILIES: &[&str] = &["Times New Roman"];
+/// Seed families for the serif default, tried in order until one exists on
+/// the system.
+const SERIF_SEED_FAMILIES: &[&str] = &[
+    "Times New Roman",  // Windows and macOS
+    "Liberation Serif", // Linux, metric-compatible with Times New Roman
+    "DejaVu Serif",     // Linux
+    "Tinos",            // metric-compatible with Times New Roman
+    "Nimbus Roman",     // older Linux distributions
+];
 
-/// Font families used to substitute missing CJK glyphs, tried in order.
-const CJK_FALLBACK_FAMILIES: &[&str] = &["Microsoft YaHei UI", "Microsoft YaHei"];
+/// Seed families for the CJK fallback, tried in order while resolving.
+const CJK_SEED_FAMILIES: &[&str] = &[
+    "Microsoft YaHei UI", // Windows
+    "Microsoft YaHei",    // Windows
+    "PingFang SC",        // macOS
+    "Hiragino Sans GB",   // macOS
+    "Noto Sans SC",       // Linux
+    "Noto Sans CJK SC",   // Linux
+    "Source Han Sans",    // Linux
+    "Source Han Sans SC", // Linux
+    "Noto Sans CJK TC",
+    "Noto Sans CJK JP",
+    "WenQuanYi Zen Hei",
+    "Noto Sans SC Variable",
+    "Source Han Sans CN",
+    "Source Han Sans CN VF",
+    "Source Han Sans SC VF",
+    "MiSans",
+    "MiSans L3",
+    "HarmonyOS Sans SC",
+    "HONOR Sans CN",
+    "OPPO Sans 4.0",
+    "vivo Sans SC L3",
+    "vivo Sans",
+    "vivo Sans SC VF",
+    "Droid Sans Fallback",
+];
+
+/// Characters probed while scanning for a CJK-capable face: Han, Hiragana
+/// and Hangul representatives.
+const CJK_PROBE_CHARS: &[char] = &['中', 'あ', '가'];
+
+/// System fonts with the fallback faces resolved against them.
+struct ResolvedFonts {
+    database: Arc<fontdb::Database>,
+    /// Face covering CJK codepoints, if the system has one.
+    cjk_face: Option<fontdb::ID>,
+}
 
 /// Creates a font resolver that warns about missing fonts and substitutes
 /// system fonts.
@@ -27,19 +72,51 @@ pub(super) fn font_resolver() -> usvg::FontResolver<'static> {
     }
 }
 
-/// Loads system fonts once and shares the database across all renders.
+/// Loads system fonts once, resolves the fallback faces and shares the
+/// result across all renders.
+fn resolved_fonts() -> &'static ResolvedFonts {
+    static FONTS: OnceLock<ResolvedFonts> = OnceLock::new();
+
+    FONTS.get_or_init(|| {
+        let mut database = fontdb::Database::new();
+        database.load_system_fonts();
+
+        let serif_family = resolve_serif_family(&database);
+        if let Some(family) = &serif_family {
+            // Point the `serif` generic alias at a family that actually
+            // exists, so `font-family="serif"` resolves on every platform.
+            database.set_serif_family(family);
+        }
+
+        let cjk_face = resolve_cjk_face(&database);
+
+        if database.is_empty() {
+            log::error!("No system fonts found, text in SVG images will not be rendered");
+        } else {
+            if serif_family.is_none() {
+                log::warn!(
+                    "None of the default serif fonts was found, SVG text may be rendered with an arbitrary font"
+                );
+            }
+            if cjk_face.is_none() {
+                log::warn!(
+                    "No CJK font was found, CJK characters will not be rendered unless the SVG names an available font"
+                );
+            }
+        }
+
+        log::debug!("loaded {} font faces from the system", database.len());
+
+        ResolvedFonts {
+            database: Arc::new(database),
+            cjk_face,
+        }
+    })
+}
+
+/// Shares the resolved database with usvg and resvg.
 pub(super) fn system_fontdb() -> Arc<fontdb::Database> {
-    static DATABASE: OnceLock<Arc<fontdb::Database>> = OnceLock::new();
-
-    DATABASE
-        .get_or_init(|| {
-            let mut database = fontdb::Database::new();
-            database.load_system_fonts();
-            log::debug!("loaded {} font faces from the system", database.len());
-
-            Arc::new(database)
-        })
-        .clone()
+    resolved_fonts().database.clone()
 }
 
 fn select_font(font: &usvg::Font, fontdb: &mut Arc<fontdb::Database>) -> Option<fontdb::ID> {
@@ -76,16 +153,24 @@ fn select_font(font: &usvg::Font, fontdb: &mut Arc<fontdb::Database>) -> Option<
             .join(", ")
     );
 
-    let mut fallback: Vec<fontdb::Family> = DEFAULT_FAMILIES
+    // Seed families known to exist per platform, then the serif alias that
+    // load time pointed at a family that actually exists.
+    let mut fallback: Vec<fontdb::Family> = SERIF_SEED_FAMILIES
         .iter()
         .map(|name| fontdb::Family::Name(name))
         .collect();
     fallback.push(fontdb::Family::Serif);
 
-    fontdb.query(&fontdb::Query {
+    if let Some(id) = fontdb.query(&fontdb::Query {
         families: &fallback,
         ..query
-    })
+    }) {
+        return Some(id);
+    }
+
+    // Never drop a text span for the lack of a font: render it with
+    // whatever face the system has instead.
+    fontdb.faces().next().map(|face| face.id)
 }
 
 fn select_fallback(
@@ -94,22 +179,66 @@ fn select_fallback(
     fontdb: &mut Arc<fontdb::Database>,
 ) -> Option<fontdb::ID> {
     if is_cjk(c) {
-        for family in CJK_FALLBACK_FAMILIES {
-            let id = fontdb.query(&fontdb::Query {
-                families: &[fontdb::Family::Name(family)],
-                ..fontdb::Query::default()
-            });
+        let resolved = resolved_fonts()
+            .cjk_face
+            .filter(|id| fontdb.face(*id).is_some() && !exclude_fonts.contains(id))
+            .filter(|id| has_char(fontdb, *id, c));
 
-            if let Some(id) =
-                id.filter(|id| has_char(fontdb, *id, c) && !exclude_fonts.contains(id))
-            {
-                log_missing_glyph(c, family);
-                return Some(id);
-            }
+        if let Some(id) = resolved {
+            let family = fontdb
+                .face(id)
+                .and_then(|face| {
+                    face.families
+                        .iter()
+                        .find(|(_, language)| *language == fontdb::Language::English_UnitedStates)
+                        .or_else(|| face.families.first())
+                })
+                .map(|(name, _)| name.clone())
+                .unwrap_or_else(|| "unknown".into());
+
+            log_missing_glyph(c, &family);
+            return Some(id);
         }
     }
 
     (usvg::FontResolver::default_fallback_selector())(c, exclude_fonts, fontdb)
+}
+
+/// Picks the first serif seed family present on the system.
+fn resolve_serif_family(database: &fontdb::Database) -> Option<String> {
+    SERIF_SEED_FAMILIES
+        .iter()
+        .find(|name| {
+            database
+                .query(&fontdb::Query {
+                    families: &[fontdb::Family::Name(name)],
+                    ..fontdb::Query::default()
+                })
+                .is_some()
+        })
+        .map(|name| (*name).to_string())
+}
+
+/// Picks a CJK-capable face: seed families first, then a scan over every
+/// loaded face for any of the probe characters.
+fn resolve_cjk_face(database: &fontdb::Database) -> Option<fontdb::ID> {
+    for name in CJK_SEED_FAMILIES {
+        let id = database.query(&fontdb::Query {
+            families: &[fontdb::Family::Name(name)],
+            ..fontdb::Query::default()
+        });
+
+        if let Some(id) =
+            id.filter(|id| CJK_PROBE_CHARS.iter().any(|&c| has_char(database, *id, c)))
+        {
+            return Some(id);
+        }
+    }
+
+    database
+        .faces()
+        .map(|face| face.id)
+        .find(|id| CJK_PROBE_CHARS.iter().any(|&c| has_char(database, *id, c)))
 }
 
 /// Warns about a substituted glyph once per character to avoid log flooding
@@ -172,7 +301,7 @@ fn is_cjk(c: char) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::is_cjk;
+    use super::*;
 
     #[test]
     fn cjk_ranges() {
@@ -184,5 +313,36 @@ mod tests {
         assert!(!is_cjk('A'));
         assert!(!is_cjk('é'));
         assert!(!is_cjk('😀'));
+    }
+
+    #[test]
+    fn serif_resolution_returns_a_seed() {
+        let mut database = fontdb::Database::new();
+        database.load_system_fonts();
+
+        if let Some(family) = resolve_serif_family(&database) {
+            assert!(SERIF_SEED_FAMILIES.contains(&family.as_str()));
+
+            // the alias must resolve once it points at the found family
+            database.set_serif_family(&family);
+            assert!(
+                database
+                    .query(&fontdb::Query {
+                        families: &[fontdb::Family::Serif],
+                        ..fontdb::Query::default()
+                    })
+                    .is_some()
+            );
+        }
+    }
+
+    #[test]
+    fn cjk_resolution_finds_a_covering_face() {
+        let mut database = fontdb::Database::new();
+        database.load_system_fonts();
+
+        if let Some(id) = resolve_cjk_face(&database) {
+            assert!(CJK_PROBE_CHARS.iter().any(|&c| has_char(&database, id, c)));
+        }
     }
 }

--- a/src/codecs/svg/mod.rs
+++ b/src/codecs/svg/mod.rs
@@ -1,0 +1,7 @@
+//! SVG input support rendering vector images through [`resvg`].
+
+pub mod decoder;
+
+pub(crate) mod fonts;
+
+pub use decoder::{SvgDecoder, SvgOptions};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ Rimage is a powerful Rust image optimization library extending `zune_image` crat
 | png          | -       | oxipng  |
 | avif         | libavif | ravif   |
 | webp         | webp    | webp    |
+| svg          | resvg   | -       |
 
 ## Usage
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -822,7 +822,7 @@ fn main() -> std::process::ExitCode {
                         let input_format = get_file_extension(&input);
                         let input_modified = get_file_modified_time(&input);
 
-                        let mut img = handle_error!(input, decode(&input));
+                        let mut img = handle_error!(input, decode(&input, matches));
                         let exif_metadata: Option<ExifMetadata> = ExifMetadata::new_from_path(&input)
                             .ok()
                             .filter(|_| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -592,6 +592,7 @@ fn pretty_path(path: &Path) -> PathBuf {
 
 fn main() -> std::process::ExitCode {
     let logger = pretty_env_logger::formatted_builder()
+        .filter_level(log::LevelFilter::Warn)
         .parse_default_env()
         .filter_module("little_exif", log::LevelFilter::Off)
         .build();

--- a/src/main.rs
+++ b/src/main.rs
@@ -823,6 +823,12 @@ fn main() -> std::process::ExitCode {
                         let input_format = get_file_extension(&input);
                         let input_modified = get_file_modified_time(&input);
 
+                        let input_is_svg = input
+                            .extension()
+                            .is_some_and(|ext| {
+                                ext.eq_ignore_ascii_case("svg") || ext.eq_ignore_ascii_case("svgz")
+                            });
+
                         let mut img = handle_error!(input, decode(&input, matches));
                         let exif_metadata: Option<ExifMetadata> = ExifMetadata::new_from_path(&input)
                             .ok()
@@ -856,7 +862,7 @@ fn main() -> std::process::ExitCode {
                             ops.push(Box::new(AutoOrient));
                         }
 
-                        operations(matches, &img)
+                        operations(matches, &img, input_is_svg)
                             .into_iter()
                             .for_each(|(_, operations)| match operations.name() {
                                 "quantize" => {

--- a/src/operations/icc/mod.rs
+++ b/src/operations/icc/mod.rs
@@ -154,7 +154,9 @@ impl OperationsTrait for ApplySRGB {
 
     fn execute_impl(&self, image: &mut Image) -> Result<(), ImageErrors> {
         if image.metadata().icc_chunk().is_none() {
-            log::warn!("No icc profile in the image, skipping");
+            // Routine path for images without an embedded profile, so this is
+            // debug-level to stay quiet under the default warn-level logging.
+            log::debug!("No icc profile in the image, skipping");
             return Ok(());
         }
 

--- a/tests/files/svg/huge-canvas.svg
+++ b/tests/files/svg/huge-canvas.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="99999999" height="99999999" viewBox="0 0 99999999 99999999">
+  <rect width="99999999" height="99999999" fill="#ff0000"/>
+</svg>

--- a/tests/files/svg/invalid.svg
+++ b/tests/files/svg/invalid.svg
@@ -1,0 +1,1 @@
+this is not a svg file

--- a/tests/files/svg/no-viewbox.svg
+++ b/tests/files/svg/no-viewbox.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <circle cx="120" cy="80" r="40" fill="#00ff00"/>
+</svg>

--- a/tests/files/svg/rect.svg
+++ b/tests/files/svg/rect.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="50" viewBox="0 0 100 50">
+  <rect width="100" height="50" fill="#ff0000"/>
+</svg>

--- a/tests/files/svg/text-cjk.svg
+++ b/tests/files/svg/text-cjk.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <text x="10" y="50" font-size="16">中文テスト English</text>
+</svg>

--- a/tests/files/svg/text-cjk.svg
+++ b/tests/files/svg/text-cjk.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
-  <text x="10" y="50" font-size="16">中文テスト English</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100">
+  <text x="14" y="55" font-size="20">简体简體テストEng</text>
 </svg>


### PR DESCRIPTION
close #393 

### Breaking Changes

- add SVG input support rendered through `resvg` (static SVG and gzipped SVGZ), usable with every output format

### Features

- resize SVG inputs through the existing `--resize` option by rendering the SVG vectorly with `resvg` directly at the final target size, so upscaling keeps the vector quality of the source
- load system fonts for SVG text and substitute missing fonts with a warning: the serif default and the CJK fallback are resolved once at load time from platform-appropriate seeds (Times New Roman/Liberation Serif/DejaVu Serif, etc., YaHei/PingFang/Noto CJK, etc.), the `serif` generic alias is pointed at a family that actually exists, and a text span is never dropped for the lack of a font — as a last resort it renders with whatever face the system has
- declare `rust-version = "1.90"` to track the effective minimum supported Rust version