### PR TITLE
Replace libavif decoder with dav1d

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,19 +7,8 @@ linker = 'aarch64-linux-gnu-gcc'
 [target.aarch64-unknown-linux-musl]
 linker = 'aarch64-linux-musl-gcc'
 
-[target.x86_64-pc-windows-gnu]
-linker = 'gcc'
-rustflags = [
-    "-C", "target-feature=+crt-static",
-    "-C", "link-arg=-static-libgcc",
-    "-C", "link-arg=-static-libstdc++",
-]
-
-[env]
-CMAKE_GENERATOR_x86_64-pc-windows-gnu = "MinGW Makefiles"
-CC_x86_64-pc-windows-gnu = "gcc"
-CXX_x86_64-pc-windows-gnu = "g++"
-AR_x86_64-pc-windows-gnu = "ar"
+[target.i686-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]
 
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]

--- a/.github/workflows/rimage.yml
+++ b/.github/workflows/rimage.yml
@@ -101,20 +101,20 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          packages=(ninja-build meson nasm)
+          # meson+ninja build dav1d from source for the musl and aarch64 GNU
+          # targets, nasm assembles mozjpeg's x86 SIMD code
+          packages=(ninja-build meson nasm pkg-config)
           if [[ "${{ matrix.target }}" == *-musl ]]; then
             packages+=(musl-tools "musl-dev:${{ matrix.target-apt-arch }}")
           fi
           if [[ "${{ matrix.target }}" == aarch64-unknown-linux-* ]]; then
-            packages+=(qemu-user gcc-aarch64-linux-gnu g++-aarch64-linux-gnu "libc6:${{ matrix.target-apt-arch }}")
+            packages+=(qemu-user gcc-aarch64-linux-gnu "libc6:${{ matrix.target-apt-arch }}")
+          fi
+          if [[ "${{ matrix.target }}" == x86_64-unknown-linux-gnu ]]; then
+            packages+=(libdav1d-dev)
           fi
           sudo apt-get -yq update
           sudo apt-get -yq install --fix-missing "${packages[@]}"
-
-      - name: configure x86_64 musl C++ compiler
-        if: matrix.target == 'x86_64-unknown-linux-musl'
-        shell: bash
-        run: sudo ln -sf /bin/g++ /bin/musl-g++
 
       - name: install macOS dependencies
         if: startsWith(matrix.os, 'macos')
@@ -126,12 +126,19 @@ jobs:
           # Nothing in this build uses these taps, so untap them first.
           brew untap aws/tap 2>/dev/null || true
           brew untap azure/bicep 2>/dev/null || true
-          brew install ninja meson nasm yasm || brew upgrade ninja meson nasm yasm
+          brew install llvm ninja nasm pkg-config dav1d || brew upgrade llvm ninja nasm pkg-config dav1d
 
       - name: install Windows dependencies
         if: startsWith(matrix.os, 'windows')
         shell: pwsh
-        run: choco install -y ninja meson nasm
+        run: |
+          choco install -y ninja nasm
+          # static dav1d matches the +crt-static rustflag of the MSVC target;
+          # dav1d-sys locates it through pkgconf from the same vcpkg install
+          $triplet = if ('${{ matrix.target }}' -eq 'i686-pc-windows-msvc') { 'x86-windows-static' } else { 'x64-windows-static' }
+          & "$env:VCPKG_ROOT\vcpkg.exe" install "dav1d:$triplet" "pkgconf:x64-windows"
+          "PKG_CONFIG=$env:VCPKG_ROOT\installed\x64-windows\tools\pkgconf\pkgconf.exe" >> $env:GITHUB_ENV
+          "PKG_CONFIG_PATH=$env:VCPKG_ROOT\installed\$triplet\lib\pkgconfig" >> $env:GITHUB_ENV
 
       - name: install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -152,6 +159,30 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: cross@0.2.5
+
+      # musl and cross-compiled GNU targets have no dav1d package to link
+      # against; build a static dav1d with the target toolchain and point
+      # pkg-config at it. x86_64-gnu uses the distro package instead.
+      - name: build static dav1d for the target
+        if: startsWith(matrix.os, 'ubuntu') && !matrix.cross && matrix.target != 'x86_64-unknown-linux-gnu'
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "${{ matrix.target }}" in
+            x86_64-unknown-linux-musl)
+              prefix=/opt/dav1d-target
+              export CC=musl-gcc
+              ;;
+            aarch64-unknown-linux-gnu)
+              prefix=/opt/dav1d-target
+              export CROSS_FILE=ci/meson/aarch64-gnu.ini
+              ;;
+          esac
+          ci/build-dav1d.sh "$prefix" ${CROSS_FILE:-}
+          {
+            echo "PKG_CONFIG_PATH=$prefix/lib/pkgconfig"
+            echo "PKG_CONFIG_ALLOW_CROSS=1"
+          } >> "$GITHUB_ENV"
 
       - name: build release binary
         shell: bash
@@ -208,13 +239,14 @@ jobs:
       - name: install native dependencies
         run: |
           sudo apt-get -yq update
-          sudo apt-get -yq install --fix-missing ninja-build meson nasm
+          sudo apt-get -yq install --fix-missing ninja-build nasm libdav1d-dev
 
       - name: Clippy check
         run: cargo clippy --all-targets --all-features -- -D warnings
 
   # Keep the complete WASM configuration in one disabled job. Remove the
-  # job-level `if` when the Emscripten build is ready to be enabled again.
+  # job-level `if` when the Emscripten build is ready to be enabled again;
+  # enabling it also requires a dav1d build for the Emscripten target.
   wasm:
     name: wasm32-unknown-emscripten (disabled)
     if: ${{ false }}
@@ -242,5 +274,4 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          export EMSCRIPTEN_CMAKE_FILE="$(brew --cellar emscripten)/$(brew list --versions emscripten | tr ' ' '\n' | tail -1)/libexec/cmake/Modules/Platform/Emscripten.cmake"
           cargo check --all-features

--- a/.github/workflows/rimage.yml
+++ b/.github/workflows/rimage.yml
@@ -134,11 +134,13 @@ jobs:
         run: |
           choco install -y ninja nasm
           # static dav1d matches the +crt-static rustflag of the MSVC target;
-          # dav1d-sys locates it through pkgconf from the same vcpkg install
+          # dav1d-sys locates it through pkgconf from the same vcpkg install.
+          # the runner images expose vcpkg only via VCPKG_INSTALLATION_ROOT,
+          # there is no VCPKG_ROOT
           $triplet = if ('${{ matrix.target }}' -eq 'i686-pc-windows-msvc') { 'x86-windows-static' } else { 'x64-windows-static' }
-          & "$env:VCPKG_ROOT\vcpkg.exe" install "dav1d:$triplet" "pkgconf:x64-windows"
-          "PKG_CONFIG=$env:VCPKG_ROOT\installed\x64-windows\tools\pkgconf\pkgconf.exe" >> $env:GITHUB_ENV
-          "PKG_CONFIG_PATH=$env:VCPKG_ROOT\installed\$triplet\lib\pkgconfig" >> $env:GITHUB_ENV
+          & "$env:VCPKG_INSTALLATION_ROOT\vcpkg.exe" install "dav1d:$triplet" "pkgconf:x64-windows"
+          "PKG_CONFIG=$env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\tools\pkgconf\pkgconf.exe" >> $env:GITHUB_ENV
+          "PKG_CONFIG_PATH=$env:VCPKG_INSTALLATION_ROOT\installed\$triplet\lib\pkgconfig" >> $env:GITHUB_ENV
 
       - name: install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/rimage.yml
+++ b/.github/workflows/rimage.yml
@@ -57,12 +57,15 @@ jobs:
           - target: x86_64-pc-windows-msvc
             os: windows-2025
             cross: false
+            rustflags: -C target-feature=+crt-static
           - target: i686-pc-windows-msvc
             os: windows-2025
             cross: false
+            rustflags: -C target-feature=+crt-static
           - target: x86_64-apple-darwin
             os: macos-15-intel
             cross: false
+            rustflags: -A linker_messages
           - target: aarch64-apple-darwin
             os: macos-15
             cross: false
@@ -70,6 +73,7 @@ jobs:
     env:
       CARGO_BUILD_TARGET: ${{ matrix.target }}
       CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER: qemu-aarch64 -L /usr/aarch64-linux-gnu
+      RUSTFLAGS: -D warnings ${{ matrix.rustflags }}
 
     steps:
       - name: checkout
@@ -188,6 +192,8 @@ jobs:
 
       - name: build release binary
         shell: bash
+        env:
+          RUSTFLAGS: -D warnings ${{ matrix.rustflags }}
         run: |
           set -euo pipefail
           if [[ "${{ matrix.cross }}" == "true" ]]; then
@@ -198,6 +204,8 @@ jobs:
 
       - name: run tests
         shell: bash
+        env:
+          RUSTFLAGS: -D warnings ${{ matrix.rustflags }}
         run: |
           set -euo pipefail
           if [[ "${{ matrix.cross }}" == "true" ]]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Rimage library will be documented in this file.
 ### Breaking Changes
 
 - add SVG input support rendered through `resvg` (static SVG and gzipped SVGZ), usable with every output format
+- replace the `libavif` AVIF decoder with a `dav1d`-based one (`dav1d` + `avif-parse` + `yuvutils-rs`); decoding now links a system-installed `dav1d` (>= 1.3.0) through pkg-config instead of building libaom from source with cmake.
 
 ### Features
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,7 @@ dependencies = [
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "av-data"
@@ -287,7 +287,7 @@ checksum = "5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9"
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byte-slice-cast"
@@ -299,7 +299,21 @@ checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 name = "bytemuck"
 version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
+]
 
 [[package]]
 name = "byteorder"
@@ -773,7 +787,7 @@ dependencies = [
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -2090,7 +2104,12 @@ dependencies = [
 name = "syn"
 version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "system-deps"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,20 @@ dependencies = [
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "av-data"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fca67ba5d317924c02180c576157afd54babe48a76ebc66ce6d34bb8ba08308e"
+dependencies = [
+ "byte-slice-cast",
+ "bytes",
+ "num-derive",
+ "num-rational",
+ "num-traits",
+]
 
 [[package]]
 name = "av-scenechange"
@@ -185,6 +198,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "avif-parse"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "048e72663e14be27bfd8a9e01e8a0bf27610511ffd5f74c7955f4e4847ce2530"
+dependencies = [
+ "arrayvec",
+ "bitreader",
+ "byteorder",
+ "fallible_collections",
+ "leb128",
+ "log",
+]
+
+[[package]]
 name = "avif-serialize"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,6 +237,15 @@ name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "bitreader"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "886559b1e163d56c765bc3a985febb4eee8009f625244511d8ee3c432e08c066"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "bitstream-io"
@@ -251,33 +287,37 @@ checksum = "5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9"
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byte-slice-cast"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "bytemuck"
 version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
-dependencies = [
- "bytemuck_derive",
-]
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
-name = "bytemuck_derive"
-version = "1.12.0"
+name = "byteorder"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 3.0.5",
-]
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "byteorder-lite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
@@ -289,6 +329,16 @@ dependencies = [
  "jobserver",
  "libc",
  "shlex",
+]
+
+[[package]]
+name = "cfg-expr"
+version = "0.20.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe4ece8474b5f766c63426647e7b4b316b67431ade1036a8313cee24a03ae917"
+dependencies = [
+ "smallvec",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -323,15 +373,6 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
-name = "cmake"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "color_quant"
@@ -383,9 +424,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+checksum = "622f3fc73690be383c7214310406f28a90e6edeadc3cea882f9d71e495b9711a"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -393,18 +434,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.20"
+version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+checksum = "dc74980687109a3b14c72fd458107bf0baa1da1a1a805e178d15501ba9b86d9d"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.22"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+checksum = "a31eee39dddec8330830986fcd7625edb5a24ec90ea038215273bbc3adb08ac6"
 
 [[package]]
 name = "crunchy"
@@ -417,6 +458,28 @@ name = "data-url"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
+
+[[package]]
+name = "dav1d"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee89cb860616069c67520dcd66cacdb900b57c799f634a0eb6d91f6e2a82b61"
+dependencies = [
+ "av-data",
+ "bitflags",
+ "dav1d-sys",
+ "static_assertions",
+]
+
+[[package]]
+name = "dav1d-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c91aea6668645415331133ed6f8ddf0e7f40160cd97a12d59e68716a58704b"
+dependencies = [
+ "libc",
+ "system-deps",
+]
 
 [[package]]
 name = "document-features"
@@ -509,6 +572,12 @@ dependencies = [
  "smallvec",
  "zune-inflate",
 ]
+
+[[package]]
+name = "fallible_collections"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab93c7205280c4785c44517fe84d99751b81f6deb8450cb196da6be88e332bb"
 
 [[package]]
 name = "fast_image_resize"
@@ -704,7 +773,13 @@ dependencies = [
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1105,39 +1180,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83bff1d572d6b9aeef67ddfc8448e4a3737909cb28e81f97c791b9018703e52"
+
+[[package]]
 name = "lebe"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
-
-[[package]]
-name = "libaom-sys"
-version = "0.17.2+libaom.3.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c4fce8aaf0c2d8534529b0698ed98ec1da8d35319588d20b0d79ce6446e4194"
-dependencies = [
- "cmake",
-]
-
-[[package]]
-name = "libavif"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b710faf0de92da0e32a9a9c89bbf849e37277fd447b4f17b0f0f798796ae1f2"
-dependencies = [
- "libavif-sys",
-]
-
-[[package]]
-name = "libavif-sys"
-version = "0.17.0+libavif.1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490ca74b61e773140bebb086c81facb23273a99364a9ab0c92ab1532b90ade35"
-dependencies = [
- "cmake",
- "libaom-sys",
- "libc",
-]
 
 [[package]]
 name = "libc"
@@ -1797,8 +1849,10 @@ name = "rimage"
 version = "0.13.0"
 dependencies = [
  "anyhow",
+ "avif-parse",
  "clap",
  "console",
+ "dav1d",
  "fast_image_resize",
  "glob",
  "imagequant",
@@ -1806,7 +1860,6 @@ dependencies = [
  "indicatif-log-bridge",
  "indoc",
  "lcms2",
- "libavif",
  "little_exif",
  "log",
  "mozjpeg",
@@ -1823,6 +1876,7 @@ dependencies = [
  "tiff",
  "webp",
  "winresource",
+ "yuvutils-rs",
  "zune-core",
  "zune-image",
  "zune-imageprocs",
@@ -1991,6 +2045,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strict-num"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2030,12 +2090,26 @@ dependencies = [
 name = "syn"
 version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "system-deps"
+version = "7.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396a35feb67335377e0251fcbc1092fc85c484bd4e3a7a54319399da127796e7"
 dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
+ "cfg-expr",
+ "heck",
+ "pkg-config",
+ "toml",
+ "version-compare",
 ]
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "termcolor"
@@ -2266,6 +2340,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "version-compare"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2407,6 +2487,16 @@ name = "y4m"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
+
+[[package]]
+name = "yuvutils-rs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b699b6503cd14c70b258eaffedd7ada5a781ea23206eeb9066736b99ba37af1"
+dependencies = [
+ "num-traits",
+ "rayon",
+]
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name          = "rimage"
 version       = "0.13.0"
 edition       = "2024"
-rust-version  = "1.88.0"
+rust-version  = "1.90.0"
 description   = "Optimize images natively with best-in-class codecs"
 license       = "MIT OR Apache-2.0"
 readme        = "README.md"
@@ -72,6 +72,7 @@ threads = [
     "oxipng?/parallel",
     "fast_image_resize?/rayon",
     "ravif?/threading",
+    "yuvutils-rs?/rayon",
     "zune-image/threads",
 ]
 # Enables metadata support
@@ -89,7 +90,13 @@ oxipng = ["dep:oxipng"]
 # Enables webp codec
 webp = ["dep:webp"]
 # Enables avif codec
-avif = ["dep:ravif", "dep:libavif", "dep:rgb"]
+avif = [
+    "dep:ravif",
+    "dep:rgb",
+    "dep:dav1d",
+    "dep:avif-parse",
+    "dep:yuvutils-rs",
+]
 # Enables tiff codec
 tiff    = ["dep:tiff"]
 # Enables SVG input support (rendered via resvg)
@@ -114,9 +121,9 @@ oxipng = { version = "10.1.1", default-features = false, features = [
 ], optional = true }
 webp = { version = "0.3", default-features = false, optional = true }
 ravif = { version = "0.13.0", optional = true }
-libavif = { version = "0.14.0", default-features = false, features = [
-    "codec-aom",
-], optional = true }
+dav1d = { version = "0.11", optional = true }
+avif-parse = { version = "2.1", optional = true }
+yuvutils-rs = { version = "0.8", optional = true }
 lcms2 = { version = "6.2", optional = true }
 tiff = { version = "0.11.3", default-features = false, features = [
     "lzw",

--- a/Cross.toml
+++ b/Cross.toml
@@ -11,17 +11,24 @@
 # AVIF decoding links dav1d through pkg-config and the stock image carries no
 # dav1d, so pre-build compiles a static dav1d against the musl toolchain.
 # nasm is not needed here: the aarch64 asm is assembled by the C compiler.
+#
+# cross 0.2.5 joins the pre-build entries into `RUN eval "..."`, so no entry
+# may contain double quotes (they would terminate the eval string); printf %b
+# with \047 emits the apostrophes the cross-file values need. `set -e` makes
+# any pre-build failure abort the docker build instead of silently shipping an
+# image without dav1d. cross 0.2.5 has no [env] support and exports
+# PKG_CONFIG_ALLOW_CROSS=1 itself; dav1d installs into /usr/local, which the
+# default pkg-config search path already covers.
 [target.aarch64-unknown-linux-musl]
 image = "ghcr.io/cross-rs/aarch64-unknown-linux-musl@sha256:10769140e3ce9c01cb2b1d4751ce3afb31fb2edea5afcd409ccde589729d7910"
 pre-build = [
+    "set -e",
     "apt-get update",
     "apt-get install --assume-yes ninja-build meson pkg-config git ca-certificates",
     "git clone --depth 1 --branch 1.5.1 https://code.videolan.org/videolan/dav1d.git /tmp/dav1d",
-    "printf '%s\\n' '[binaries]' \"c = 'aarch64-linux-musl-gcc'\" \"ar = 'aarch64-linux-musl-ar'\" \"pkg-config = 'pkg-config'\" '[host_machine]' \"system = 'linux'\" \"cpu_family = 'aarch64'\" \"cpu = 'aarch64'\" \"endian = 'little'\" > /tmp/dav1d-cross.ini",
-    "meson setup /tmp/dav1d/build -Ddefault_library=static -Dtools=false -Dbuild_tests=false --prefix=/usr/local --cross-file /tmp/dav1d-cross.ini /tmp/dav1d",
+    "printf '%b\\n' '[binaries]' 'c = \\047aarch64-linux-musl-gcc\\047' 'ar = \\047aarch64-linux-musl-ar\\047' 'pkg-config = \\047pkg-config\\047' '[host_machine]' 'system = \\047linux\\047' 'cpu_family = \\047aarch64\\047' 'cpu = \\047aarch64\\047' 'endian = \\047little\\047' > /tmp/dav1d-cross.ini",
+    "cd /tmp/dav1d",
+    "meson setup /tmp/dav1d/build -Ddefault_library=static -Denable_tools=false -Denable_tests=false --prefix=/usr/local --cross-file /tmp/dav1d-cross.ini",
     "ninja -C /tmp/dav1d/build install",
     "rm -rf /tmp/dav1d /tmp/dav1d-cross.ini",
 ]
-[env]
-PKG_CONFIG_ALLOW_CROSS = "1"
-PKG_CONFIG_PATH = "/usr/local/lib/pkgconfig"

--- a/Cross.toml
+++ b/Cross.toml
@@ -7,9 +7,21 @@
 # main-branch image (Ubuntu 24.04 base) by digest so the toolchain cannot
 # change silently. Refresh with:
 #   docker buildx imagetools inspect ghcr.io/cross-rs/aarch64-unknown-linux-musl:main
+#
+# AVIF decoding links dav1d through pkg-config and the stock image carries no
+# dav1d, so pre-build compiles a static dav1d against the musl toolchain.
+# nasm is not needed here: the aarch64 asm is assembled by the C compiler.
 [target.aarch64-unknown-linux-musl]
 image = "ghcr.io/cross-rs/aarch64-unknown-linux-musl@sha256:10769140e3ce9c01cb2b1d4751ce3afb31fb2edea5afcd409ccde589729d7910"
 pre-build = [
     "apt-get update",
-    "apt-get install --assume-yes ninja-build meson nasm",
+    "apt-get install --assume-yes ninja-build meson pkg-config git ca-certificates",
+    "git clone --depth 1 --branch 1.5.1 https://code.videolan.org/videolan/dav1d.git /tmp/dav1d",
+    "printf '%s\\n' '[binaries]' \"c = 'aarch64-linux-musl-gcc'\" \"ar = 'aarch64-linux-musl-ar'\" \"pkg-config = 'pkg-config'\" '[host_machine]' \"system = 'linux'\" \"cpu_family = 'aarch64'\" \"cpu = 'aarch64'\" \"endian = 'little'\" > /tmp/dav1d-cross.ini",
+    "meson setup /tmp/dav1d/build -Ddefault_library=static -Dtools=false -Dbuild_tests=false --prefix=/usr/local --cross-file /tmp/dav1d-cross.ini /tmp/dav1d",
+    "ninja -C /tmp/dav1d/build install",
+    "rm -rf /tmp/dav1d /tmp/dav1d-cross.ini",
 ]
+[env]
+PKG_CONFIG_ALLOW_CROSS = "1"
+PKG_CONFIG_PATH = "/usr/local/lib/pkgconfig"

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ For library usage check [Docs.rs](https://docs.rs/rimage/latest/rimage/)
 
 | Image Codecs | Decoder       | Encoder                 | NOTE                                                 |
 | ------------ | ------------- | ----------------------- | ---------------------------------------------------- |
-| avif         | libavif       | ravif                   | Common features only, Static only                    |
+| avif         | dav1d         | ravif                   | Common features only, Static only                    |
 | bmp          | zune-bmp      | ❌                      | Input only                                           |
 | farbfeld     | zune-farbfeld | zune-farbfeld           |                                                      |
 | hdr          | zune-hdr      | zune-hdr                |                                                      |
@@ -365,28 +365,35 @@ rimage png "D:\example.jpg" -s "suffix"  -d "D:\desktop\" # backslash at the end
    - During installation, select "Desktop development with C++" workload.
    - OR, just use `choco install visualstudio2026-workload-vctools` to install it.
 
-4. Install Perl:
-   - Download and install from [Strawberry Perl](https://strawberryperl.com/).
-   - OR, just use `choco install strawberryperl` to install it.
-
-5. Install cmake (OPTIONAL if you use the MSVC bundled version):
+4. Install cmake (OPTIONAL if you use the MSVC bundled version):
     - Download and install from [CMake](https://cmake.org/download/).
     - OR, just use `choco install cmake` to install it.
     - OR, you can use the bundled cmake in MSVC, but please note that only **4.2.3** + could be used.
 
-6. Install nasm and yasm:
-   - Download and install from [nasm](https://www.nasm.us/) and [yasm](https://github.com/yasm/yasm/releases).
-   - OR, just use `choco install nasm` and `choco install yasm` to install them.
-   - **WARNING**: `libaom` requires older version of the nasm binary or yasm instead for a successful build, see [libavif-rs#122](https://github.com/njaard/libavif-rs/issues/122) for details.
+5. Install nasm (for the mozjpeg encoder's SIMD code):
+   - Download and install from [nasm](https://www.nasm.us/).
+   - OR, just use `choco install nasm` to install it.
 
-7. **WARNING** Avoid conflicts from perl:
-    - Remove `C:\Strawberry\c\bin` (Your Perl installation directory) from `$PATH$` to avoid conflicts with newer `cmake` installed in step 5 (The bundled `cmake.exe` in perl is OUTDATED and would make build scripts get error).
+6. Install dav1d through [vcpkg](https://vcpkg.io/) (the AVIF decoder links a
+   static dav1d found through pkg-config):
 
-8. Make sure `$PATH`
-    - Make sure the cmake installed in step 5 is in your system `$PATH` and can be called from command line. You can check this by running `cmake --version` in your terminal, it should show the version of cmake you installed in step 5.
-    - Make sure Perl is in your system `$PATH` and can be called from command line. You can check this by running `perl --version` in your terminal, it should show the version of Perl you installed in step 4.
+    ```pwsh
+    vcpkg install dav1d:x64-windows-static pkgconf:x64-windows
 
-9. Build / Test / Format the project:
+    # point the build at pkgconf and the dav1d package
+    $env:PKG_CONFIG = "$env:VCPKG_ROOT\installed\x64-windows\tools\pkgconf\pkgconf.exe"
+    $env:PKG_CONFIG_PATH = "$env:VCPKG_ROOT\installed\x64-windows-static\lib\pkgconfig"
+    ```
+
+    Use `x86-windows-static` instead of `x64-windows-static` when building for
+    the i686 target. To persist the two environment variables, add them with
+    `setx` or through the system settings.
+
+7. Make sure cmake is in your system `$PATH` and can be called from command
+   line. You can check this by running `cmake --version` in your terminal, it
+   should show the version of cmake you installed in step 4.
+
+8. Build / Test / Format the project:
 
     ```pwsh
     # build the library and the CLI binary

--- a/build.rs
+++ b/build.rs
@@ -17,17 +17,15 @@ fn main() {
         std::process::exit(1);
     }
 
-    let pack = |pre: u16| -> u64 {
-        (env_u64("CARGO_PKG_VERSION_MAJOR") << 48)
-            | (env_u64("CARGO_PKG_VERSION_MINOR") << 32)
-            | (env_u64("CARGO_PKG_VERSION_PATCH") << 16)
-            | u64::from(pre)
-    };
+    let packed = (env_u64("CARGO_PKG_VERSION_MAJOR") << 48)
+        | (env_u64("CARGO_PKG_VERSION_MINOR") << 32)
+        | (env_u64("CARGO_PKG_VERSION_PATCH") << 16)
+        | (env_u64("CARGO_PKG_VERSION_PRE"));
 
     let mut res = WindowsResource::new();
 
-    res.set_version_info(VersionInfo::FILEVERSION, pack(VERSION_PRE))
-        .set_version_info(VersionInfo::PRODUCTVERSION, pack(VERSION_PRE));
+    res.set_version_info(VersionInfo::FILEVERSION, packed)
+        .set_version_info(VersionInfo::PRODUCTVERSION, packed);
 
     if let Err(e) = res.compile() {
         eprintln!("{e}");

--- a/build.rs
+++ b/build.rs
@@ -1,12 +1,20 @@
 use winresource::{VersionInfo, WindowsResource};
 
-// This is the pre-release version number.
-const VERSION_PRE: u16 = 0;
-
 fn main() {
     // only run if target os is windows
     if std::env::var("CARGO_CFG_TARGET_OS").unwrap() != "windows" {
         return;
+    }
+
+    // The winresource-based version-info build script only supports the MSVC
+    // toolchain. Reject Windows GNU builds instead of failing later with a
+    // confusing linker/resource error.
+    if std::env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default() == "gnu" {
+        eprintln!(
+            "rimage on Windows only supports the MSVC toolchain; \
+             x86_64-pc-windows-gnu / i686-pc-windows-gnu are not supported"
+        );
+        std::process::exit(1);
     }
 
     let pack = |pre: u16| -> u64 {

--- a/build.rs
+++ b/build.rs
@@ -6,10 +6,6 @@ const VERSION_PRE: u16 = 0;
 fn main() {
     // only run if target os is windows
     if std::env::var("CARGO_CFG_TARGET_OS").unwrap() != "windows" {
-        println!(
-            "cargo:warning={:#?}",
-            "This build script is only for windows target, skipping..."
-        );
         return;
     }
 

--- a/ci/build-dav1d.sh
+++ b/ci/build-dav1d.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Builds a static dav1d and installs it into a prefix, for targets that have
+# no system dav1d package (musl and cross-compiled GNU targets).
+#
+# Usage: build-dav1d.sh <install-prefix> [meson-cross-file]
+#
+# The following environment variables select the toolchain when cross file is
+# omitted and the target differs from the host: CC, AR.
+set -euo pipefail
+
+prefix=$1
+version=1.5.1
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+git clone --depth 1 --branch "$version" \
+    https://code.videolan.org/videolan/dav1d.git "$work/dav1d"
+
+args=(-Ddefault_library=static -Dtools=false -Dbuild_tests=false --prefix="$prefix")
+if [[ $# -gt 1 ]]; then
+    args+=(--cross-file "$2")
+fi
+
+meson setup "$work/build" "${args[@]}" "$work/dav1d"
+ninja -C "$work/build" install

--- a/ci/build-dav1d.sh
+++ b/ci/build-dav1d.sh
@@ -19,9 +19,9 @@ git clone --depth 1 --branch "$version" \
 
 # dav1d 1.5.x spells these options enable_tools/enable_tests; the shorter
 # tools/build_tests names are rejected as unknown project options
-args=(-Ddefault_library=static -Denable_tools=false -Denable_tests=false --prefix="$prefix")
+args=(-Ddefault_library=static -Denable_tools=false -Denable_tests=false -Dlibdir=lib --prefix="$prefix")
 if [[ $# -gt 1 ]]; then
-    args+=(--cross-file "$2")
+    args+=(--cross-file "$(realpath "$2")")
 fi
 
 # options must not sit between meson setup's two positional arguments:

--- a/ci/build-dav1d.sh
+++ b/ci/build-dav1d.sh
@@ -17,10 +17,15 @@ trap 'rm -rf "$work"' EXIT
 git clone --depth 1 --branch "$version" \
     https://code.videolan.org/videolan/dav1d.git "$work/dav1d"
 
-args=(-Ddefault_library=static -Dtools=false -Dbuild_tests=false --prefix="$prefix")
+# dav1d 1.5.x spells these options enable_tools/enable_tests; the shorter
+# tools/build_tests names are rejected as unknown project options
+args=(-Ddefault_library=static -Denable_tools=false -Denable_tests=false --prefix="$prefix")
 if [[ $# -gt 1 ]]; then
     args+=(--cross-file "$2")
 fi
 
-meson setup "$work/build" "${args[@]}" "$work/dav1d"
+# options must not sit between meson setup's two positional arguments:
+# argparse then fails to bind the trailing sourcedir ("unrecognized
+# arguments"), so run from inside the source tree and pass only the builddir
+(cd "$work/dav1d" && meson setup "$work/build" "${args[@]}")
 ninja -C "$work/build" install

--- a/ci/meson/aarch64-gnu.ini
+++ b/ci/meson/aarch64-gnu.ini
@@ -1,0 +1,14 @@
+# Meson cross file used by ci/build-dav1d.sh to compile a static dav1d for
+# aarch64-unknown-linux-gnu on the x86_64 CI runner. Declaring the host
+# machine explicitly keeps meson from running aarch64 binaries during its
+# sanity check.
+[binaries]
+c = 'aarch64-linux-gnu-gcc'
+ar = 'aarch64-linux-gnu-ar'
+pkg-config = 'pkg-config'
+
+[host_machine]
+system = 'linux'
+cpu_family = 'aarch64'
+cpu = 'aarch64'
+endian = 'little'

--- a/src/cli/pipeline.rs
+++ b/src/cli/pipeline.rs
@@ -72,7 +72,7 @@ pub fn decode<P: AsRef<Path>>(f: P, matches: &ArgMatches) -> Result<Image, Image
                 file.read_to_end(&mut file_content)?;
                 file.seek(SeekFrom::Start(0))?;
 
-                if libavif::is_avif(&file_content) {
+                if rimage::codecs::avif::is_avif(&file_content) {
                     use rimage::codecs::avif::AvifDecoder;
 
                     let decoder = AvifDecoder::try_new(file)?;

--- a/src/codecs/avif/decoder/mod.rs
+++ b/src/codecs/avif/decoder/mod.rs
@@ -212,8 +212,10 @@ fn color_transform(coefficients: MatrixCoefficients) -> Result<ColorTransform, I
             kb: 0.087,
             standard: YuvStandardMatrix::Smpte240,
         }),
-        MatrixCoefficients::BT2020NonConstantLuminance
-        | MatrixCoefficients::BT2020ConstantLuminance => Ok(ColorTransform::Ycbcr {
+        MatrixCoefficients::BT2020ConstantLuminance => Err(decode_error(
+            "unsupported matrix coefficients (BT.2020 constant luminance)",
+        )),
+        MatrixCoefficients::BT2020NonConstantLuminance => Ok(ColorTransform::Ycbcr {
             kr: 0.2627,
             kb: 0.0593,
             standard: YuvStandardMatrix::Bt2020,

--- a/src/codecs/avif/decoder/mod.rs
+++ b/src/codecs/avif/decoder/mod.rs
@@ -1,9 +1,49 @@
 use std::{io::Read, marker::PhantomData};
 
+use dav1d::{
+    Decoder, Error as Dav1dError, Picture, PixelLayout, PlanarImageComponent,
+    pixel::{MatrixCoefficients, YUVRange as Dav1dYuvRange},
+};
+use yuvutils_rs::{
+    YuvGrayImage, YuvPlanarImage, YuvRange, YuvStandardMatrix, ycgco420_to_rgba, ycgco422_to_rgba,
+    ycgco444_to_rgba, yuv400_to_rgba, yuv420_to_rgba, yuv422_to_rgba, yuv444_to_rgba,
+};
 use zune_core::colorspace::ColorSpace;
 use zune_image::{errors::ImageErrors, image::Image, traits::DecoderTrait};
 
-/// A AVIF decoder
+/// Checks whether `data` looks like an AVIF file.
+///
+/// An ISO-BMFF file must start with an `ftyp` box (ISO 14496-12 § 4.3.1) that
+/// carries the `avif` or `avis` brand either as the major brand or somewhere in
+/// the compatible brands list.
+pub fn is_avif(data: &[u8]) -> bool {
+    if data.len() < 12 || &data[4..8] != b"ftyp" {
+        return false;
+    }
+
+    let size = u32::from_be_bytes([data[0], data[1], data[2], data[3]]) as usize;
+    let end = if size == 0 {
+        data.len()
+    } else {
+        size.min(data.len())
+    };
+
+    let brand = |b: &[u8]| b == b"avif" || b == b"avis";
+
+    if brand(&data[8..12]) {
+        return true;
+    }
+
+    // compatible brands start after the 4-byte minor version
+    end >= 16
+        && data[16..end]
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .any(|arg0: &[u8; 4]| brand(arg0))
+}
+
+/// A AVIF decoder that decodes the AV1 bitstream through `dav1d`
 pub struct AvifDecoder<R: Read> {
     inner: Vec<u8>,
     dimensions: Option<(usize, usize)>,
@@ -29,13 +69,22 @@ where
     R: Read,
 {
     fn decode(&mut self) -> Result<Image, ImageErrors> {
-        let img = libavif::decode_rgb(&self.inner)
-            .map_err(|e| ImageErrors::ImageDecodeErrors(e.to_string()))?;
+        let parsed = avif_parse::read_avif(&mut self.inner.as_slice()).map_err(decode_error)?;
 
-        let (w, h) = (img.width() as usize, img.height() as usize);
-        self.dimensions = Some((w, h));
+        let color = decode_av1_stream(&parsed.primary_item)?;
+        let alpha = parsed
+            .alpha_item
+            .as_deref()
+            .filter(|stream| !stream.is_empty())
+            .map(decode_av1_stream)
+            .transpose()?;
 
-        Ok(Image::from_u8(&img, w, h, ColorSpace::RGBA))
+        let rgba = picture_to_rgba(&color, alpha.as_ref(), parsed.premultiplied_alpha)?;
+
+        let (width, height) = (color.width() as usize, color.height() as usize);
+        self.dimensions = Some((width, height));
+
+        Ok(Image::from_u8(&rgba, width, height, ColorSpace::RGBA))
     }
 
     fn dimensions(&self) -> Option<(usize, usize)> {
@@ -47,8 +96,476 @@ where
     }
 
     fn name(&self) -> &'static str {
-        "avif-decoder (aom)"
+        "avif-decoder (dav1d)"
     }
+}
+
+fn decode_error(err: impl std::fmt::Display) -> ImageErrors {
+    ImageErrors::ImageDecodeErrors(format!("avif: {err}"))
+}
+
+/// Decodes a still-picture AV1 bitstream and returns its frame.
+///
+/// Still AVIF carries a single frame, so frame threading is disabled through
+/// `max_frame_delay`: it would otherwise hold the picture back until an
+/// end-of-stream drain, and `dav1d_flush` only discards state instead of
+/// draining it.
+fn decode_av1_stream(data: &[u8]) -> Result<Picture, ImageErrors> {
+    let mut settings = dav1d::Settings::new();
+    settings.set_max_frame_delay(1);
+
+    let mut decoder = Decoder::with_settings(&settings).map_err(decode_error)?;
+
+    match decoder.send_data(data.to_vec(), None, None, None) {
+        // `Again` only means decoded frames are pending retrieval, not rejection
+        Ok(()) | Err(Dav1dError::Again) => {}
+        Err(err) => return Err(decode_error(err)),
+    }
+
+    let mut pending_pushed = false;
+    loop {
+        match decoder.get_picture() {
+            Ok(picture) => return Ok(picture),
+            Err(Dav1dError::Again) => {
+                if pending_pushed {
+                    return Err(ImageErrors::ImageDecodeErrors(
+                        "avif: the bitstream contains no frame".into(),
+                    ));
+                }
+                decoder.send_pending_data().map_err(decode_error)?;
+                pending_pushed = true;
+            }
+            Err(err) => return Err(decode_error(err)),
+        }
+    }
+}
+
+fn picture_to_rgba(
+    color: &Picture,
+    alpha: Option<&Picture>,
+    premultiplied: bool,
+) -> Result<Vec<u8>, ImageErrors> {
+    let (width, height) = (color.width() as usize, color.height() as usize);
+
+    if let Some(alpha) = alpha
+        && (alpha.width() as usize != width || alpha.height() as usize != height)
+    {
+        return Err(ImageErrors::ImageDecodeErrors(
+            "avif: alpha item dimensions do not match the color item".into(),
+        ));
+    }
+
+    let mut rgba = vec![0u8; width * height * 4];
+
+    if color.matrix_coefficients() == MatrixCoefficients::Identity {
+        identity_planes_to_rgba(color, &mut rgba);
+    } else {
+        color_planes_to_rgba(color, &mut rgba)?;
+    }
+
+    if let Some(alpha) = alpha {
+        merge_alpha_plane(&mut rgba, alpha, width, height);
+    }
+
+    if premultiplied {
+        unpremultiply_rgba(&mut rgba);
+    }
+
+    Ok(rgba)
+}
+
+enum ColorTransform {
+    /// YCbCr with the ITU-R kr/kb weights of the bitstream's matrix, plus the
+    /// matching yuvutils preset for the 8-bit path.
+    Ycbcr {
+        kr: f32,
+        kb: f32,
+        standard: YuvStandardMatrix,
+    },
+    /// YCgCo (H.273 matrix 8); full range only.
+    Ycgco,
+}
+
+fn color_transform(coefficients: MatrixCoefficients) -> Result<ColorTransform, ImageErrors> {
+    match coefficients {
+        MatrixCoefficients::BT709 => Ok(ColorTransform::Ycbcr {
+            kr: 0.2126,
+            kb: 0.0722,
+            standard: YuvStandardMatrix::Bt709,
+        }),
+        MatrixCoefficients::BT470M => Ok(ColorTransform::Ycbcr {
+            kr: 0.30,
+            kb: 0.11,
+            standard: YuvStandardMatrix::Custom(0.30, 0.11),
+        }),
+        // BT.470BG and ST-170M are both BT.601; libavif also defaults to BT.601
+        // when the bitstream leaves the matrix unspecified
+        MatrixCoefficients::BT470BG
+        | MatrixCoefficients::ST170M
+        | MatrixCoefficients::Unspecified => Ok(ColorTransform::Ycbcr {
+            kr: 0.299,
+            kb: 0.114,
+            standard: YuvStandardMatrix::Bt601,
+        }),
+        MatrixCoefficients::ST240M => Ok(ColorTransform::Ycbcr {
+            kr: 0.212,
+            kb: 0.087,
+            standard: YuvStandardMatrix::Smpte240,
+        }),
+        MatrixCoefficients::BT2020NonConstantLuminance
+        | MatrixCoefficients::BT2020ConstantLuminance => Ok(ColorTransform::Ycbcr {
+            kr: 0.2627,
+            kb: 0.0593,
+            standard: YuvStandardMatrix::Bt2020,
+        }),
+        MatrixCoefficients::YCgCo => Ok(ColorTransform::Ycgco),
+        other => Err(decode_error(format!(
+            "unsupported matrix coefficients ({other})"
+        ))),
+    }
+}
+
+fn color_planes_to_rgba(color: &Picture, rgba: &mut [u8]) -> Result<(), ImageErrors> {
+    let (width, height) = (color.width() as usize, color.height() as usize);
+    let range = match color.color_range() {
+        Dav1dYuvRange::Full => YuvRange::Full,
+        _ => YuvRange::Limited,
+    };
+    let transform = color_transform(color.matrix_coefficients())?;
+    let layout = color.pixel_layout();
+
+    if layout == PixelLayout::I400 {
+        return monochrome_to_rgba(color, rgba, range);
+    }
+
+    if color.bit_depth() == 8 {
+        let image = YuvPlanarImage {
+            y_plane: &color.plane(PlanarImageComponent::Y),
+            y_stride: color.stride(PlanarImageComponent::Y),
+            u_plane: &color.plane(PlanarImageComponent::U),
+            u_stride: color.stride(PlanarImageComponent::U),
+            v_plane: &color.plane(PlanarImageComponent::V),
+            v_stride: color.stride(PlanarImageComponent::V),
+            width: width as u32,
+            height: height as u32,
+        };
+
+        match (transform, layout) {
+            (ColorTransform::Ycbcr { standard, .. }, PixelLayout::I420) => {
+                yuv420_to_rgba(&image, rgba, rgba_stride(width), range, standard)
+            }
+            (ColorTransform::Ycbcr { standard, .. }, PixelLayout::I422) => {
+                yuv422_to_rgba(&image, rgba, rgba_stride(width), range, standard)
+            }
+            (ColorTransform::Ycbcr { standard, .. }, PixelLayout::I444) => {
+                yuv444_to_rgba(&image, rgba, rgba_stride(width), range, standard)
+            }
+            (ColorTransform::Ycgco, PixelLayout::I420) => {
+                ycgco420_to_rgba(&image, rgba, rgba_stride(width), range)
+            }
+            (ColorTransform::Ycgco, PixelLayout::I422) => {
+                ycgco422_to_rgba(&image, rgba, rgba_stride(width), range)
+            }
+            (ColorTransform::Ycgco, PixelLayout::I444) => {
+                ycgco444_to_rgba(&image, rgba, rgba_stride(width), range)
+            }
+            _ => unreachable!("layout is not monochrome here"),
+        }
+        .map_err(decode_error)
+    } else {
+        // `Plane` owns an `Arc` clone of the picture, so bind the planes here
+        // and hand `Planes` slices of them
+        let y_plane = color.plane(PlanarImageComponent::Y);
+        let u_plane = color.plane(PlanarImageComponent::U);
+        let v_plane = color.plane(PlanarImageComponent::V);
+        let view = Planes {
+            y: &y_plane,
+            y_stride: color.stride(PlanarImageComponent::Y) as usize,
+            u: &u_plane,
+            u_stride: color.stride(PlanarImageComponent::U) as usize,
+            v: &v_plane,
+            v_stride: color.stride(PlanarImageComponent::V) as usize,
+            width,
+            height,
+            layout,
+        };
+        high_depth_ycbcr_to_rgba(
+            &view,
+            color.bits_per_component().map(|bits| bits.0).unwrap_or(8),
+            color.color_range() == Dav1dYuvRange::Full,
+            &transform,
+            rgba,
+        );
+        Ok(())
+    }
+}
+
+/// Monochrome pictures only carry luma; gray expansion never uses the matrix.
+fn monochrome_to_rgba(
+    color: &Picture,
+    rgba: &mut [u8],
+    range: YuvRange,
+) -> Result<(), ImageErrors> {
+    let (width, height) = (color.width() as usize, color.height() as usize);
+
+    if color.bit_depth() == 8 {
+        let gray = YuvGrayImage {
+            y_plane: &color.plane(PlanarImageComponent::Y),
+            y_stride: color.stride(PlanarImageComponent::Y),
+            width: width as u32,
+            height: height as u32,
+        };
+
+        yuv400_to_rgba(
+            &gray,
+            rgba,
+            rgba_stride(width),
+            range,
+            YuvStandardMatrix::Bt601,
+        )
+        .map_err(decode_error)
+    } else {
+        let used = used_bits(color)?;
+        let full_range = color.color_range() == Dav1dYuvRange::Full;
+        let plane = &color.plane(PlanarImageComponent::Y);
+        let stride = color.stride(PlanarImageComponent::Y) as usize;
+
+        for row in 0..height {
+            let source = &plane[row * stride..][..width * 2];
+            let out = &mut rgba[row * width * 4..][..width * 4];
+            for (x, bytes) in source.as_chunks::<2>().0.iter().enumerate() {
+                let sample = u16::from_le_bytes([bytes[0], bytes[1]]) as u32;
+                // clamp: lossy bitstreams can undershoot the limited range
+                let gray = expand_luma(sample, used, full_range).clamp(0.0, 255.0) as u8;
+                out[x * 4] = gray;
+                out[x * 4 + 1] = gray;
+                out[x * 4 + 2] = gray;
+                out[x * 4 + 3] = 255;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// AV1 identity matrix carries RGB directly in the planes: Y=G, U=B, V=R.
+fn identity_planes_to_rgba(color: &Picture, rgba: &mut [u8]) {
+    let (width, height) = (color.width() as usize, color.height() as usize);
+    let g_plane = &color.plane(PlanarImageComponent::Y);
+    let g_stride = color.stride(PlanarImageComponent::Y) as usize;
+    let b_plane = &color.plane(PlanarImageComponent::U);
+    let b_stride = color.stride(PlanarImageComponent::U) as usize;
+    let r_plane = &color.plane(PlanarImageComponent::V);
+    let r_stride = color.stride(PlanarImageComponent::V) as usize;
+
+    if color.bit_depth() == 8 {
+        for y in 0..height {
+            let row = &mut rgba[y * width * 4..][..width * 4];
+            for (x, px) in row.as_chunks_mut::<4>().0.iter_mut().enumerate() {
+                px[0] = r_plane[y * r_stride + x];
+                px[1] = g_plane[y * g_stride + x];
+                px[2] = b_plane[y * b_stride + x];
+                px[3] = 255;
+            }
+        }
+    } else {
+        let used = used_bits(color).unwrap_or(16);
+        for y in 0..height {
+            let row = &mut rgba[y * width * 4..][..width * 4];
+            for (x, px) in row.as_chunks_mut::<4>().0.iter_mut().enumerate() {
+                px[0] = sample_u8(&r_plane[y * r_stride + x * 2..], used);
+                px[1] = sample_u8(&g_plane[y * g_stride + x * 2..], used);
+                px[2] = sample_u8(&b_plane[y * b_stride + x * 2..], used);
+                px[3] = 255;
+            }
+        }
+    }
+}
+
+/// Copies the alpha stream's luma plane into the RGBA alpha channel.
+fn merge_alpha_plane(rgba: &mut [u8], alpha: &Picture, width: usize, height: usize) {
+    let plane = &alpha.plane(PlanarImageComponent::Y);
+    let stride = alpha.stride(PlanarImageComponent::Y) as usize;
+
+    if alpha.bit_depth() == 8 {
+        for y in 0..height {
+            let source = &plane[y * stride..][..width];
+            let row = &mut rgba[y * width * 4..][..width * 4];
+            for (x, &a) in source.iter().enumerate() {
+                row[x * 4 + 3] = a;
+            }
+        }
+    } else {
+        let used = used_bits(alpha).unwrap_or(16);
+        for y in 0..height {
+            let source = &plane[y * stride..][..width * 2];
+            let row = &mut rgba[y * width * 4..][..width * 4];
+            for (x, bytes) in source.as_chunks::<2>().0.iter().enumerate() {
+                row[x * 4 + 3] = sample_u8(bytes, used);
+            }
+        }
+    }
+}
+
+/// Recovers straight alpha from premultiplied color (MIAF § 7.3.5.2).
+fn unpremultiply_rgba(rgba: &mut [u8]) {
+    for px in rgba.as_chunks_mut::<4>().0 {
+        let a = px[3] as u32;
+        if a > 0 && a < 255 {
+            px[0] = ((px[0] as u32 * 255 + a / 2) / a).min(255) as u8;
+            px[1] = ((px[1] as u32 * 255 + a / 2) / a).min(255) as u8;
+            px[2] = ((px[2] as u32 * 255 + a / 2) / a).min(255) as u8;
+        }
+    }
+}
+
+/// Raw planar slices of a picture, valid as long as the borrowed `Plane`s.
+struct Planes<'a> {
+    y: &'a [u8],
+    y_stride: usize,
+    u: &'a [u8],
+    u_stride: usize,
+    v: &'a [u8],
+    v_stride: usize,
+    width: usize,
+    height: usize,
+    layout: PixelLayout,
+}
+
+impl Planes<'_> {
+    fn sample(&self, component: Sample, x: usize, y: usize) -> u16 {
+        let (plane, stride) = match component {
+            Sample::Y => (self.y, self.y_stride),
+            Sample::U => (self.u, self.u_stride),
+            Sample::V => (self.v, self.v_stride),
+        };
+        let offset = y * stride + x * 2;
+        u16::from_le_bytes([plane[offset], plane[offset + 1]])
+    }
+}
+
+enum Sample {
+    Y,
+    U,
+    V,
+}
+
+/// Scalar YCbCr/YCgCo -> RGBA8 conversion for >8-bit pictures.
+///
+/// Done by hand because yuvutils-rs 0.8.3 gets >8-bit conversions wrong: its
+/// SIMD kernels corrupt the alpha channel and its BT.2020 inverse mis-scales
+/// the red channel.
+///
+/// Chroma is nearest-neighbor upsampled; BT.2020 constant luminance is treated
+/// as non-constant luminance.
+fn high_depth_ycbcr_to_rgba(
+    planes: &Planes,
+    used: usize,
+    full_range: bool,
+    transform: &ColorTransform,
+    rgba: &mut [u8],
+) {
+    let width = planes.width;
+    let height = planes.height;
+    // chroma sits at half resolution horizontally for 4:2:0/4:2:2 and
+    // vertically only for 4:2:0
+    let chroma_down_x = planes.layout != PixelLayout::I444;
+    let chroma_down_y = planes.layout == PixelLayout::I420;
+
+    for row in 0..height {
+        let chroma_row = if chroma_down_y { row / 2 } else { row };
+        let out = &mut rgba[row * width * 4..][..width * 4];
+        for (x, px) in out.as_chunks_mut::<4>().0.iter_mut().enumerate() {
+            let chroma_x = if chroma_down_x { x / 2 } else { x };
+
+            let y = expand_luma(planes.sample(Sample::Y, x, row) as u32, used, full_range);
+
+            let (r, g, b) = match transform {
+                ColorTransform::Ycbcr { kr, kb, .. } => {
+                    let cb = expand_chroma(
+                        planes.sample(Sample::U, chroma_x, chroma_row) as u32,
+                        used,
+                        full_range,
+                    );
+                    let cr = expand_chroma(
+                        planes.sample(Sample::V, chroma_x, chroma_row) as u32,
+                        used,
+                        full_range,
+                    );
+                    let kb_g = 2.0 * kb * (1.0 - kb) / (1.0 - kr - kb);
+                    let kr_g = 2.0 * kr * (1.0 - kr) / (1.0 - kr - kb);
+                    (
+                        y + (2.0 - 2.0 * kr) * cr,
+                        y - kb_g * cb - kr_g * cr,
+                        y + (2.0 - 2.0 * kb) * cb,
+                    )
+                }
+                ColorTransform::Ycgco => {
+                    let cg = expand_chroma(
+                        planes.sample(Sample::U, chroma_x, chroma_row) as u32,
+                        used,
+                        full_range,
+                    );
+                    let co = expand_chroma(
+                        planes.sample(Sample::V, chroma_x, chroma_row) as u32,
+                        used,
+                        full_range,
+                    );
+                    (y - cg + co, y + cg, y - cg - co)
+                }
+            };
+
+            px[0] = clamp_u8(r);
+            px[1] = clamp_u8(g);
+            px[2] = clamp_u8(b);
+            px[3] = 255;
+        }
+    }
+}
+
+/// Maps a luma sample to the 8-bit domain.
+fn expand_luma(sample: u32, used: usize, full_range: bool) -> f32 {
+    if full_range {
+        sample as f32 * 255.0 / (((1u32 << used) - 1) as f32)
+    } else {
+        let floor = 16u32 << (used - 8);
+        let span = 219u32 << (used - 8);
+        (sample.saturating_sub(floor)) as f32 * 255.0 / span as f32
+    }
+}
+
+/// Maps a chroma sample to a signed offset in the 8-bit domain.
+fn expand_chroma(sample: u32, used: usize, full_range: bool) -> f32 {
+    let mid = 1u32 << (used - 1);
+    if full_range {
+        (sample as i32 - mid as i32) as f32 * 255.0 / mid as f32
+    } else {
+        let floor = 16u32 << (used - 8);
+        let span = 224u32 << (used - 8);
+        (sample.saturating_sub(floor) as i32 - (span / 2) as i32) as f32 * 255.0 / span as f32
+    }
+}
+
+fn clamp_u8(value: f32) -> u8 {
+    (value + 0.5).clamp(0.0, 255.0) as u8
+}
+
+fn rgba_stride(width: usize) -> u32 {
+    (width * 4) as u32
+}
+
+/// Number of bits actually used by the samples of a picture.
+fn used_bits(picture: &Picture) -> Result<usize, ImageErrors> {
+    picture
+        .bits_per_component()
+        .map(|bits| bits.0)
+        .ok_or_else(|| decode_error("unknown bit depth"))
+}
+
+/// Reads a little-endian sample and scales it down to 8 bits.
+fn sample_u8(bytes: &[u8], used: usize) -> u8 {
+    let value = u16::from_le_bytes([bytes[0], bytes[1]]) as u32;
+    let max = ((1u32 << used) - 1).max(1);
+    ((value * 255 + max / 2) / max) as u8
 }
 
 #[cfg(test)]

--- a/src/codecs/avif/decoder/tests.rs
+++ b/src/codecs/avif/decoder/tests.rs
@@ -13,3 +13,128 @@ fn decode() {
     assert_eq!(img.dimensions(), (48, 80));
     assert_eq!(img.colorspace(), ColorSpace::RGBA);
 }
+
+/// Packs samples into little-endian 16-bit rows; `stride` is in bytes.
+fn u16_plane(samples: &[u16], stride: usize, rows: usize) -> Vec<u8> {
+    let mut plane = vec![0u8; stride * rows];
+    for (row, sample_row) in samples.chunks(stride / 2).take(rows).enumerate() {
+        for (column, &sample) in sample_row.iter().enumerate() {
+            let bytes = sample.to_le_bytes();
+            plane[row * stride + column * 2] = bytes[0];
+            plane[row * stride + column * 2 + 1] = bytes[1];
+        }
+    }
+    plane
+}
+
+#[test]
+fn high_depth_bt2020_limited() {
+    // values taken from a real 10-bit sample; yuvutils-rs 0.8.3 mis-scales the
+    // red channel for exactly this input (limited range, BT.2020, positive Cr)
+    let y = u16_plane(&[834; 32], 16, 4);
+    let u = u16_plane(&[491; 8], 8, 2);
+    let v = u16_plane(&[586; 8], 8, 2);
+    let planes = Planes {
+        y: &y,
+        y_stride: 16,
+        u: &u,
+        u_stride: 8,
+        v: &v,
+        v_stride: 8,
+        width: 8,
+        height: 4,
+        layout: PixelLayout::I420,
+    };
+
+    let mut rgba = vec![0u8; 8 * 4 * 4];
+    high_depth_ycbcr_to_rgba(
+        &planes,
+        10,
+        false,
+        &ColorTransform::Ycbcr {
+            kr: 0.2627,
+            kb: 0.0593,
+            standard: YuvStandardMatrix::Bt2020,
+        },
+        &mut rgba,
+    );
+
+    // Y8=224, Cb8=-6.0, Cr8=+21.0 -> R clamps to 255, G=213, B=213
+    for px in rgba.as_chunks::<4>().0 {
+        assert_eq!(px[0], 255, "red");
+        assert_eq!(px[1], 213, "green");
+        assert_eq!(px[2], 213, "blue");
+        assert_eq!(px[3], 255, "alpha");
+    }
+}
+
+#[test]
+fn high_depth_ycgco_round_trip() {
+    // forward YCgCo (H.273 matrix 8) of R=200 G=50 B=100 in the 8-bit domain:
+    // Y=100, Cg=-50, Co=+50, scaled into full-range 10-bit samples
+    let y = u16_plane(&[400; 32], 16, 4);
+    let u = u16_plane(&[412; 8], 8, 2);
+    let v = u16_plane(&[612; 8], 8, 2);
+    let planes = Planes {
+        y: &y,
+        y_stride: 16,
+        u: &u,
+        u_stride: 8,
+        v: &v,
+        v_stride: 8,
+        width: 8,
+        height: 4,
+        layout: PixelLayout::I420,
+    };
+
+    let mut rgba = vec![0u8; 8 * 4 * 4];
+    high_depth_ycbcr_to_rgba(&planes, 10, true, &ColorTransform::Ycgco, &mut rgba);
+
+    for px in rgba.as_chunks::<4>().0 {
+        assert!((px[0] as i32 - 200).abs() <= 2, "red: {}", px[0]);
+        assert!((px[1] as i32 - 50).abs() <= 2, "green: {}", px[1]);
+        assert!((px[2] as i32 - 100).abs() <= 2, "blue: {}", px[2]);
+        assert_eq!(px[3], 255);
+    }
+}
+
+#[test]
+fn high_depth_luma_expansion_bounds() {
+    // limited-range 10-bit luma spans [64, 940]
+    assert_eq!(expand_luma(64, 10, false), 0.0);
+    assert!((expand_luma(940, 10, false) - 255.0).abs() < 0.01);
+    // full-range 10-bit spans [0, 1023]
+    assert_eq!(expand_luma(0, 10, true), 0.0);
+    assert!((expand_luma(1023, 10, true) - 255.0).abs() < 0.01);
+    // limited-range chroma is neutral at 512
+    assert_eq!(expand_chroma(512, 10, false), 0.0);
+    // full-range chroma is neutral at 512
+    assert_eq!(expand_chroma(512, 10, true), 0.0);
+}
+
+fn ftyp(major: &[u8; 4], compatible: &[*const [u8; 4]]) -> Vec<u8> {
+    let mut box_data = vec![0u8; 8 + 4 + 4 + 4 * compatible.len()];
+    let size = box_data.len() as u32;
+    box_data[..4].copy_from_slice(&size.to_be_bytes());
+    box_data[4..8].copy_from_slice(b"ftyp");
+    box_data[8..12].copy_from_slice(major);
+    for (index, brand) in compatible.iter().enumerate() {
+        let start = 16 + index * 4;
+        box_data[start..start + 4].copy_from_slice(unsafe { &**brand });
+    }
+    box_data
+}
+
+#[test]
+fn avif_sniffing() {
+    assert!(is_avif(&ftyp(b"avif", &[b"mif1" as *const [u8; 4]])));
+    // `avis` (image sequences) as major brand
+    assert!(is_avif(&ftyp(b"avis", &[b"mif1" as *const [u8; 4]])));
+    // brand listed only in the compatible brands
+    assert!(is_avif(&ftyp(b"mif1", &[b"avif" as *const [u8; 4]])));
+
+    assert!(!is_avif(&ftyp(b"isom", &[b"mif1" as *const [u8; 4]])));
+    assert!(!is_avif(&[]));
+    assert!(!is_avif(&[0; 12]));
+    assert!(!is_avif(b"RIFF0000WEBPVP8 "));
+}

--- a/src/codecs/avif/decoder/tests.rs
+++ b/src/codecs/avif/decoder/tests.rs
@@ -14,6 +14,11 @@ fn decode() {
     assert_eq!(img.colorspace(), ColorSpace::RGBA);
 }
 
+#[test]
+fn bt2020_constant_luminance_is_rejected() {
+    assert!(color_transform(MatrixCoefficients::BT2020ConstantLuminance).is_err());
+}
+
 /// Packs samples into little-endian 16-bit rows; `stride` is in bytes.
 fn u16_plane(samples: &[u16], stride: usize, rows: usize) -> Vec<u8> {
     let mut plane = vec![0u8; stride * rows];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,9 +19,14 @@ Rimage is a powerful Rust image optimization library extending `zune_image` crat
 |--------------|---------|---------|
 | jpeg         | -       | mozjpeg |
 | png          | -       | oxipng  |
-| avif         | libavif | ravif   |
+| avif         | dav1d   | ravif   |
 | webp         | webp    | webp    |
 | svg          | resvg   | -       |
+
+> AVIF decoding requires a system-installed `dav1d` (>= 1.3.0) found through
+> pkg-config and only handles still images: grid collages and animated
+> sequences are rejected, 10/12-bit sources are converted to 8-bit output, and
+> ICC profiles are not applied.
 
 ## Usage
 


### PR DESCRIPTION
close #395 

### Breaking Changes

- replace the `libavif` AVIF decoder with a `dav1d`-based one (`dav1d` + `avif-parse` + `yuvutils-rs`); decoding now links a system-installed `dav1d` (>= 1.3.0) through pkg-config instead of building libaom from source with cmake.

### Features

- declare `rust-version = "1.90"` to track the effective minimum supported Rust version