### PR TITLE
Error enhance, Image overflow and Pre size limits

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,19 +7,8 @@ linker = 'aarch64-linux-gnu-gcc'
 [target.aarch64-unknown-linux-musl]
 linker = 'aarch64-linux-musl-gcc'
 
-[target.x86_64-pc-windows-gnu]
-linker = 'gcc'
-rustflags = [
-    "-C", "target-feature=+crt-static",
-    "-C", "link-arg=-static-libgcc",
-    "-C", "link-arg=-static-libstdc++",
-]
-
-[env]
-CMAKE_GENERATOR_x86_64-pc-windows-gnu = "MinGW Makefiles"
-CC_x86_64-pc-windows-gnu = "gcc"
-CXX_x86_64-pc-windows-gnu = "g++"
-AR_x86_64-pc-windows-gnu = "ar"
+[target.i686-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]
 
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]

--- a/.github/workflows/rimage.yml
+++ b/.github/workflows/rimage.yml
@@ -101,20 +101,20 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          packages=(ninja-build meson nasm)
+          # meson+ninja build dav1d from source for the musl and aarch64 GNU
+          # targets, nasm assembles mozjpeg's x86 SIMD code
+          packages=(ninja-build meson nasm pkg-config)
           if [[ "${{ matrix.target }}" == *-musl ]]; then
             packages+=(musl-tools "musl-dev:${{ matrix.target-apt-arch }}")
           fi
           if [[ "${{ matrix.target }}" == aarch64-unknown-linux-* ]]; then
-            packages+=(qemu-user gcc-aarch64-linux-gnu g++-aarch64-linux-gnu "libc6:${{ matrix.target-apt-arch }}")
+            packages+=(qemu-user gcc-aarch64-linux-gnu "libc6:${{ matrix.target-apt-arch }}")
+          fi
+          if [[ "${{ matrix.target }}" == x86_64-unknown-linux-gnu ]]; then
+            packages+=(libdav1d-dev)
           fi
           sudo apt-get -yq update
           sudo apt-get -yq install --fix-missing "${packages[@]}"
-
-      - name: configure x86_64 musl C++ compiler
-        if: matrix.target == 'x86_64-unknown-linux-musl'
-        shell: bash
-        run: sudo ln -sf /bin/g++ /bin/musl-g++
 
       - name: install macOS dependencies
         if: startsWith(matrix.os, 'macos')
@@ -126,12 +126,19 @@ jobs:
           # Nothing in this build uses these taps, so untap them first.
           brew untap aws/tap 2>/dev/null || true
           brew untap azure/bicep 2>/dev/null || true
-          brew install ninja meson nasm yasm || brew upgrade ninja meson nasm yasm
+          brew install llvm ninja nasm pkg-config dav1d || brew upgrade llvm ninja nasm pkg-config dav1d
 
       - name: install Windows dependencies
         if: startsWith(matrix.os, 'windows')
         shell: pwsh
-        run: choco install -y ninja meson nasm
+        run: |
+          choco install -y ninja nasm
+          # static dav1d matches the +crt-static rustflag of the MSVC target;
+          # dav1d-sys locates it through pkgconf from the same vcpkg install
+          $triplet = if ('${{ matrix.target }}' -eq 'i686-pc-windows-msvc') { 'x86-windows-static' } else { 'x64-windows-static' }
+          & "$env:VCPKG_ROOT\vcpkg.exe" install "dav1d:$triplet" "pkgconf:x64-windows"
+          "PKG_CONFIG=$env:VCPKG_ROOT\installed\x64-windows\tools\pkgconf\pkgconf.exe" >> $env:GITHUB_ENV
+          "PKG_CONFIG_PATH=$env:VCPKG_ROOT\installed\$triplet\lib\pkgconfig" >> $env:GITHUB_ENV
 
       - name: install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -152,6 +159,30 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: cross@0.2.5
+
+      # musl and cross-compiled GNU targets have no dav1d package to link
+      # against; build a static dav1d with the target toolchain and point
+      # pkg-config at it. x86_64-gnu uses the distro package instead.
+      - name: build static dav1d for the target
+        if: startsWith(matrix.os, 'ubuntu') && !matrix.cross && matrix.target != 'x86_64-unknown-linux-gnu'
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "${{ matrix.target }}" in
+            x86_64-unknown-linux-musl)
+              prefix=/opt/dav1d-target
+              export CC=musl-gcc
+              ;;
+            aarch64-unknown-linux-gnu)
+              prefix=/opt/dav1d-target
+              export CROSS_FILE=ci/meson/aarch64-gnu.ini
+              ;;
+          esac
+          ci/build-dav1d.sh "$prefix" ${CROSS_FILE:-}
+          {
+            echo "PKG_CONFIG_PATH=$prefix/lib/pkgconfig"
+            echo "PKG_CONFIG_ALLOW_CROSS=1"
+          } >> "$GITHUB_ENV"
 
       - name: build release binary
         shell: bash
@@ -208,13 +239,14 @@ jobs:
       - name: install native dependencies
         run: |
           sudo apt-get -yq update
-          sudo apt-get -yq install --fix-missing ninja-build meson nasm
+          sudo apt-get -yq install --fix-missing ninja-build nasm libdav1d-dev
 
       - name: Clippy check
         run: cargo clippy --all-targets --all-features -- -D warnings
 
   # Keep the complete WASM configuration in one disabled job. Remove the
-  # job-level `if` when the Emscripten build is ready to be enabled again.
+  # job-level `if` when the Emscripten build is ready to be enabled again;
+  # enabling it also requires a dav1d build for the Emscripten target.
   wasm:
     name: wasm32-unknown-emscripten (disabled)
     if: ${{ false }}
@@ -242,5 +274,4 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          export EMSCRIPTEN_CMAKE_FILE="$(brew --cellar emscripten)/$(brew list --versions emscripten | tr ' ' '\n' | tail -1)/libexec/cmake/Modules/Platform/Emscripten.cmake"
           cargo check --all-features

--- a/.github/workflows/rimage.yml
+++ b/.github/workflows/rimage.yml
@@ -134,11 +134,13 @@ jobs:
         run: |
           choco install -y ninja nasm
           # static dav1d matches the +crt-static rustflag of the MSVC target;
-          # dav1d-sys locates it through pkgconf from the same vcpkg install
+          # dav1d-sys locates it through pkgconf from the same vcpkg install.
+          # the runner images expose vcpkg only via VCPKG_INSTALLATION_ROOT,
+          # there is no VCPKG_ROOT
           $triplet = if ('${{ matrix.target }}' -eq 'i686-pc-windows-msvc') { 'x86-windows-static' } else { 'x64-windows-static' }
-          & "$env:VCPKG_ROOT\vcpkg.exe" install "dav1d:$triplet" "pkgconf:x64-windows"
-          "PKG_CONFIG=$env:VCPKG_ROOT\installed\x64-windows\tools\pkgconf\pkgconf.exe" >> $env:GITHUB_ENV
-          "PKG_CONFIG_PATH=$env:VCPKG_ROOT\installed\$triplet\lib\pkgconfig" >> $env:GITHUB_ENV
+          & "$env:VCPKG_INSTALLATION_ROOT\vcpkg.exe" install "dav1d:$triplet" "pkgconf:x64-windows"
+          "PKG_CONFIG=$env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\tools\pkgconf\pkgconf.exe" >> $env:GITHUB_ENV
+          "PKG_CONFIG_PATH=$env:VCPKG_INSTALLATION_ROOT\installed\$triplet\lib\pkgconfig" >> $env:GITHUB_ENV
 
       - name: install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/rimage.yml
+++ b/.github/workflows/rimage.yml
@@ -57,12 +57,15 @@ jobs:
           - target: x86_64-pc-windows-msvc
             os: windows-2025
             cross: false
+            rustflags: -C target-feature=+crt-static
           - target: i686-pc-windows-msvc
             os: windows-2025
             cross: false
+            rustflags: -C target-feature=+crt-static
           - target: x86_64-apple-darwin
             os: macos-15-intel
             cross: false
+            rustflags: -A linker_messages
           - target: aarch64-apple-darwin
             os: macos-15
             cross: false
@@ -70,6 +73,7 @@ jobs:
     env:
       CARGO_BUILD_TARGET: ${{ matrix.target }}
       CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER: qemu-aarch64 -L /usr/aarch64-linux-gnu
+      RUSTFLAGS: -D warnings ${{ matrix.rustflags }}
 
     steps:
       - name: checkout
@@ -188,6 +192,8 @@ jobs:
 
       - name: build release binary
         shell: bash
+        env:
+          RUSTFLAGS: -D warnings ${{ matrix.rustflags }}
         run: |
           set -euo pipefail
           if [[ "${{ matrix.cross }}" == "true" ]]; then
@@ -198,6 +204,8 @@ jobs:
 
       - name: run tests
         shell: bash
+        env:
+          RUSTFLAGS: -D warnings ${{ matrix.rustflags }}
         run: |
           set -euo pipefail
           if [[ "${{ matrix.cross }}" == "true" ]]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Rimage library will be documented in this file.
 ### Breaking Changes
 
 - add SVG input support rendered through `resvg` (static SVG and gzipped SVGZ), usable with every output format
+- replace the `libavif` AVIF decoder with a `dav1d`-based one (`dav1d` + `avif-parse` + `yuvutils-rs`); decoding now links a system-installed `dav1d` (>= 1.3.0) through pkg-config instead of building libaom from source with cmake.
 
 ### Features
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,7 @@ dependencies = [
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "av-data"
@@ -287,7 +287,7 @@ checksum = "5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9"
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byte-slice-cast"
@@ -299,7 +299,21 @@ checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 name = "bytemuck"
 version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
+]
 
 [[package]]
 name = "byteorder"
@@ -773,7 +787,7 @@ dependencies = [
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -2090,7 +2104,12 @@ dependencies = [
 name = "syn"
 version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "system-deps"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,20 @@ dependencies = [
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "av-data"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fca67ba5d317924c02180c576157afd54babe48a76ebc66ce6d34bb8ba08308e"
+dependencies = [
+ "byte-slice-cast",
+ "bytes",
+ "num-derive",
+ "num-rational",
+ "num-traits",
+]
 
 [[package]]
 name = "av-scenechange"
@@ -185,6 +198,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "avif-parse"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "048e72663e14be27bfd8a9e01e8a0bf27610511ffd5f74c7955f4e4847ce2530"
+dependencies = [
+ "arrayvec",
+ "bitreader",
+ "byteorder",
+ "fallible_collections",
+ "leb128",
+ "log",
+]
+
+[[package]]
 name = "avif-serialize"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,6 +237,15 @@ name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "bitreader"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "886559b1e163d56c765bc3a985febb4eee8009f625244511d8ee3c432e08c066"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "bitstream-io"
@@ -251,33 +287,37 @@ checksum = "5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9"
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byte-slice-cast"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "bytemuck"
 version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
-dependencies = [
- "bytemuck_derive",
-]
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
-name = "bytemuck_derive"
-version = "1.12.0"
+name = "byteorder"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 3.0.5",
-]
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "byteorder-lite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
@@ -289,6 +329,16 @@ dependencies = [
  "jobserver",
  "libc",
  "shlex",
+]
+
+[[package]]
+name = "cfg-expr"
+version = "0.20.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe4ece8474b5f766c63426647e7b4b316b67431ade1036a8313cee24a03ae917"
+dependencies = [
+ "smallvec",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -323,15 +373,6 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
-name = "cmake"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "color_quant"
@@ -383,9 +424,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+checksum = "622f3fc73690be383c7214310406f28a90e6edeadc3cea882f9d71e495b9711a"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -393,18 +434,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.20"
+version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+checksum = "dc74980687109a3b14c72fd458107bf0baa1da1a1a805e178d15501ba9b86d9d"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.22"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+checksum = "a31eee39dddec8330830986fcd7625edb5a24ec90ea038215273bbc3adb08ac6"
 
 [[package]]
 name = "crunchy"
@@ -417,6 +458,28 @@ name = "data-url"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
+
+[[package]]
+name = "dav1d"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee89cb860616069c67520dcd66cacdb900b57c799f634a0eb6d91f6e2a82b61"
+dependencies = [
+ "av-data",
+ "bitflags",
+ "dav1d-sys",
+ "static_assertions",
+]
+
+[[package]]
+name = "dav1d-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c91aea6668645415331133ed6f8ddf0e7f40160cd97a12d59e68716a58704b"
+dependencies = [
+ "libc",
+ "system-deps",
+]
 
 [[package]]
 name = "document-features"
@@ -509,6 +572,12 @@ dependencies = [
  "smallvec",
  "zune-inflate",
 ]
+
+[[package]]
+name = "fallible_collections"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab93c7205280c4785c44517fe84d99751b81f6deb8450cb196da6be88e332bb"
 
 [[package]]
 name = "fast_image_resize"
@@ -704,7 +773,13 @@ dependencies = [
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1105,39 +1180,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83bff1d572d6b9aeef67ddfc8448e4a3737909cb28e81f97c791b9018703e52"
+
+[[package]]
 name = "lebe"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
-
-[[package]]
-name = "libaom-sys"
-version = "0.17.2+libaom.3.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c4fce8aaf0c2d8534529b0698ed98ec1da8d35319588d20b0d79ce6446e4194"
-dependencies = [
- "cmake",
-]
-
-[[package]]
-name = "libavif"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b710faf0de92da0e32a9a9c89bbf849e37277fd447b4f17b0f0f798796ae1f2"
-dependencies = [
- "libavif-sys",
-]
-
-[[package]]
-name = "libavif-sys"
-version = "0.17.0+libavif.1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490ca74b61e773140bebb086c81facb23273a99364a9ab0c92ab1532b90ade35"
-dependencies = [
- "cmake",
- "libaom-sys",
- "libc",
-]
 
 [[package]]
 name = "libc"
@@ -1797,8 +1849,10 @@ name = "rimage"
 version = "0.13.0"
 dependencies = [
  "anyhow",
+ "avif-parse",
  "clap",
  "console",
+ "dav1d",
  "fast_image_resize",
  "glob",
  "imagequant",
@@ -1806,7 +1860,6 @@ dependencies = [
  "indicatif-log-bridge",
  "indoc",
  "lcms2",
- "libavif",
  "little_exif",
  "log",
  "mozjpeg",
@@ -1823,6 +1876,7 @@ dependencies = [
  "tiff",
  "webp",
  "winresource",
+ "yuvutils-rs",
  "zune-core",
  "zune-image",
  "zune-imageprocs",
@@ -1991,6 +2045,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strict-num"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2030,12 +2090,26 @@ dependencies = [
 name = "syn"
 version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "system-deps"
+version = "7.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396a35feb67335377e0251fcbc1092fc85c484bd4e3a7a54319399da127796e7"
 dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
+ "cfg-expr",
+ "heck",
+ "pkg-config",
+ "toml",
+ "version-compare",
 ]
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "termcolor"
@@ -2266,6 +2340,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "version-compare"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2407,6 +2487,16 @@ name = "y4m"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
+
+[[package]]
+name = "yuvutils-rs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b699b6503cd14c70b258eaffedd7ada5a781ea23206eeb9066736b99ba37af1"
+dependencies = [
+ "num-traits",
+ "rayon",
+]
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1964,7 +1964,6 @@ dependencies = [
  "serde_json",
  "skrifa 0.46.2",
  "sysinfo",
- "thiserror",
  "tiff",
  "webp",
  "winresource",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,16 +533,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
-name = "env_logger"
-version = "0.10.2"
+name = "env_filter"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
 dependencies = [
- "humantime",
- "is-terminal",
  "log",
  "regex",
- "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "log",
 ]
 
 [[package]]
@@ -806,18 +815,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17592d60ebacc7d5e169f4663c5f84f9161cc90328abcfe8456f41e4dfcb284"
-
-[[package]]
-name = "humantime"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
-
-[[package]]
 name = "image"
 version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -920,17 +917,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys",
 ]
 
 [[package]]
@@ -1638,16 +1624,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pretty_env_logger"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "865724d4dbe39d9f3dd3b52b88d859d66bcb2d6a0acfd5ea68a65fb66d4bdc1c"
-dependencies = [
- "env_logger",
- "log",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1943,6 +1919,7 @@ dependencies = [
  "clap",
  "console",
  "dav1d",
+ "env_logger",
  "fast_image_resize",
  "glob",
  "imagequant",
@@ -1954,7 +1931,6 @@ dependencies = [
  "log",
  "mozjpeg",
  "oxipng",
- "pretty_env_logger",
  "ravif",
  "rayon",
  "regex",
@@ -2221,15 +2197,6 @@ name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
-
-[[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
 
 [[package]]
 name = "thiserror"
@@ -2556,15 +2523,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
-dependencies = [
- "windows-sys",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1860,7 +1860,7 @@ dependencies = [
 
 [[package]]
 name = "rimage"
-version = "0.13.0"
+version = "0.13.0-10"
 dependencies = [
  "anyhow",
  "avif-parse",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,9 +642,9 @@ checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 
 [[package]]
 name = "font-types"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64eb721ca85a34323425f4041adc5d82704d3782d5f8f03793bc012419dce23"
+checksum = "b8eb065f3251655b3c90e22e5e363f310fc5332fb3402e37bbc94752283248f6"
 dependencies = [
  "bytemuck",
 ]
@@ -1860,7 +1860,7 @@ dependencies = [
 
 [[package]]
 name = "rimage"
-version = "0.13.0-10"
+version = "0.13.0-11"
 dependencies = [
  "anyhow",
  "avif-parse",
@@ -2519,18 +2519,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.56"
+version = "0.8.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+checksum = "d35102a9f36d089ccae9e4c6802bc118be4487b80aaffc0ab4e0cf5ce92d2873"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.56"
+version = "0.8.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+checksum = "146c01f5ab44258da43cf276c74a2763db2ff3969c9c652c3f2de07041d0b2bc"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -496,6 +496,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "objc2",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1408,6 +1418,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1465,6 +1484,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-open-directory"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb82bed227edf5201dfedf072bba4015a33d3d4a98519837295a90f0a23f676d"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -1887,6 +1963,8 @@ dependencies = [
  "serde",
  "serde_json",
  "skrifa 0.46.2",
+ "sysinfo",
+ "thiserror",
  "tiff",
  "webp",
  "winresource",
@@ -2109,6 +2187,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.39.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2071df9448915b71c4fe6d25deaf1c22f12bd234f01540b77312bb8e41361e6"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "objc2-open-directory",
+ "windows",
 ]
 
 [[package]]
@@ -2450,6 +2543,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2459,16 +2568,126 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
  "windows-link",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name          = "rimage"
 version       = "0.13.0"
 edition       = "2024"
-rust-version  = "1.88.0"
+rust-version  = "1.90.0"
 description   = "Optimize images natively with best-in-class codecs"
 license       = "MIT OR Apache-2.0"
 readme        = "README.md"
@@ -72,6 +72,7 @@ threads = [
     "oxipng?/parallel",
     "fast_image_resize?/rayon",
     "ravif?/threading",
+    "yuvutils-rs?/rayon",
     "zune-image/threads",
 ]
 # Enables metadata support
@@ -89,7 +90,13 @@ oxipng = ["dep:oxipng"]
 # Enables webp codec
 webp = ["dep:webp"]
 # Enables avif codec
-avif = ["dep:ravif", "dep:libavif", "dep:rgb"]
+avif = [
+    "dep:ravif",
+    "dep:rgb",
+    "dep:dav1d",
+    "dep:avif-parse",
+    "dep:yuvutils-rs",
+]
 # Enables tiff codec
 tiff    = ["dep:tiff"]
 # Enables SVG input support (rendered via resvg)
@@ -114,9 +121,9 @@ oxipng = { version = "10.1.1", default-features = false, features = [
 ], optional = true }
 webp = { version = "0.3", default-features = false, optional = true }
 ravif = { version = "0.13.0", optional = true }
-libavif = { version = "0.14.0", default-features = false, features = [
-    "codec-aom",
-], optional = true }
+dav1d = { version = "0.11", optional = true }
+avif-parse = { version = "2.1", optional = true }
+yuvutils-rs = { version = "0.8", optional = true }
 lcms2 = { version = "6.2", optional = true }
 tiff = { version = "0.11.3", default-features = false, features = [
     "lzw",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ svg = ["dep:resvg", "dep:skrifa"]
 icc     = ["dep:lcms2"]
 console = ["dep:console"]
 # Enables runtime system-resource probing, used to derive image size limits
-limits = ["dep:sysinfo", "dep:thiserror"]
+limits = ["dep:sysinfo"]
 
 [dependencies]
 log = "0.4"
@@ -140,8 +140,7 @@ skrifa = { version = "0.46.2", default-features = false, features = [
 ], optional = true }
 
 # System resource probing for dynamic image size limits
-sysinfo   = { version = "0.39.6", optional = true }
-thiserror = { version = "2", optional = true }
+sysinfo = { version = "0.39.6", optional = true }
 
 # cli
 anyhow = { version = "1.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "rimage"
-version       = "0.13.0-10"
+version       = "0.13.0-11"
 edition       = "2024"
 rust-version  = "1.90.0"
 description   = "Optimize images natively with best-in-class codecs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name          = "rimage"
 version       = "0.13.0-11"
 edition       = "2024"
-rust-version  = "1.90.0"
+rust-version  = "1.95.0"
 description   = "Optimize images natively with best-in-class codecs"
 license       = "MIT OR Apache-2.0"
 readme        = "README.md"
@@ -103,6 +103,8 @@ tiff    = ["dep:tiff"]
 svg = ["dep:resvg", "dep:skrifa"]
 icc     = ["dep:lcms2"]
 console = ["dep:console"]
+# Enables runtime system-resource probing, used to derive image size limits
+limits = ["dep:sysinfo", "dep:thiserror"]
 
 [dependencies]
 log = "0.4"
@@ -136,6 +138,10 @@ resvg = { version = "0.48.1", default-features = false, features = [
 skrifa = { version = "0.46.2", default-features = false, features = [
     "std",
 ], optional = true }
+
+# System resource probing for dynamic image size limits
+sysinfo   = { version = "0.39.6", optional = true }
+thiserror = { version = "2", optional = true }
 
 # cli
 anyhow = { version = "1.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "rimage"
-version       = "0.13.0"
+version       = "0.13.0-10"
 edition       = "2024"
 rust-version  = "1.90.0"
 description   = "Optimize images natively with best-in-class codecs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ build-binary = [
     "dep:clap",
     "dep:indoc",
     "dep:rayon",
-    "dep:pretty_env_logger",
+    "dep:env_logger",
     "dep:zune-imageprocs",
     "dep:glob",
     "zune-image/default",
@@ -146,7 +146,7 @@ sysinfo = { version = "0.39.6", optional = true }
 anyhow = { version = "1.0", optional = true }
 clap = { version = "4.6", features = ["cargo", "string"], optional = true }
 indoc = { version = "2.0", optional = true }
-pretty_env_logger = { version = "0.5.0", optional = true }
+env_logger = { version = "0.11", optional = true, default-features = false, features = ["auto-color"] }
 rayon = { version = "1.12.0", optional = true }
 zune-imageprocs = { version = "0.5.1", features = [
     "exif",

--- a/Cross.toml
+++ b/Cross.toml
@@ -11,17 +11,24 @@
 # AVIF decoding links dav1d through pkg-config and the stock image carries no
 # dav1d, so pre-build compiles a static dav1d against the musl toolchain.
 # nasm is not needed here: the aarch64 asm is assembled by the C compiler.
+#
+# cross 0.2.5 joins the pre-build entries into `RUN eval "..."`, so no entry
+# may contain double quotes (they would terminate the eval string); printf %b
+# with \047 emits the apostrophes the cross-file values need. `set -e` makes
+# any pre-build failure abort the docker build instead of silently shipping an
+# image without dav1d. cross 0.2.5 has no [env] support and exports
+# PKG_CONFIG_ALLOW_CROSS=1 itself; dav1d installs into /usr/local, which the
+# default pkg-config search path already covers.
 [target.aarch64-unknown-linux-musl]
 image = "ghcr.io/cross-rs/aarch64-unknown-linux-musl@sha256:10769140e3ce9c01cb2b1d4751ce3afb31fb2edea5afcd409ccde589729d7910"
 pre-build = [
+    "set -e",
     "apt-get update",
     "apt-get install --assume-yes ninja-build meson pkg-config git ca-certificates",
     "git clone --depth 1 --branch 1.5.1 https://code.videolan.org/videolan/dav1d.git /tmp/dav1d",
-    "printf '%s\\n' '[binaries]' \"c = 'aarch64-linux-musl-gcc'\" \"ar = 'aarch64-linux-musl-ar'\" \"pkg-config = 'pkg-config'\" '[host_machine]' \"system = 'linux'\" \"cpu_family = 'aarch64'\" \"cpu = 'aarch64'\" \"endian = 'little'\" > /tmp/dav1d-cross.ini",
-    "meson setup /tmp/dav1d/build -Ddefault_library=static -Dtools=false -Dbuild_tests=false --prefix=/usr/local --cross-file /tmp/dav1d-cross.ini /tmp/dav1d",
+    "printf '%b\\n' '[binaries]' 'c = \\047aarch64-linux-musl-gcc\\047' 'ar = \\047aarch64-linux-musl-ar\\047' 'pkg-config = \\047pkg-config\\047' '[host_machine]' 'system = \\047linux\\047' 'cpu_family = \\047aarch64\\047' 'cpu = \\047aarch64\\047' 'endian = \\047little\\047' > /tmp/dav1d-cross.ini",
+    "cd /tmp/dav1d",
+    "meson setup /tmp/dav1d/build -Ddefault_library=static -Denable_tools=false -Denable_tests=false --prefix=/usr/local --cross-file /tmp/dav1d-cross.ini",
     "ninja -C /tmp/dav1d/build install",
     "rm -rf /tmp/dav1d /tmp/dav1d-cross.ini",
 ]
-[env]
-PKG_CONFIG_ALLOW_CROSS = "1"
-PKG_CONFIG_PATH = "/usr/local/lib/pkgconfig"

--- a/Cross.toml
+++ b/Cross.toml
@@ -7,9 +7,21 @@
 # main-branch image (Ubuntu 24.04 base) by digest so the toolchain cannot
 # change silently. Refresh with:
 #   docker buildx imagetools inspect ghcr.io/cross-rs/aarch64-unknown-linux-musl:main
+#
+# AVIF decoding links dav1d through pkg-config and the stock image carries no
+# dav1d, so pre-build compiles a static dav1d against the musl toolchain.
+# nasm is not needed here: the aarch64 asm is assembled by the C compiler.
 [target.aarch64-unknown-linux-musl]
 image = "ghcr.io/cross-rs/aarch64-unknown-linux-musl@sha256:10769140e3ce9c01cb2b1d4751ce3afb31fb2edea5afcd409ccde589729d7910"
 pre-build = [
     "apt-get update",
-    "apt-get install --assume-yes ninja-build meson nasm",
+    "apt-get install --assume-yes ninja-build meson pkg-config git ca-certificates",
+    "git clone --depth 1 --branch 1.5.1 https://code.videolan.org/videolan/dav1d.git /tmp/dav1d",
+    "printf '%s\\n' '[binaries]' \"c = 'aarch64-linux-musl-gcc'\" \"ar = 'aarch64-linux-musl-ar'\" \"pkg-config = 'pkg-config'\" '[host_machine]' \"system = 'linux'\" \"cpu_family = 'aarch64'\" \"cpu = 'aarch64'\" \"endian = 'little'\" > /tmp/dav1d-cross.ini",
+    "meson setup /tmp/dav1d/build -Ddefault_library=static -Dtools=false -Dbuild_tests=false --prefix=/usr/local --cross-file /tmp/dav1d-cross.ini /tmp/dav1d",
+    "ninja -C /tmp/dav1d/build install",
+    "rm -rf /tmp/dav1d /tmp/dav1d-cross.ini",
 ]
+[env]
+PKG_CONFIG_ALLOW_CROSS = "1"
+PKG_CONFIG_PATH = "/usr/local/lib/pkgconfig"

--- a/Cross.toml
+++ b/Cross.toml
@@ -18,7 +18,9 @@
 # any pre-build failure abort the docker build instead of silently shipping an
 # image without dav1d. cross 0.2.5 has no [env] support and exports
 # PKG_CONFIG_ALLOW_CROSS=1 itself; dav1d installs into /usr/local, which the
-# default pkg-config search path already covers.
+# default pkg-config search path already covers. The clone is verified
+# against the commit the 1.5.1 tag pointed at when pinned, because a tag
+# can be re-pointed upstream.
 [target.aarch64-unknown-linux-musl]
 image = "ghcr.io/cross-rs/aarch64-unknown-linux-musl@sha256:10769140e3ce9c01cb2b1d4751ce3afb31fb2edea5afcd409ccde589729d7910"
 pre-build = [
@@ -26,6 +28,7 @@ pre-build = [
     "apt-get update",
     "apt-get install --assume-yes ninja-build meson pkg-config git ca-certificates",
     "git clone --depth 1 --branch 1.5.1 https://code.videolan.org/videolan/dav1d.git /tmp/dav1d",
+    "git -C /tmp/dav1d rev-parse HEAD | grep -qx 3060ebf8dd26952579373084984daf70a54f5368",
     "printf '%b\\n' '[binaries]' 'c = \\047aarch64-linux-musl-gcc\\047' 'ar = \\047aarch64-linux-musl-ar\\047' 'pkg-config = \\047pkg-config\\047' '[host_machine]' 'system = \\047linux\\047' 'cpu_family = \\047aarch64\\047' 'cpu = \\047aarch64\\047' 'endian = \\047little\\047' > /tmp/dav1d-cross.ini",
     "cd /tmp/dav1d",
     "meson setup /tmp/dav1d/build -Ddefault_library=static -Denable_tools=false -Denable_tests=false --prefix=/usr/local --cross-file /tmp/dav1d-cross.ini",

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ For library usage check [Docs.rs](https://docs.rs/rimage/latest/rimage/)
 
 | Image Codecs | Decoder       | Encoder                 | NOTE                                                 |
 | ------------ | ------------- | ----------------------- | ---------------------------------------------------- |
-| avif         | libavif       | ravif                   | Common features only, Static only                    |
+| avif         | dav1d         | ravif                   | Common features only, Static only                    |
 | bmp          | zune-bmp      | ❌                      | Input only                                           |
 | farbfeld     | zune-farbfeld | zune-farbfeld           |                                                      |
 | hdr          | zune-hdr      | zune-hdr                |                                                      |
@@ -365,28 +365,35 @@ rimage png "D:\example.jpg" -s "suffix"  -d "D:\desktop\" # backslash at the end
    - During installation, select "Desktop development with C++" workload.
    - OR, just use `choco install visualstudio2026-workload-vctools` to install it.
 
-4. Install Perl:
-   - Download and install from [Strawberry Perl](https://strawberryperl.com/).
-   - OR, just use `choco install strawberryperl` to install it.
-
-5. Install cmake (OPTIONAL if you use the MSVC bundled version):
+4. Install cmake (OPTIONAL if you use the MSVC bundled version):
     - Download and install from [CMake](https://cmake.org/download/).
     - OR, just use `choco install cmake` to install it.
     - OR, you can use the bundled cmake in MSVC, but please note that only **4.2.3** + could be used.
 
-6. Install nasm and yasm:
-   - Download and install from [nasm](https://www.nasm.us/) and [yasm](https://github.com/yasm/yasm/releases).
-   - OR, just use `choco install nasm` and `choco install yasm` to install them.
-   - **WARNING**: `libaom` requires older version of the nasm binary or yasm instead for a successful build, see [libavif-rs#122](https://github.com/njaard/libavif-rs/issues/122) for details.
+5. Install nasm (for the mozjpeg encoder's SIMD code):
+   - Download and install from [nasm](https://www.nasm.us/).
+   - OR, just use `choco install nasm` to install it.
 
-7. **WARNING** Avoid conflicts from perl:
-    - Remove `C:\Strawberry\c\bin` (Your Perl installation directory) from `$PATH$` to avoid conflicts with newer `cmake` installed in step 5 (The bundled `cmake.exe` in perl is OUTDATED and would make build scripts get error).
+6. Install dav1d through [vcpkg](https://vcpkg.io/) (the AVIF decoder links a
+   static dav1d found through pkg-config):
 
-8. Make sure `$PATH`
-    - Make sure the cmake installed in step 5 is in your system `$PATH` and can be called from command line. You can check this by running `cmake --version` in your terminal, it should show the version of cmake you installed in step 5.
-    - Make sure Perl is in your system `$PATH` and can be called from command line. You can check this by running `perl --version` in your terminal, it should show the version of Perl you installed in step 4.
+    ```pwsh
+    vcpkg install dav1d:x64-windows-static pkgconf:x64-windows
 
-9. Build / Test / Format the project:
+    # point the build at pkgconf and the dav1d package
+    $env:PKG_CONFIG = "$env:VCPKG_ROOT\installed\x64-windows\tools\pkgconf\pkgconf.exe"
+    $env:PKG_CONFIG_PATH = "$env:VCPKG_ROOT\installed\x64-windows-static\lib\pkgconfig"
+    ```
+
+    Use `x86-windows-static` instead of `x64-windows-static` when building for
+    the i686 target. To persist the two environment variables, add them with
+    `setx` or through the system settings.
+
+7. Make sure cmake is in your system `$PATH` and can be called from command
+   line. You can check this by running `cmake --version` in your terminal, it
+   should show the version of cmake you installed in step 4.
+
+8. Build / Test / Format the project:
 
     ```pwsh
     # build the library and the CLI binary

--- a/README.md
+++ b/README.md
@@ -87,6 +87,25 @@ rimage mozjpeg --backup ./image.jpg
 rimage mozjpeg -d ./output -r ./inner/image.jpg ./image.jpg
 ```
 
+### Color fidelity and chroma subsampling
+
+`rimage mozjpeg` lets MozJPEG choose the chroma subsampling automatically. At
+typical quality levels it picks **2x2 (4:2:0)**, which discards three quarters
+of the chroma resolution to make the file smaller. A side effect is that highly
+saturated colors (for example a bright red) can come out visibly darker or
+duller than the original.
+
+If color fidelity matters more than file size, force 4:4:4 with:
+
+```sh
+rimage mozjpeg --subsample 1 ./image.jpg
+```
+
+`1` means 4:4:4 (no chroma subsampling), `2` means 4:2:0. The default
+quantization table is `NRobidoux`; if you are comparing output with tools that
+use the standard Annex K tables (such as ImageMagick), pass
+`--qtable AnnexK` to make the comparison closer.
+
 ### File lists
 
 To process many images without a long command line, create a UTF-8 text file named `file.list`

--- a/build.rs
+++ b/build.rs
@@ -17,17 +17,15 @@ fn main() {
         std::process::exit(1);
     }
 
-    let pack = |pre: u16| -> u64 {
-        (env_u64("CARGO_PKG_VERSION_MAJOR") << 48)
-            | (env_u64("CARGO_PKG_VERSION_MINOR") << 32)
-            | (env_u64("CARGO_PKG_VERSION_PATCH") << 16)
-            | u64::from(pre)
-    };
+    let packed = (env_u64("CARGO_PKG_VERSION_MAJOR") << 48)
+        | (env_u64("CARGO_PKG_VERSION_MINOR") << 32)
+        | (env_u64("CARGO_PKG_VERSION_PATCH") << 16)
+        | (env_u64("CARGO_PKG_VERSION_PRE"));
 
     let mut res = WindowsResource::new();
 
-    res.set_version_info(VersionInfo::FILEVERSION, pack(VERSION_PRE))
-        .set_version_info(VersionInfo::PRODUCTVERSION, pack(VERSION_PRE));
+    res.set_version_info(VersionInfo::FILEVERSION, packed)
+        .set_version_info(VersionInfo::PRODUCTVERSION, packed);
 
     if let Err(e) = res.compile() {
         eprintln!("{e}");

--- a/build.rs
+++ b/build.rs
@@ -1,12 +1,20 @@
 use winresource::{VersionInfo, WindowsResource};
 
-// This is the pre-release version number.
-const VERSION_PRE: u16 = 0;
-
 fn main() {
     // only run if target os is windows
     if std::env::var("CARGO_CFG_TARGET_OS").unwrap() != "windows" {
         return;
+    }
+
+    // The winresource-based version-info build script only supports the MSVC
+    // toolchain. Reject Windows GNU builds instead of failing later with a
+    // confusing linker/resource error.
+    if std::env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default() == "gnu" {
+        eprintln!(
+            "rimage on Windows only supports the MSVC toolchain; \
+             x86_64-pc-windows-gnu / i686-pc-windows-gnu are not supported"
+        );
+        std::process::exit(1);
     }
 
     let pack = |pre: u16| -> u64 {

--- a/build.rs
+++ b/build.rs
@@ -6,10 +6,6 @@ const VERSION_PRE: u16 = 0;
 fn main() {
     // only run if target os is windows
     if std::env::var("CARGO_CFG_TARGET_OS").unwrap() != "windows" {
-        println!(
-            "cargo:warning={:#?}",
-            "This build script is only for windows target, skipping..."
-        );
         return;
     }
 

--- a/build.rs
+++ b/build.rs
@@ -2,7 +2,7 @@ use winresource::{VersionInfo, WindowsResource};
 
 fn main() {
     // only run if target os is windows
-    if std::env::var("CARGO_CFG_TARGET_OS").unwrap() != "windows" {
+    if std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default() != "windows" {
         return;
     }
 

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,23 @@
 use winresource::{VersionInfo, WindowsResource};
 
 fn main() {
+    // Without any rerun-if instruction Cargo re-runs this script when any
+    // package file changes. The script only depends on itself and on the
+    // version/target environment variables it reads, so scope the rebuilds
+    // to those. (The CARGO_PKG_* names are how Cargo is told to watch the
+    // manifest's version fields.)
+    println!("cargo:rerun-if-changed=build.rs");
+    for var in [
+        "CARGO_PKG_VERSION_MAJOR",
+        "CARGO_PKG_VERSION_MINOR",
+        "CARGO_PKG_VERSION_PATCH",
+        "CARGO_PKG_VERSION_PRE",
+        "CARGO_CFG_TARGET_OS",
+        "CARGO_CFG_TARGET_ENV",
+    ] {
+        println!("cargo:rerun-if-env-changed={var}");
+    }
+
     // only run if target os is windows
     if std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default() != "windows" {
         return;

--- a/ci/build-dav1d.sh
+++ b/ci/build-dav1d.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Builds a static dav1d and installs it into a prefix, for targets that have
+# no system dav1d package (musl and cross-compiled GNU targets).
+#
+# Usage: build-dav1d.sh <install-prefix> [meson-cross-file]
+#
+# The following environment variables select the toolchain when cross file is
+# omitted and the target differs from the host: CC, AR.
+set -euo pipefail
+
+prefix=$1
+version=1.5.1
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+git clone --depth 1 --branch "$version" \
+    https://code.videolan.org/videolan/dav1d.git "$work/dav1d"
+
+args=(-Ddefault_library=static -Dtools=false -Dbuild_tests=false --prefix="$prefix")
+if [[ $# -gt 1 ]]; then
+    args+=(--cross-file "$2")
+fi
+
+meson setup "$work/build" "${args[@]}" "$work/dav1d"
+ninja -C "$work/build" install

--- a/ci/build-dav1d.sh
+++ b/ci/build-dav1d.sh
@@ -19,9 +19,9 @@ git clone --depth 1 --branch "$version" \
 
 # dav1d 1.5.x spells these options enable_tools/enable_tests; the shorter
 # tools/build_tests names are rejected as unknown project options
-args=(-Ddefault_library=static -Denable_tools=false -Denable_tests=false --prefix="$prefix")
+args=(-Ddefault_library=static -Denable_tools=false -Denable_tests=false -Dlibdir=lib --prefix="$prefix")
 if [[ $# -gt 1 ]]; then
-    args+=(--cross-file "$2")
+    args+=(--cross-file "$(realpath "$2")")
 fi
 
 # options must not sit between meson setup's two positional arguments:

--- a/ci/build-dav1d.sh
+++ b/ci/build-dav1d.sh
@@ -17,10 +17,15 @@ trap 'rm -rf "$work"' EXIT
 git clone --depth 1 --branch "$version" \
     https://code.videolan.org/videolan/dav1d.git "$work/dav1d"
 
-args=(-Ddefault_library=static -Dtools=false -Dbuild_tests=false --prefix="$prefix")
+# dav1d 1.5.x spells these options enable_tools/enable_tests; the shorter
+# tools/build_tests names are rejected as unknown project options
+args=(-Ddefault_library=static -Denable_tools=false -Denable_tests=false --prefix="$prefix")
 if [[ $# -gt 1 ]]; then
     args+=(--cross-file "$2")
 fi
 
-meson setup "$work/build" "${args[@]}" "$work/dav1d"
+# options must not sit between meson setup's two positional arguments:
+# argparse then fails to bind the trailing sourcedir ("unrecognized
+# arguments"), so run from inside the source tree and pass only the builddir
+(cd "$work/dav1d" && meson setup "$work/build" "${args[@]}")
 ninja -C "$work/build" install

--- a/ci/build-dav1d.sh
+++ b/ci/build-dav1d.sh
@@ -8,20 +8,33 @@
 # omitted and the target differs from the host: CC, AR.
 set -euo pipefail
 
+if [[ $# -lt 1 ]]; then
+    echo "Usage: build-dav1d.sh <install-prefix> [meson-cross-file]" >&2
+    exit 2
+fi
+
 prefix=$1
 version=1.5.1
+# Commit the 1.5.1 tag pointed at when this pin was written. A tag can be
+# re-pointed upstream; verifying the checkout keeps the build reproducible.
+commit=3060ebf8dd26952579373084984daf70a54f5368
 
 work=$(mktemp -d)
 trap 'rm -rf "$work"' EXIT
 
 git clone --depth 1 --branch "$version" \
     https://code.videolan.org/videolan/dav1d.git "$work/dav1d"
+if [[ $(git -C "$work/dav1d" rev-parse HEAD) != "$commit" ]]; then
+    echo "build-dav1d: tag $version no longer points at the pinned commit $commit" >&2
+    exit 1
+fi
 
 # dav1d 1.5.x spells these options enable_tools/enable_tests; the shorter
 # tools/build_tests names are rejected as unknown project options
 args=(-Ddefault_library=static -Denable_tools=false -Denable_tests=false -Dlibdir=lib --prefix="$prefix")
 if [[ $# -gt 1 ]]; then
-    args+=(--cross-file "$(realpath "$2")")
+    # realpath(1) is GNU-only; cd+pwd resolves the cross file on macOS too.
+    args+=(--cross-file "$(cd "$(dirname "$2")" && pwd)/$(basename "$2")")
 fi
 
 # options must not sit between meson setup's two positional arguments:

--- a/ci/meson/aarch64-gnu.ini
+++ b/ci/meson/aarch64-gnu.ini
@@ -1,0 +1,14 @@
+# Meson cross file used by ci/build-dav1d.sh to compile a static dav1d for
+# aarch64-unknown-linux-gnu on the x86_64 CI runner. Declaring the host
+# machine explicitly keeps meson from running aarch64 binaries during its
+# sanity check.
+[binaries]
+c = 'aarch64-linux-gnu-gcc'
+ar = 'aarch64-linux-gnu-ar'
+pkg-config = 'pkg-config'
+
+[host_machine]
+system = 'linux'
+cpu_family = 'aarch64'
+cpu = 'aarch64'
+endian = 'little'

--- a/ci/msvc-env.sh
+++ b/ci/msvc-env.sh
@@ -9,11 +9,69 @@
 # It only affects the current shell. Nothing is written to the persistent
 # environment, the registry, or any profile.
 #
+# The MSVC and SDK versions are auto-detected from the filesystem. If the
+# detection fails, override them by setting RIMAGE_MSVC_ROOT and
+# RIMAGE_SDK_VER before sourcing this file.
+#
 # Usage: source ci/msvc-env.sh
 
-_msvc_root='/c/Program Files (x86)/Microsoft Visual Studio/18/BuildTools/VC/Tools/MSVC/14.51.36231'
 _sdk_root='/c/Program Files (x86)/Windows Kits/10'
-_sdk_ver='10.0.26100.0'
+
+# --- Auto-detect the MSVC tools root --------------------------------------
+# Looks for the highest-versioned directory under the VS BuildTools path.
+# Override: set RIMAGE_MSVC_ROOT to the full MSVC tools path before sourcing.
+if [ -z "${RIMAGE_MSVC_ROOT:-}" ]; then
+    _vs_base='/c/Program Files (x86)/Microsoft Visual Studio'
+    _msvc_root=""
+    if [ -d "$_vs_base" ]; then
+        # Search for any edition (BuildTools, Community, Professional, Enterprise)
+        # under VS 17 or 18, then pick the highest-numbered MSVC version.
+        for _edition in "$_vs_base"/*/BuildTools \
+                        "$_vs_base"/*/Community \
+                        "$_vs_base"/*/Professional \
+                        "$_vs_base"/*/Enterprise; do
+            _vc_tools="$_edition/VC/Tools/MSVC"
+            if [ -d "$_vc_tools" ]; then
+                # Pick the highest version directory (lexicographic = numeric
+                # for dotted version strings like 14.51.36231).
+                _found=$(ls -1 "$_vc_tools" 2>/dev/null | sort -V | tail -1)
+                if [ -n "$_found" ]; then
+                    _msvc_root="$_vc_tools/$_found"
+                    break
+                fi
+            fi
+        done
+    fi
+    if [ -z "$_msvc_root" ]; then
+        echo "msvc-env: could not auto-detect MSVC tools root." >&2
+        echo "msvc-env: set RIMAGE_MSVC_ROOT to the full path, e.g.:" >&2
+        echo "msvc-env:   export RIMAGE_MSVC_ROOT='/c/Program Files (x86)/Microsoft Visual Studio/18/BuildTools/VC/Tools/MSVC/14.51.36231'" >&2
+        return 1 2>/dev/null || exit 1
+    fi
+else
+    _msvc_root="$RIMAGE_MSVC_ROOT"
+fi
+
+# --- Auto-detect the Windows SDK version ---------------------------------
+# Override: set RIMAGE_SDK_VER to the desired SDK version string.
+if [ -z "${RIMAGE_SDK_VER:-}" ]; then
+    _sdk_ver=""
+    if [ -d "$_sdk_root/Lib" ]; then
+        # Pick the highest version that has both Lib and bin directories.
+        _sdk_ver=$(ls -1 "$_sdk_root/Lib" 2>/dev/null | sort -V | tail -1)
+    fi
+    if [ -z "$_sdk_ver" ]; then
+        echo "msvc-env: could not auto-detect Windows SDK version under $_sdk_root." >&2
+        echo "msvc-env: set RIMAGE_SDK_VER to the desired version, e.g.:" >&2
+        echo "msvc-env:   export RIMAGE_SDK_VER='10.0.26100.0'" >&2
+        return 1 2>/dev/null || exit 1
+    fi
+else
+    _sdk_ver="$RIMAGE_SDK_VER"
+fi
+
+echo "msvc-env: detected MSVC root: $_msvc_root"
+echo "msvc-env: detected SDK ver:    $_sdk_ver"
 
 for _dir in \
     "$_msvc_root/bin/Hostx64/x64" \
@@ -46,7 +104,8 @@ export INCLUDE="$(_win "$_msvc_root/include");$(_win "$_sdk_root/Include/$_sdk_v
 export RC_PATH="$(_win "$_sdk_root/bin/$_sdk_ver/x64/rc.exe")"
 
 _RC_PATH="$RC_PATH"
-unset _msvc_root _sdk_root _sdk_ver _dir
+unset _vs_base _edition _vc_tools _found _msvc_root _sdk_root _sdk_ver _dir
+unset RIMAGE_MSVC_ROOT RIMAGE_SDK_VER 2>/dev/null || true
 
 echo "msvc-env: link -> $(command -v link)"
 echo "msvc-env: rc   -> $_RC_PATH"

--- a/ci/msvc-env.sh
+++ b/ci/msvc-env.sh
@@ -17,30 +17,44 @@
 
 _sdk_root='/c/Program Files (x86)/Windows Kits/10'
 
+# --- Target architecture ---------------------------------------------------
+# x64 is the default because Git Bash itself is x64-only (on ARM64 Windows it
+# runs emulated, and the x64 toolchain is what it can execute). Override for
+# an ARM64-native environment (e.g. MSYS2 clangarm64): RIMAGE_ARCH=arm64.
+_arch="${RIMAGE_ARCH:-x64}"
+case "$_arch" in
+    x64)   _host_dir="Hostx64" ;;
+    arm64) _host_dir="Hostarm64" ;;
+    *)
+        echo "msvc-env: unsupported RIMAGE_ARCH '$_arch' (expected x64 or arm64)" >&2
+        return 1 2>/dev/null || exit 1
+        ;;
+esac
+
 # --- Auto-detect the MSVC tools root --------------------------------------
-# Looks for the highest-versioned directory under the VS BuildTools path.
+# Picks the highest-numbered MSVC version across every installed VS edition.
 # Override: set RIMAGE_MSVC_ROOT to the full MSVC tools path before sourcing.
 if [ -z "${RIMAGE_MSVC_ROOT:-}" ]; then
     _vs_base='/c/Program Files (x86)/Microsoft Visual Studio'
     _msvc_root=""
     if [ -d "$_vs_base" ]; then
-        # Search for any edition (BuildTools, Community, Professional, Enterprise)
-        # under VS 17 or 18, then pick the highest-numbered MSVC version.
-        for _edition in "$_vs_base"/*/BuildTools \
-                        "$_vs_base"/*/Community \
-                        "$_vs_base"/*/Professional \
-                        "$_vs_base"/*/Enterprise; do
-            _vc_tools="$_edition/VC/Tools/MSVC"
-            if [ -d "$_vc_tools" ]; then
-                # Pick the highest version directory (lexicographic = numeric
-                # for dotted version strings like 14.51.36231).
-                _found=$(ls -1 "$_vc_tools" 2>/dev/null | sort -V | tail -1)
-                if [ -n "$_found" ]; then
-                    _msvc_root="$_vc_tools/$_found"
-                    break
+        # Gather every MSVC tools tree from any edition (BuildTools,
+        # Community, Professional, Enterprise), then pick the highest
+        # version (lexicographic sort = numeric for dotted versions like
+        # 14.51.36231).
+        _msvc_root=$(
+            for _edition in "$_vs_base"/*/BuildTools \
+                            "$_vs_base"/*/Community \
+                            "$_vs_base"/*/Professional \
+                            "$_vs_base"/*/Enterprise; do
+                _vc_tools="$_edition/VC/Tools/MSVC"
+                if [ -d "$_vc_tools" ]; then
+                    for _ver in "$_vc_tools"/*; do
+                        [ -d "$_ver" ] && printf '%s\n' "$_ver"
+                    done
                 fi
-            fi
-        done
+            done | sort -V | tail -1
+        )
     fi
     if [ -z "$_msvc_root" ]; then
         echo "msvc-env: could not auto-detect MSVC tools root." >&2
@@ -50,6 +64,13 @@ if [ -z "${RIMAGE_MSVC_ROOT:-}" ]; then
     fi
 else
     _msvc_root="$RIMAGE_MSVC_ROOT"
+fi
+
+# An ARM64 host without the native tools installed can still use the
+# x64-hosted cross-compiler, which Windows on ARM runs emulated.
+if [ ! -d "$_msvc_root/bin/$_host_dir/$_arch" ] && [ -d "$_msvc_root/bin/Hostx64/$_arch" ]; then
+    echo "msvc-env: $_host_dir/$_arch not found, falling back to Hostx64/$_arch" >&2
+    _host_dir="Hostx64"
 fi
 
 # --- Auto-detect the Windows SDK version ---------------------------------
@@ -74,11 +95,11 @@ echo "msvc-env: detected MSVC root: $_msvc_root"
 echo "msvc-env: detected SDK ver:    $_sdk_ver"
 
 for _dir in \
-    "$_msvc_root/bin/Hostx64/x64" \
-    "$_msvc_root/lib/x64" \
-    "$_sdk_root/Lib/$_sdk_ver/ucrt/x64" \
-    "$_sdk_root/Lib/$_sdk_ver/um/x64" \
-    "$_sdk_root/bin/$_sdk_ver/x64"
+    "$_msvc_root/bin/$_host_dir/$_arch" \
+    "$_msvc_root/lib/$_arch" \
+    "$_sdk_root/Lib/$_sdk_ver/ucrt/$_arch" \
+    "$_sdk_root/Lib/$_sdk_ver/um/$_arch" \
+    "$_sdk_root/bin/$_sdk_ver/$_arch"
 do
     if [ ! -d "$_dir" ]; then
         echo "msvc-env: missing directory: $_dir" >&2
@@ -86,14 +107,14 @@ do
     fi
 done
 
-export PATH="$_sdk_root/bin/$_sdk_ver/x64:$_msvc_root/bin/Hostx64/x64:$PATH"
+export PATH="$_sdk_root/bin/$_sdk_ver/$_arch:$_msvc_root/bin/$_host_dir/$_arch:$PATH"
 
 # link.exe cannot read Git Bash's /c/... paths, so LIB and INCLUDE must use
 # native Windows paths with backslashes. `cygpath -w` does the conversion.
 _win() { cygpath -w "$1"; }
 
 # LIB tells link.exe where to resolve kernel32.lib & friends.
-export LIB="$(_win "$_msvc_root/lib/x64");$(_win "$_sdk_root/Lib/$_sdk_ver/ucrt/x64");$(_win "$_sdk_root/Lib/$_sdk_ver/um/x64")${LIB:+;$LIB}"
+export LIB="$(_win "$_msvc_root/lib/$_arch");$(_win "$_sdk_root/Lib/$_sdk_ver/ucrt/$_arch");$(_win "$_sdk_root/Lib/$_sdk_ver/um/$_arch")${LIB:+;$LIB}"
 
 # INCLUDE is needed when a -sys crate compiles C sources.
 export INCLUDE="$(_win "$_msvc_root/include");$(_win "$_sdk_root/Include/$_sdk_ver/ucrt");$(_win "$_sdk_root/Include/$_sdk_ver/um");$(_win "$_sdk_root/Include/$_sdk_ver/shared")${INCLUDE:+;$INCLUDE}"
@@ -101,11 +122,11 @@ export INCLUDE="$(_win "$_msvc_root/include");$(_win "$_sdk_root/Include/$_sdk_v
 # winresource (build.rs of this crate) resolves rc.exe from its own toolkit_path
 # instead of PATH, and derives that path from registry lookups that do not work
 # reliably here. RC_PATH short-circuits that lookup with an explicit path.
-export RC_PATH="$(_win "$_sdk_root/bin/$_sdk_ver/x64/rc.exe")"
+export RC_PATH="$(_win "$_sdk_root/bin/$_sdk_ver/$_arch/rc.exe")"
 
 _RC_PATH="$RC_PATH"
-unset _vs_base _edition _vc_tools _found _msvc_root _sdk_root _sdk_ver _dir
-unset RIMAGE_MSVC_ROOT RIMAGE_SDK_VER 2>/dev/null || true
+unset _vs_base _edition _vc_tools _ver _msvc_root _sdk_root _sdk_ver _dir _arch _host_dir
+unset RIMAGE_MSVC_ROOT RIMAGE_SDK_VER RIMAGE_ARCH 2>/dev/null || true
 
 echo "msvc-env: link -> $(command -v link)"
 echo "msvc-env: rc   -> $_RC_PATH"

--- a/ci/msvc-env.sh
+++ b/ci/msvc-env.sh
@@ -1,0 +1,53 @@
+# Prepends the MSVC toolchain and Windows SDK to PATH/LIB for this shell only.
+#
+# Why this exists: Git Bash ships GNU coreutils `link.exe`, which shadows MSVC's
+# linker and makes every `cargo build` fail with "link: extra operand". The MSVC
+# environment (INCLUDE/LIB/PATH) is normally set up by vcvarsall.bat, which is a
+# cmd.exe script and is therefore awkward to use from bash. This file sets the
+# same variables directly.
+#
+# It only affects the current shell. Nothing is written to the persistent
+# environment, the registry, or any profile.
+#
+# Usage: source ci/msvc-env.sh
+
+_msvc_root='/c/Program Files (x86)/Microsoft Visual Studio/18/BuildTools/VC/Tools/MSVC/14.51.36231'
+_sdk_root='/c/Program Files (x86)/Windows Kits/10'
+_sdk_ver='10.0.26100.0'
+
+for _dir in \
+    "$_msvc_root/bin/Hostx64/x64" \
+    "$_msvc_root/lib/x64" \
+    "$_sdk_root/Lib/$_sdk_ver/ucrt/x64" \
+    "$_sdk_root/Lib/$_sdk_ver/um/x64" \
+    "$_sdk_root/bin/$_sdk_ver/x64"
+do
+    if [ ! -d "$_dir" ]; then
+        echo "msvc-env: missing directory: $_dir" >&2
+        return 1 2>/dev/null || exit 1
+    fi
+done
+
+export PATH="$_sdk_root/bin/$_sdk_ver/x64:$_msvc_root/bin/Hostx64/x64:$PATH"
+
+# link.exe cannot read Git Bash's /c/... paths, so LIB and INCLUDE must use
+# native Windows paths with backslashes. `cygpath -w` does the conversion.
+_win() { cygpath -w "$1"; }
+
+# LIB tells link.exe where to resolve kernel32.lib & friends.
+export LIB="$(_win "$_msvc_root/lib/x64");$(_win "$_sdk_root/Lib/$_sdk_ver/ucrt/x64");$(_win "$_sdk_root/Lib/$_sdk_ver/um/x64")${LIB:+;$LIB}"
+
+# INCLUDE is needed when a -sys crate compiles C sources.
+export INCLUDE="$(_win "$_msvc_root/include");$(_win "$_sdk_root/Include/$_sdk_ver/ucrt");$(_win "$_sdk_root/Include/$_sdk_ver/um");$(_win "$_sdk_root/Include/$_sdk_ver/shared")${INCLUDE:+;$INCLUDE}"
+
+# winresource (build.rs of this crate) resolves rc.exe from its own toolkit_path
+# instead of PATH, and derives that path from registry lookups that do not work
+# reliably here. RC_PATH short-circuits that lookup with an explicit path.
+export RC_PATH="$(_win "$_sdk_root/bin/$_sdk_ver/x64/rc.exe")"
+
+_RC_PATH="$RC_PATH"
+unset _msvc_root _sdk_root _sdk_ver _dir
+
+echo "msvc-env: link -> $(command -v link)"
+echo "msvc-env: rc   -> $_RC_PATH"
+unset _RC_PATH

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,28 +20,29 @@ pub fn cli() -> Command {
 /// and both preprocessing operations are feature-gated, and a static table
 /// would advertise subcommands that do not exist in a trimmed build.
 fn after_help() -> String {
-    let mut rows: Vec<&'static str> = Vec::new();
-    #[cfg(feature = "avif")]
-    rows.push("| avif          | O     | O      | Static only       |");
-    rows.push("| bmp           | O     | X      |                   |");
-    rows.push("| farbfeld      | O     | O      |                   |");
-    rows.push("| hdr           | O     | O      |                   |");
-    rows.push("| jpeg          | O     | O      |                   |");
-    rows.push("| jpeg_xl(jxl)  | O     | O      |                   |");
-    #[cfg(feature = "mozjpeg")]
-    rows.push("| mozjpeg(moz)  | O     | O      |                   |");
-    #[cfg(feature = "oxipng")]
-    rows.push("| oxipng(oxi)   | O     | O      | Static only       |");
-    rows.push("| png           | O     | O      | Static only       |");
-    rows.push("| ppm           | O     | O      |                   |");
-    rows.push("| psd           | O     | X      |                   |");
-    rows.push("| qoi           | O     | O      |                   |");
-    #[cfg(feature = "svg")]
-    rows.push("| svg           | O     | X      | Resize losslessly |");
-    #[cfg(feature = "tiff")]
-    rows.push("| tiff          | O     | X      |                   |");
-    #[cfg(feature = "webp")]
-    rows.push("| webp          | O     | O      | Static only       |");
+    let rows: &[&'static str] = &[
+        #[cfg(feature = "avif")]
+        "| avif          | O     | O      | Static only       |",
+        "| bmp           | O     | X      |                   |",
+        "| farbfeld      | O     | O      |                   |",
+        "| hdr           | O     | O      |                   |",
+        "| jpeg          | O     | O      |                   |",
+        "| jpeg_xl(jxl)  | O     | O      |                   |",
+        #[cfg(feature = "mozjpeg")]
+        "| mozjpeg(moz)  | O     | O      |                   |",
+        #[cfg(feature = "oxipng")]
+        "| oxipng(oxi)   | O     | O      | Static only       |",
+        "| png           | O     | O      | Static only       |",
+        "| ppm           | O     | O      |                   |",
+        "| psd           | O     | X      |                   |",
+        "| qoi           | O     | O      |                   |",
+        #[cfg(feature = "svg")]
+        "| svg           | O     | X      | Resize losslessly |",
+        #[cfg(feature = "tiff")]
+        "| tiff          | O     | X      |                   |",
+        #[cfg(feature = "webp")]
+        "| webp          | O     | O      | Static only       |",
+    ];
 
     let mut text = String::from(
         "\nList of supported codecs\n\
@@ -52,7 +53,6 @@ fn after_help() -> String {
         text.push_str(row);
         text.push('\n');
     }
-
     text.push_str("\nList of supported preprocessing options\n");
     #[cfg(feature = "resize")]
     text.push_str("- Resize\n");

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,4 @@
 use clap::{Command, command};
-use indoc::indoc;
 
 use self::codecs::Codecs;
 
@@ -12,36 +11,61 @@ pub mod utils;
 pub fn cli() -> Command {
     command!()
         .arg_required_else_help(true)
-        .after_help(indoc! {r#"
-List of supported codecs
-| Image Format  | Input | Output | Note              |
-| ------------- | ----- | ------ | ----------------- |
-| avif          | O     | O      | Static only       |
-| bmp           | O     | X      |                   |
-| farbfeld      | O     | O      |                   |
-| hdr           | O     | O      |                   |
-| jpeg          | O     | O      |                   |
-| jpeg_xl(jxl)  | O     | O      |                   |
-| mozjpeg(moz)  | O     | O      |                   |
-| oxipng(oxi)   | O     | O      | Static only       |
-| png           | O     | O      | Static only       |
-| ppm           | O     | O      |                   |
-| psd           | O     | X      |                   |
-| qoi           | O     | O      |                   |
-| svg           | O     | X      | Resize losslessly |
-| tiff          | O     | X      |                   |
-| webp          | O     | O      | Static only       |
-
-List of supported preprocessing options
-- Resize
-- Quantization
-- Alpha premultiply
-
-List of supported mode for output info presenting
-- No-progress (Shown on Default)
-- Quiet (Show all msgs on Default)
-"#})
+        .after_help(after_help())
         .codecs()
+}
+
+/// The help epilogue is generated rather than literal so the codec table
+/// only lists what this binary was actually compiled with: several codecs
+/// and both preprocessing operations are feature-gated, and a static table
+/// would advertise subcommands that do not exist in a trimmed build.
+fn after_help() -> String {
+    let mut rows: Vec<&'static str> = Vec::new();
+    #[cfg(feature = "avif")]
+    rows.push("| avif          | O     | O      | Static only       |");
+    rows.push("| bmp           | O     | X      |                   |");
+    rows.push("| farbfeld      | O     | O      |                   |");
+    rows.push("| hdr           | O     | O      |                   |");
+    rows.push("| jpeg          | O     | O      |                   |");
+    rows.push("| jpeg_xl(jxl)  | O     | O      |                   |");
+    #[cfg(feature = "mozjpeg")]
+    rows.push("| mozjpeg(moz)  | O     | O      |                   |");
+    #[cfg(feature = "oxipng")]
+    rows.push("| oxipng(oxi)   | O     | O      | Static only       |");
+    rows.push("| png           | O     | O      | Static only       |");
+    rows.push("| ppm           | O     | O      |                   |");
+    rows.push("| psd           | O     | X      |                   |");
+    rows.push("| qoi           | O     | O      |                   |");
+    #[cfg(feature = "svg")]
+    rows.push("| svg           | O     | X      | Resize losslessly |");
+    #[cfg(feature = "tiff")]
+    rows.push("| tiff          | O     | X      |                   |");
+    #[cfg(feature = "webp")]
+    rows.push("| webp          | O     | O      | Static only       |");
+
+    let mut text = String::from(
+        "\nList of supported codecs\n\
+         | Image Format  | Input | Output | Note              |\n\
+         | ------------- | ----- | ------ | ----------------- |\n",
+    );
+    for row in rows {
+        text.push_str(row);
+        text.push('\n');
+    }
+
+    text.push_str("\nList of supported preprocessing options\n");
+    #[cfg(feature = "resize")]
+    text.push_str("- Resize\n");
+    #[cfg(feature = "quantization")]
+    text.push_str("- Quantization\n");
+    text.push_str("- Alpha premultiply\n");
+
+    text.push_str(
+        "\nList of supported mode for output info presenting\n\
+         - No-progress (Shown on Default)\n\
+         - Quiet (Show all msgs on Default)\n",
+    );
+    text
 }
 
 #[cfg(test)]

--- a/src/cli/codecs/mozjpeg.rs
+++ b/src/cli/codecs/mozjpeg.rs
@@ -21,8 +21,27 @@ pub fn mozjpeg() -> Command {
                 .default_value("ycbcr"),
             arg!(--multipass "Specifies whether multiple scans should be considered during trellis quantization."),
             arg!(--subsample <PIX> "Sets chroma subsampling.")
+                .long_help(
+                    "Sets chroma subsampling for the output JPEG.\n\
+                     \n\
+                     1 = 4:4:4 (no chroma subsampling, best color fidelity), \
+                     2 = 4:2:0 (default at most quality levels, smallest file).\n\
+                     \n\
+                     By default rimage lets MozJPEG pick automatically; at \
+                     typical qualities it picks 2 (4:2:0), which throws away \
+                     three quarters of the chroma resolution. Saturated colors \
+                     (e.g. bright red) can become visibly darker or duller. \
+                     Use --subsample 1 to preserve color detail at the cost of \
+                     a larger file.")
                 .value_parser(value_parser!(u8).range(1..=4)),
             arg!(--qtable <TABLE> "Use a specific quantization table.")
+                .long_help(
+                    "Use a specific quantization table.\n\
+                     \n\
+                     rimage defaults to NRobidoux, which favors smaller files. \
+                     Other tools such as ImageMagick typically use the standard \
+                     Annex K tables; together with chroma subsampling this can \
+                     produce small color differences at the same quality value.")
                 .value_parser([
                     "AhumadaWatsonPeterson",
                     "AnnexK",

--- a/src/cli/codecs/mozjpeg.rs
+++ b/src/cli/codecs/mozjpeg.rs
@@ -25,7 +25,10 @@ pub fn mozjpeg() -> Command {
                     "Sets chroma subsampling for the output JPEG.\n\
                      \n\
                      1 = 4:4:4 (no chroma subsampling, best color fidelity), \
-                     2 = 4:2:0 (default at most quality levels, smallest file).\n\
+                     2 = 4:2:0 (default at most quality levels, smallest file), \
+                     3 and 4 = NxN sampling factors that downsample chroma even \
+                     further; legal but nonstandard, and rarely useful outside \
+                     file-size experiments.\n\
                      \n\
                      By default rimage lets MozJPEG pick automatically; at \
                      typical qualities it picks 2 (4:2:0), which throws away \

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -9,12 +9,13 @@ impl CommonArgs for Command {
     fn common_args(self) -> Self {
         let cmd = self
         .next_help_heading("General").args([
-            arg!(files: <FILES> ... "Input file(s) to process.")
+            arg!(files: [FILES] ... "Input file(s) to process.")
                 .long_help(indoc! {r#"Input file(s) to process.
 
                 If the file path contains spaces, enclose the path with double quotation marks on both sides.
 
                 A file named `file.list` is read as a UTF-8 file list with one input file per line. Blank lines are skipped, surrounding whitespace is ignored, and relative paths are resolved against the current working directory. When a `file.list` is provided, all other input file arguments are ignored."#})
+                .required_unless_present("print-limits")
                 .value_parser(value_parser!(PathBuf)),
             arg!(-d --directory <DIR> "The directory to write output file(s) to.")
                 .long_help(indoc! {r#"The directory to write output file(s) to.
@@ -58,6 +59,16 @@ impl CommonArgs for Command {
 
                 This will output the metadata of the processed image(s) in JSON format."#})
                 .value_parser(value_parser!(PathBuf)),
+            arg!(--"print-limits" "Print the runtime-derived size limits and exit.")
+                .long_help(indoc! {r#"Print the runtime-derived size limits and exit.
+
+                Shows the probed system memory budget, the per-format dimension and pixel
+                ceilings, and which source (format, memory, or disk) is the binding
+                constraint. No files are processed. This is a diagnostic tool for
+                understanding why an image was rejected or for calibrating the
+                pipeline cost estimates."#})
+                .action(ArgAction::SetTrue)
+                .hide(true),
         ]);
 
         cmd.preprocessors()

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -42,7 +42,10 @@ impl CommonArgs for Command {
                 Limits how many images are decoded and held in memory at once.
                 Higher values increase speed but use more RAM, which may cause out-of-memory errors with large images.
                 By default, processes one image at a time (--threads 1)."#})
-                .value_parser(value_parser!(u8).range(1i64..=threads::num_threads() as i64)),
+                // u16, not u8: the range upper bound is the machine's core
+                // count, and u8 would cap that at 255 on hardware with more
+                // cores.
+                .value_parser(value_parser!(u16).range(1i64..=threads::num_threads() as i64)),
             arg!(-x --strip "Strip metadata when encoding images (where supported)")
                 .action(ArgAction::SetTrue),
             arg!(--"no-progress" "Disables progress bar.")

--- a/src/cli/pipeline.rs
+++ b/src/cli/pipeline.rs
@@ -72,7 +72,7 @@ pub fn decode<P: AsRef<Path>>(f: P, matches: &ArgMatches) -> Result<Image, Image
                 file.read_to_end(&mut file_content)?;
                 file.seek(SeekFrom::Start(0))?;
 
-                if libavif::is_avif(&file_content) {
+                if rimage::codecs::avif::is_avif(&file_content) {
                     use rimage::codecs::avif::AvifDecoder;
 
                     let decoder = AvifDecoder::try_new(file)?;

--- a/src/cli/pipeline.rs
+++ b/src/cli/pipeline.rs
@@ -35,16 +35,21 @@ use zune_imageprocs::premul_alpha::PremultiplyAlpha;
 
 /// Decoder options shared by every path in [`decode`].
 ///
-/// The defaults are wrong for this program in one specific way: zune decodes
-/// *every* frame of an animated PNG or JXL. We only ever re-encode a single
-/// still image, and an animation holds one full-size buffer per frame, so
-/// decoding the frames we are about to discard is pure memory waste. Asking for
-/// the first frame only keeps peak memory proportional to one image.
+/// The defaults differ from what this program wants in two ways.
 ///
-/// The maximum dimensions are deliberately left at the library default rather
-/// than pinned to a constant here: the size limit is derived at runtime by
-/// `rimage::limits`, and hard-coding a second, different ceiling in this file
-/// would give the two a way to disagree.
+/// First, zune decodes *every* frame of an animated PNG or JXL. We only ever
+/// re-encode a single still image, and an animation holds one full-size buffer
+/// per frame, so decoding the frames we are about to discard is pure memory
+/// waste. Asking for the first frame only keeps peak memory proportional to one
+/// image.
+///
+/// Second, the default `max_width`/`max_height` of 16384 is the ceiling the
+/// size pre-check reports, and it is deliberately *not* raised here. The
+/// underlying codecs advertise more (libjpeg allows 65500), but the decoder
+/// refuses a larger image from its header before the codec runs, so pinning a
+/// bigger number in [`rimage::limits::format_caps`] would only make the
+/// pre-check pass files that fail to decode. The two numbers are the same
+/// constant on purpose: raising one without the other reopens that gap.
 fn decode_options() -> DecoderOptions {
     DecoderOptions::default()
         .png_set_decode_animated(false)
@@ -105,14 +110,15 @@ fn check_input_limits(
 
 /// Read just the dimensions from an image header.
 ///
-/// Only the formats with a *published per-side limit* are handled here. They
-/// are the ones a cheap header read can settle, and rejecting them up front is
-/// what turns an oversized input into a message naming the ceiling instead of
-/// an allocation abort inside the codec.
+/// Every format rimage can decode is probed here where a header read can settle
+/// the size. Rejecting an oversized input up front is what turns it into a
+/// message naming the ceiling instead of an allocation abort inside the codec.
 ///
-/// Formats with no published side limit are bounded by the memory budget,
-/// which the decoder applies to the buffer it actually allocates; probing their
-/// headers here would duplicate that check without adding a format limit.
+/// The two probes that cannot simply read a fixed struct are the two container
+/// formats: AVIF keeps its dimensions in an ISO-BMFF property box, and TIFF in
+/// an IFD whose location depends on the header. Both are walked rather than
+/// scanned for a byte pattern, because a pattern would also match inside
+/// compressed image data and report the wrong size.
 #[cfg(feature = "limits")]
 fn probe_dimensions<R: std::io::Read>(
     mut reader: R, format: rimage::limits::ImageFormatId,
@@ -121,14 +127,8 @@ fn probe_dimensions<R: std::io::Read>(
 
     match format {
         ImageFormatId::Jpeg => {
-            use zune_core::bytestream::ZCursor;
-
             let prefix = read_prefix(&mut reader, JPEG_HEADER_PROBE_BYTES)?;
-
-            let mut decoder = zune_image::codecs::jpeg::JpegDecoder::new(ZCursor::new(prefix));
-            decoder.decode_headers().ok()?;
-            let (width, height) = decoder.dimensions()?;
-            Some((width as u64, height as u64))
+            jpeg_dimensions(&prefix)
         }
         ImageFormatId::WebP => {
             // libwebp exposes a bitstream-features probe that parses the RIFF
@@ -146,9 +146,323 @@ fn probe_dimensions<R: std::io::Read>(
                 None
             }
         }
+        ImageFormatId::Png => {
+            // The IHDR chunk holds both dimensions as big-endian `u32` and is
+            // required to be the first chunk (PNG spec § 11.2.2), so a fixed
+            // 16-byte prefix settles the size.
+            let prefix = read_prefix(&mut reader, PNG_HEADER_PROBE_BYTES)?;
+            png_dimensions(&prefix)
+        }
+        ImageFormatId::Avif => {
+            let prefix = read_prefix(&mut reader, CONTAINER_HEADER_PROBE_BYTES)?;
+            avif_dimensions(&prefix)
+        }
+        ImageFormatId::Tiff => {
+            let prefix = read_prefix(&mut reader, CONTAINER_HEADER_PROBE_BYTES)?;
+            tiff_dimensions(&prefix)
+        }
         _ => None,
     }
 }
+
+/// Read the width and height from a JPEG Start-Of-Frame segment.
+///
+/// The dimensions are parsed straight from the marker rather than through
+/// `zune_jpeg::JpegDecoder::decode_headers`, because that call applies the
+/// decoder's own `max_width`/`max_height` and fails on exactly the images this
+/// check exists to report. Reading the marker keeps the probe independent of
+/// whatever ceiling the decoder happens to enforce.
+///
+/// The walk follows JPEG marker segments (ITU-T T.81 § B.2): each is a
+/// two-byte marker then a two-byte big-endian length covering the length field
+/// itself. Segments that carry no length (`RSTn`, `TEM`, and the standalone
+/// `SOI`/`EOI` markers) would desynchronise the walk, so encountering one is
+/// treated as "cannot read this file" rather than guessed at.
+#[cfg(feature = "limits")]
+fn jpeg_dimensions(data: &[u8]) -> Option<(u64, u64)> {
+    /// Markers that introduce entropy-coded data; the frame header always
+    /// precedes the first of them, so reaching one means it was not found.
+    const START_OF_SCAN: u8 = 0xDA;
+    /// Markers carrying no length field.
+    const STANDALONE_MARKERS: [u8; 6] = [0x01, 0xD0, 0xD1, 0xD2, 0xD8, 0xD9];
+
+    // A JPEG file begins with SOI.
+    if data.get(0..2)? != [0xFF, 0xD8] {
+        return None;
+    }
+
+    let mut at = 2;
+    while at + 4 <= data.len() {
+        // Markers are introduced by 0xFF; fill bytes of additional 0xFF are
+        // permitted before the marker code.
+        if data[at] != 0xFF {
+            return None;
+        }
+
+        let mut marker = data[at + 1];
+        while marker == 0xFF {
+            at += 1;
+            marker = *data.get(at + 1)?;
+        }
+
+        if STANDALONE_MARKERS.contains(&marker) {
+            return None;
+        }
+        if marker == START_OF_SCAN {
+            return None;
+        }
+
+        let length = u16::from_be_bytes(data.get(at + 2..at + 4)?.try_into().ok()?) as usize;
+        // The length covers itself, so it is never smaller than two.
+        if length < 2 {
+            return None;
+        }
+
+        // SOF0..SOF15 carry the frame header, except the four that are not
+        // frame headers at all: DHT (0xC4), JPG (0xC8), and DAC (0xCC).
+        if (0xC0..=0xCF).contains(&marker) && marker != 0xC4 && marker != 0xC8 && marker != 0xCC {
+            // Payload: precision(1), height(2), width(2).
+            let payload = at + 4;
+            let height = u16::from_be_bytes(data.get(payload + 1..payload + 3)?.try_into().ok()?);
+            let width = u16::from_be_bytes(data.get(payload + 3..payload + 5)?.try_into().ok()?);
+
+            if width == 0 || height == 0 {
+                return None;
+            }
+
+            return Some((u64::from(width), u64::from(height)));
+        }
+
+        at += 2 + length;
+    }
+
+    None
+}
+
+/// Bytes of a file read to recover a PNG `IHDR` chunk.
+///
+/// The signature is 8 bytes, then a 4-byte length, a 4-byte type, and the
+/// 13-byte `IHDR` payload whose first eight bytes are the dimensions.
+#[cfg(feature = "limits")]
+const PNG_HEADER_PROBE_BYTES: usize = 32;
+
+/// Read the width and height from a PNG `IHDR` chunk.
+///
+/// PNG dimensions are 32-bit and the chunk is required to come first, but the
+/// decoder applies its own ceiling of 16384 from `DecoderOptions`, so an image
+/// can be well within the format's capability and still be rejected. Probing
+/// here is what turns that refusal into a message naming the ceiling.
+#[cfg(feature = "limits")]
+fn png_dimensions(data: &[u8]) -> Option<(u64, u64)> {
+    /// The eight-byte signature every PNG starts with (PNG spec § 5.2).
+    const SIGNATURE: [u8; 8] = [0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A];
+
+    // Signature, then the chunk length and type, then the payload begins.
+    const IHDR_PAYLOAD: usize = 16;
+
+    if data.get(0..8)? != SIGNATURE {
+        return None;
+    }
+
+    // A conforming file's first chunk is `IHDR`; if it is not, this is not a
+    // file whose dimensions can be trusted from a prefix.
+    if data.get(12..16)? != b"IHDR" {
+        return None;
+    }
+
+    let width = u32::from_be_bytes(data.get(IHDR_PAYLOAD..IHDR_PAYLOAD + 4)?.try_into().ok()?);
+    let height = u32::from_be_bytes(data.get(IHDR_PAYLOAD + 4..IHDR_PAYLOAD + 8)?.try_into().ok()?);
+
+    if width == 0 || height == 0 {
+        return None;
+    }
+
+    Some((u64::from(width), u64::from(height)))
+}
+
+/// Bytes of a file read to recover a container header.
+///
+/// AVIF puts its `ispe` property box before the image data, and a TIFF IFD sits
+/// at an offset given in the first eight bytes, so both are reachable from the
+/// front of the file. The bound keeps refusing an oversized input cheap: the
+/// prefix is read, never the payload.
+#[cfg(feature = "limits")]
+const CONTAINER_HEADER_PROBE_BYTES: usize = 64 * 1024;
+
+/// Read the width and height from an AVIF `ispe` property box.
+///
+/// AVIF is ISO-BMFF (ISO 14496-12), so the dimensions live in the
+/// `ImageSpatialExtent` property of the `meta` box rather than in a fixed
+/// header. The boxes are walked by their declared sizes so a byte sequence that
+/// merely looks like `ispe` inside compressed data is never mistaken for the
+/// property.
+///
+/// Returns `None` for a malformed or truncated file: the decoder reports that
+/// better than a pre-check could.
+#[cfg(feature = "limits")]
+fn avif_dimensions(data: &[u8]) -> Option<(u64, u64)> {
+    /// A box header is a 4-byte big-endian size followed by a 4-byte type.
+    const BOX_HEADER: usize = 8;
+
+    fn read_u32(data: &[u8], at: usize) -> Option<u32> {
+        let bytes = data.get(at..at + 4)?;
+        Some(u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]))
+    }
+
+    /// Walk the boxes in `data[range]` looking for one with type `wanted`,
+    /// returning the range of its *payload*.
+    fn find_box(data: &[u8], mut start: usize, end: usize, wanted: &[u8; 4]) -> Option<(usize, usize)> {
+        while start + BOX_HEADER <= end {
+            let size = read_u32(data, start)?;
+
+            // A size of 1 means a 64-bit size follows the type; a size of 0
+            // means the box runs to the end of the enclosing range. Neither is
+            // produced for the boxes this function looks for, so rather than
+            // half-support them, refuse and let the decoder handle the file.
+            if size == 0 || size == 1 {
+                return None;
+            }
+
+            let size = size as usize;
+            let payload = start + BOX_HEADER;
+            let box_end = start.checked_add(size)?;
+            if box_end > end {
+                return None;
+            }
+
+            if data.get(start + 4..start + 8)? == wanted {
+                return Some((payload, box_end));
+            }
+
+            start = box_end;
+        }
+
+        None
+    }
+
+    // `ftyp` is not consulted: the caller already chose this probe from the
+    // file extension, and re-checking the brand here would only duplicate it.
+    // `meta` is a plain box, so hunt it at the top level.
+    let (meta_start, meta_end) = find_box(data, 0, data.len(), b"meta")?;
+
+    // `meta` is a FullBox: 4 bytes of version and flags precede its children.
+    let (iprp_start, iprp_end) = find_box(data, meta_start + 4, meta_end, b"iprp")?;
+    let (ipco_start, ipco_end) = find_box(data, iprp_start, iprp_end, b"ipco")?;
+
+    // `ispe` is a FullBox whose payload is version/flags then width and height,
+    // each a 32-bit big-endian integer (ISO 14496-12 § 12.1.4).
+    let (ispe_start, _) = find_box(data, ipco_start, ipco_end, b"ispe")?;
+    let width = read_u32(data, ispe_start + 4)?;
+    let height = read_u32(data, ispe_start + 8)?;
+
+    // A zero extent is not a size to reject on; it means the probe misread the
+    // container, and a wrong rejection is worse than no pre-check.
+    if width == 0 || height == 0 {
+        return None;
+    }
+
+    Some((u64::from(width), u64::from(height)))
+}
+
+/// Read the width and height from a TIFF image file directory.
+///
+/// Both byte orders are handled, as are both value types the specification
+/// allows for these tags: a `SHORT` when the dimension fits in 16 bits and a
+/// `LONG` otherwise. Anything else is left to the decoder.
+#[cfg(feature = "limits")]
+fn tiff_dimensions(data: &[u8]) -> Option<(u64, u64)> {
+    /// Tag numbers from TIFF 6.0 § 8: `ImageWidth` and `ImageLength`.
+    const TAG_IMAGE_WIDTH: u16 = 0x0100;
+    const TAG_IMAGE_LENGTH: u16 = 0x0101;
+
+    /// TIFF type codes; only these two are valid for the tags above.
+    const TYPE_SHORT: u16 = 3;
+    const TYPE_LONG: u16 = 4;
+
+    const IFD_ENTRY_SIZE: usize = 12;
+
+    // The first two bytes give the byte order, the next two must be 42, and the
+    // following four hold the offset of the first IFD (TIFF 6.0 § 2).
+    let little_endian = match data.get(0..2)? {
+        b"II" => true,
+        b"MM" => false,
+        _ => return None,
+    };
+
+    let u16_at = |at: usize| -> Option<u16> {
+        let bytes: [u8; 2] = data.get(at..at + 2)?.try_into().ok()?;
+        Some(if little_endian {
+            u16::from_le_bytes(bytes)
+        } else {
+            u16::from_be_bytes(bytes)
+        })
+    };
+    let u32_at = |at: usize| -> Option<u32> {
+        let bytes: [u8; 4] = data.get(at..at + 4)?.try_into().ok()?;
+        Some(if little_endian {
+            u32::from_le_bytes(bytes)
+        } else {
+            u32::from_be_bytes(bytes)
+        })
+    };
+
+    if u16_at(2)? != 42 {
+        return None;
+    }
+
+    let ifd = u32_at(4)? as usize;
+    let entry_count = u16_at(ifd)? as usize;
+
+    let mut width = None;
+    let mut height = None;
+
+    for index in 0..entry_count {
+        let entry = ifd + 2 + index * IFD_ENTRY_SIZE;
+        let tag = u16_at(entry)?;
+        if tag != TAG_IMAGE_WIDTH && tag != TAG_IMAGE_LENGTH {
+            continue;
+        }
+
+        let field_type = u16_at(entry + 2)?;
+        // The count is required to be 1 for these tags; a value other than that
+        // means this is not the dimension field it appears to be. It is a
+        // 32-bit field, so reading it as 16 bits would see only the high half
+        // on a big-endian file and reject every one of them.
+        if u32_at(entry + 4)? != 1 {
+            return None;
+        }
+
+        // TIFF 6.0 § 2 stores a value narrower than four bytes left-justified
+        // in the value field, so a `SHORT` occupies the first two bytes under
+        // either byte order. Those two bytes are then decoded in the file's
+        // order; treating the field as a truncated `LONG` would give the right
+        // answer little-endian and zero big-endian.
+        let value = match (field_type, little_endian) {
+            (TYPE_SHORT, true) => u32::from(u16::from_le_bytes(
+                data.get(entry + 8..entry + 10)?.try_into().ok()?,
+            )),
+            (TYPE_SHORT, false) => u32::from(u16::from_be_bytes(
+                data.get(entry + 8..entry + 10)?.try_into().ok()?,
+            )),
+            (TYPE_LONG, _) => u32_at(entry + 8)?,
+            _ => return None,
+        };
+
+        if tag == TAG_IMAGE_WIDTH {
+            width = Some(value);
+        } else {
+            height = Some(value);
+        }
+    }
+
+    match (width, height) {
+        (Some(width), Some(height)) if width > 0 && height > 0 => {
+            Some((u64::from(width), u64::from(height)))
+        }
+        _ => None,
+    }
+}
+
 
 /// Read up to `limit` bytes from the front of `reader`.
 ///
@@ -1348,16 +1662,54 @@ mod limit_tests {
         assert!(width > 0 && height > 0, "got {width}x{height}");
     }
 
-    /// A format with no published side limit is not probed here; its ceiling is
-    /// the memory budget, which the decoder applies to the buffer it allocates.
+    /// A format with no published limit and no decoder ceiling is not probed;
+    /// its only bound is the memory budget, which the decoder applies to the
+    /// buffer it allocates.
     #[test]
     fn formats_without_a_side_limit_are_not_probed() {
-        let file = File::open("tests/files/png/f1t.png").unwrap();
+        let file = File::open("tests/files/jpg/f1t.jpg").unwrap();
 
         assert!(
-            probe_dimensions(file, rimage::limits::ImageFormatId::Png).is_none(),
-            "PNG has no published side limit, so there is nothing to pre-check"
+            probe_dimensions(file, rimage::limits::ImageFormatId::Tiff).is_none(),
+            "format identity alone must not imply a probe; TIFF is probed by \
+             its own reader but a JPEG body is not a TIFF"
         );
+    }
+
+    /// PNG dimensions are in the `IHDR` chunk, which the spec requires to come
+    /// first, so a short prefix settles them.
+    #[test]
+    fn a_png_header_probe_reads_the_real_dimensions() {
+        let file = File::open("tests/files/png/f1trgba.png").unwrap();
+
+        let (width, height) = probe_dimensions(file, rimage::limits::ImageFormatId::Png)
+            .expect("the fixture's IHDR must be readable");
+
+        assert!(width > 0 && height > 0, "got {width}x{height}");
+    }
+
+    /// A PNG whose first chunk is not `IHDR` is malformed, and its dimensions
+    /// must not be read from wherever a 16-byte window happens to land.
+    #[test]
+    fn a_png_without_a_leading_ihdr_is_not_probed() {
+        let mut data = vec![0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A];
+        data.extend_from_slice(&13u32.to_be_bytes());
+        data.extend_from_slice(b"IDAT");
+        data.extend_from_slice(&[0; 16]);
+
+        assert!(png_dimensions(&data).is_none());
+    }
+
+    /// A file that does not start with the PNG signature is not a PNG, whatever
+    /// else it holds.
+    #[test]
+    fn a_file_that_is_not_a_png_is_not_probed() {
+        let mut data = vec![0u8; 8];
+        data.extend_from_slice(&13u32.to_be_bytes());
+        data.extend_from_slice(b"IHDR");
+        data.extend_from_slice(&[0; 16]);
+
+        assert!(png_dimensions(&data).is_none());
     }
 
     /// WebP has a published 16383-per-side limit, so its header must be
@@ -1381,6 +1733,149 @@ mod limit_tests {
         let truncated = std::io::Cursor::new(vec![0xFF, 0xD8, 0xFF]);
 
         assert!(probe_dimensions(truncated, rimage::limits::ImageFormatId::Jpeg).is_none());
+    }
+
+    /// AVIF keeps its size in an ISO-BMFF property box rather than a header, so
+    /// the box walk is the only thing standing between an oversized file and
+    /// the decoder. A wrong answer here is worse than none, so the dimensions
+    /// are compared against the values `ispe` actually declares.
+    #[test]
+    fn an_avif_probe_reads_the_dimensions_from_the_ispe_box() {
+        let file = File::open("tests/files/avif/f1t.avif").unwrap();
+
+        let (width, height) = probe_dimensions(file, rimage::limits::ImageFormatId::Avif)
+            .expect("the fixture's ispe box must be reachable");
+
+        // The fixture is a real 48x80 image; these are the values its `ispe`
+        // box carries.
+        assert_eq!((width, height), (48, 80));
+    }
+
+    /// A byte sequence that merely looks like `ispe` must not be mistaken for
+    /// the property box. The walk keys off declared box sizes, so a file with
+    /// no `meta`/`iprp`/`ipco` chain yields nothing rather than a bogus size.
+    #[test]
+    fn an_avif_file_without_the_property_chain_is_not_probed() {
+        // A well-formed `ftyp` followed by bytes that spell `ispe` where no
+        // property box can legally appear.
+        let mut data = Vec::new();
+        data.extend_from_slice(&20u32.to_be_bytes());
+        data.extend_from_slice(b"ftyp");
+        data.extend_from_slice(b"avif");
+        data.extend_from_slice(&[0; 8]);
+        data.extend_from_slice(&20u32.to_be_bytes());
+        data.extend_from_slice(b"ispe");
+        data.extend_from_slice(&[0; 12]);
+
+        assert!(avif_dimensions(&data).is_none());
+    }
+
+    /// TIFF stores its dimensions in an IFD reached through an offset in the
+    /// header, so the tag walk has to follow that offset rather than scan.
+    #[test]
+    fn a_tiff_probe_reads_the_dimensions_from_the_ifd() {
+        let file = File::open("tests/files/tiff/f1t.tif").unwrap();
+
+        let (width, height) = probe_dimensions(file, rimage::limits::ImageFormatId::Tiff)
+            .expect("the fixture's IFD must be readable");
+
+        assert!(width > 0 && height > 0, "got {width}x{height}");
+    }
+
+    /// Build a minimal TIFF containing only the two dimension tags.
+    ///
+    /// `value_type` is the TIFF type code, so the same builder covers both the
+    /// `SHORT` and `LONG` encodings the specification allows here.
+    fn tiff_with_dimensions(
+        order: &[u8; 2], value_type: u16, width: u32, height: u32,
+    ) -> Vec<u8> {
+        let big = order == b"MM";
+        let mut file = Vec::new();
+        file.extend_from_slice(order);
+
+        let push_u16 = |file: &mut Vec<u8>, value: u16| {
+            let bytes = if big {
+                value.to_be_bytes()
+            } else {
+                value.to_le_bytes()
+            };
+            file.extend_from_slice(&bytes);
+        };
+        let push_u32 = |file: &mut Vec<u8>, value: u32| {
+            let bytes = if big {
+                value.to_be_bytes()
+            } else {
+                value.to_le_bytes()
+            };
+            file.extend_from_slice(&bytes);
+        };
+
+        push_u16(&mut file, 42);
+        push_u32(&mut file, 8);
+
+        // Two IFD entries, in tag order.
+        push_u16(&mut file, 2);
+        for (tag, value) in [(0x0100u16, width), (0x0101, height)] {
+            push_u16(&mut file, tag);
+            push_u16(&mut file, value_type);
+            push_u32(&mut file, 1);
+            // A `SHORT` is stored left-justified and padded; a `LONG` fills the
+            // whole value field.
+            if value_type == 3 {
+                push_u16(&mut file, value as u16);
+                push_u16(&mut file, 0);
+            } else {
+                push_u32(&mut file, value);
+            }
+        }
+
+        file
+    }
+
+    /// Both TIFF byte orders are in the wild, and both must be accepted. The
+    /// same tag values are written little-endian and big-endian here.
+    #[test]
+    fn a_tiff_probe_handles_both_byte_orders() {
+        assert_eq!(
+            tiff_dimensions(&tiff_with_dimensions(b"II", 4, 132_778, 5_000)),
+            Some((132_778, 5_000)),
+            "little-endian TIFF must be readable"
+        );
+        assert_eq!(
+            tiff_dimensions(&tiff_with_dimensions(b"MM", 4, 132_778, 5_000)),
+            Some((132_778, 5_000)),
+            "big-endian TIFF must be readable"
+        );
+    }
+
+    /// `SHORT` is the common encoding for small dimensions and is stored
+    /// left-justified in the four-byte value field, which is the one place a
+    /// big-endian file differs from a little-endian one.
+    #[test]
+    fn a_tiff_probe_reads_short_values() {
+        assert_eq!(
+            tiff_dimensions(&tiff_with_dimensions(b"II", 3, 640, 480)),
+            Some((640, 480)),
+            "little-endian SHORT must be readable"
+        );
+        assert_eq!(
+            tiff_dimensions(&tiff_with_dimensions(b"MM", 3, 640, 480)),
+            Some((640, 480)),
+            "big-endian SHORT must be readable"
+        );
+    }
+
+    /// A file whose magic number is wrong is not a TIFF, whatever else it
+    /// contains, and must not be reported as one.
+    #[test]
+    fn a_file_that_is_not_a_tiff_is_not_probed() {
+        let mut file = Vec::new();
+        file.extend_from_slice(b"XX");
+        file.extend_from_slice(&42u16.to_le_bytes());
+        file.extend_from_slice(&8u32.to_le_bytes());
+        file.extend_from_slice(&[0; 32]);
+
+        assert!(tiff_dimensions(&file).is_none());
     }
 
     /// An ordinary image on this machine must pass the pre-check, so the limit

--- a/src/cli/pipeline.rs
+++ b/src/cli/pipeline.rs
@@ -1,5 +1,8 @@
 use std::io::{Seek, SeekFrom};
-use std::{collections::BTreeMap, fs::File, io::Read, path::Path};
+use std::{collections::BTreeMap, fs::File, path::Path};
+
+#[cfg(feature = "avif")]
+use std::io::Read;
 
 #[cfg(feature = "resize")]
 use crate::cli::preprocessors::ResizeValue;
@@ -17,7 +20,7 @@ use rimage::codecs::svg::SvgDecoder;
 use rimage::codecs::svg::SvgOptions;
 #[cfg(feature = "webp")]
 use rimage::codecs::webp::WebPEncoder;
-use zune_core::{bytestream::ZByteWriterTrait, options::EncoderOptions};
+use zune_core::{bytestream::ZByteWriterTrait, options::DecoderOptions, options::EncoderOptions};
 use zune_image::{
     codecs::{
         ImageFormat, farbfeld::FarbFeldEncoder, jpeg::JpegEncoder, jpeg_xl::JxlEncoder,
@@ -30,21 +33,168 @@ use zune_image::{
 };
 use zune_imageprocs::premul_alpha::PremultiplyAlpha;
 
+/// Decoder options shared by every path in [`decode`].
+///
+/// The defaults are wrong for this program in one specific way: zune decodes
+/// *every* frame of an animated PNG or JXL. We only ever re-encode a single
+/// still image, and an animation holds one full-size buffer per frame, so
+/// decoding the frames we are about to discard is pure memory waste. Asking for
+/// the first frame only keeps peak memory proportional to one image.
+///
+/// The maximum dimensions are deliberately left at the library default rather
+/// than pinned to a constant here: the size limit is derived at runtime by
+/// `rimage::limits`, and hard-coding a second, different ceiling in this file
+/// would give the two a way to disagree.
+fn decode_options() -> DecoderOptions {
+    DecoderOptions::default()
+        .png_set_decode_animated(false)
+        .jxl_set_decode_animated(false)
+}
+
+/// Reject an image whose header declares dimensions the machine cannot hold.
+///
+/// This runs *before* any decoding so an oversized file fails with a message
+/// naming the ceiling instead of an allocation abort somewhere inside a codec.
+/// The header is all that is read, so the check costs a few kilobytes even for
+/// an image that is gigabytes when decoded.
+///
+/// Returns `Ok(())` when the format has no readable dimensions for us (an SVG
+/// render target, for instance, which is bounded separately) or when they fit.
+/// The failure is a [`RimageError`] rather than an [`ImageErrors`] because the
+/// violation is resolved here and would otherwise have to be re-parsed out of a
+/// string to be reported.
+#[cfg(feature = "limits")]
+fn check_input_limits(path: &Path) -> Result<(), rimage::error::RimageError> {
+    use rimage::limits::{ImageFormatId, LimitSet, PipelineCost, SystemBudget};
+
+    let extension = path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .unwrap_or_default();
+    let format = ImageFormatId::from_extension(extension);
+
+    // Only worth probing for formats we can size up front. Anything else is
+    // rejected later by the decoder or by the SVG point budget. A file that
+    // cannot even be opened is left for the decode step to report, so the
+    // missing-file message keeps coming from one place.
+    let Ok(reader) = File::open(path) else {
+        return Ok(());
+    };
+
+    let Some((width, height)) = probe_dimensions(reader, format) else {
+        return Ok(());
+    };
+
+    let budget = SystemBudget::probe(concurrency_from_env());
+    let limits = LimitSet::for_input(
+        format,
+        zune_core::bit_depth::BitDepth::Eight,
+        zune_core::colorspace::ColorSpace::RGB,
+        &budget,
+        PipelineCost::for_encoder(format),
+    );
+
+    limits
+        .check(width, height)
+        .map_err(|violation| {
+            rimage::error::input_size_limit(path, format, Some((width, height)), violation)
+        })
+}
+
+/// Read just the dimensions from an image header.
+///
+/// Only JPEG is handled here. It is the format with a published per-side limit
+/// that a header read can settle cheaply, and it is the one the task names for
+/// the extreme case. Other formats are bounded by memory alone, which the
+/// decoders enforce on the buffer they actually allocate; probing their headers
+/// here would duplicate that check without adding a format limit.
+#[cfg(feature = "limits")]
+fn probe_dimensions<R: std::io::Read>(
+    mut reader: R, format: rimage::limits::ImageFormatId,
+) -> Option<(u64, u64)> {
+    use rimage::limits::ImageFormatId;
+    use zune_core::bytestream::ZCursor;
+
+    match format {
+        ImageFormatId::Jpeg => {
+            // A JPEG header sits at the front of the file, so only a prefix is
+            // needed. Reading a bounded prefix rather than the whole file is
+            // what keeps rejecting an oversized input cheap.
+            let mut prefix = vec![0u8; JPEG_HEADER_PROBE_BYTES];
+            let mut filled = 0;
+            while filled < prefix.len() {
+                match reader.read(&mut prefix[filled..]) {
+                    Ok(0) => break,
+                    Ok(read) => filled += read,
+                    Err(_) => return None,
+                }
+            }
+            prefix.truncate(filled);
+
+            let mut decoder =
+                zune_image::codecs::jpeg::JpegDecoder::new(ZCursor::new(prefix));
+            decoder.decode_headers().ok()?;
+            let (width, height) = decoder.dimensions()?;
+            Some((width as u64, height as u64))
+        }
+        _ => None,
+    }
+}
+
+/// Bytes of a file read to recover a JPEG frame header.
+///
+/// The frame header follows the application segments (EXIF, ICC, XMP), which
+/// can be large but are almost never larger than this. A file whose header
+/// falls beyond the prefix simply is not pre-checked, and the decoder reports
+/// the problem instead.
+#[cfg(feature = "limits")]
+const JPEG_HEADER_PROBE_BYTES: usize = 64 * 1024;
+
+/// The concurrency the pipeline will actually use, read from the same argument
+/// the worker pool is sized from.
+///
+/// Defaults to 1, matching `--threads`.
+#[cfg(feature = "limits")]
+fn concurrency_from_env() -> usize {
+    std::env::var("RIMAGE_THREADS")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .filter(|threads| *threads > 0)
+        .unwrap_or(1)
+}
+
 #[allow(unused_variables)]
 #[allow(unused_mut)]
-pub fn decode<P: AsRef<Path>>(f: P, matches: &ArgMatches) -> Result<Image, ImageErrors> {
-    Image::open(f.as_ref()).or_else(|e| {
+pub fn decode<P: AsRef<Path>>(f: P, matches: &ArgMatches) -> Result<Image, rimage::error::RimageError> {
+    // The size pre-check already knows which ceiling it broke, so it produces
+    // the structured error directly instead of round-tripping through a string.
+    #[cfg(feature = "limits")]
+    check_input_limits(f.as_ref())?;
+
+    Image::open_with_options(f.as_ref(), decode_options())
+        .or_else(|e| decode_with_fallback(f.as_ref(), matches, e))
+        .map_err(|e| classify_decode_failure(f.as_ref(), matches, &e))
+}
+
+/// Retry the decode with the decoders `zune_image` does not own.
+///
+/// Split out of [`decode`] so the fallback chain stays readable and so the
+/// conversion to [`rimage::error::RimageError`] happens in exactly one place.
+fn decode_with_fallback(
+    path: &Path, matches: &ArgMatches, e: ImageErrors,
+) -> Result<Image, ImageErrors> {
+    {
         if matches!(e, ImageErrors::ImageDecoderNotImplemented(_)) {
             #[cfg(any(feature = "avif", feature = "webp", feature = "svg"))]
-            let mut file = File::open(f.as_ref())?;
+            let mut file = File::open(path)?;
 
             #[cfg(feature = "svg")]
             {
-                if f.as_ref()
+                if path
                     .extension()
                     .is_some_and(|f| f.eq_ignore_ascii_case("svg") | f.eq_ignore_ascii_case("svgz"))
                 {
-                    let resources_dir = f.as_ref().parent().map(Path::to_path_buf);
+                    let resources_dir = path.parent().map(Path::to_path_buf);
 
                     #[cfg(feature = "resize")]
                     let decoder = SvgDecoder::try_new_with_resize(file, resources_dir, |size| {
@@ -57,6 +207,7 @@ pub fn decode<P: AsRef<Path>>(f: P, matches: &ArgMatches) -> Result<Image, Image
                         SvgOptions {
                             resources_dir,
                             target_size: None,
+                            pixel_budget: None,
                         },
                     )?;
 
@@ -85,13 +236,13 @@ pub fn decode<P: AsRef<Path>>(f: P, matches: &ArgMatches) -> Result<Image, Image
 
             #[cfg(feature = "webp")]
             {
-                if f.as_ref()
+                if path
                     .extension()
                     .is_some_and(|f| f.eq_ignore_ascii_case("webp"))
                 {
                     use rimage::codecs::webp::WebPDecoder;
 
-                    let decoder = WebPDecoder::try_new(file)?;
+                    let decoder = WebPDecoder::try_new_with_options(file, decode_options())?;
 
                     return Image::from_decoder(decoder);
                 }
@@ -101,7 +252,7 @@ pub fn decode<P: AsRef<Path>>(f: P, matches: &ArgMatches) -> Result<Image, Image
 
             #[cfg(feature = "tiff")]
             {
-                if f.as_ref()
+                if path
                     .extension()
                     .is_some_and(|f| f.eq_ignore_ascii_case("tiff") | f.eq_ignore_ascii_case("tif"))
                 {
@@ -115,13 +266,53 @@ pub fn decode<P: AsRef<Path>>(f: P, matches: &ArgMatches) -> Result<Image, Image
                 file.seek(SeekFrom::Start(0))?;
             }
 
-            Err(ImageErrors::ImageDecoderNotImplemented(
+            return Err(ImageErrors::ImageDecoderNotImplemented(
                 ImageFormat::Unknown,
-            ))
-        } else {
-            Err(e)
+            ));
         }
+
+        Err(e)
+    }
+}
+
+/// Turn a decode failure into the structured, side-tagged form the CLI reports.
+///
+/// The resize context is deliberately not reconstructed here. `classify_input`
+/// uses it only to name the requested dimensions in an
+/// `ImageOperationNotImplemented("resize")` failure, and the only resize
+/// failures reachable at decode time are the SVG render-target ones, whose
+/// message already names the offending size. Passing `None` keeps this
+/// function honest instead of inventing a reason it did not observe; the
+/// classification still reports it as an input failure on the right format.
+fn classify_decode_failure(
+    path: &Path, _matches: &ArgMatches, error: &ImageErrors,
+) -> rimage::error::RimageError {
+    use rimage::error::{InputError, RimageError, classify_input};
+
+    classify_input(path, error, None).unwrap_or_else(|| {
+        RimageError::Input(InputError::Decode {
+            path: path.to_path_buf(),
+            format: rimage::limits::ImageFormatId::from_extension(
+                path.extension()
+                    .and_then(|ext| ext.to_str())
+                    .unwrap_or_default(),
+            ),
+            cause: clone_for_report(error),
+        })
     })
+}
+
+/// Rebuild an [`ImageErrors`] so it can be stored in a reported error.
+///
+/// `ImageErrors` has no `Clone`, and the message only ever renders it, so the
+/// text is enough to reproduce it.
+fn clone_for_report(error: &ImageErrors) -> ImageErrors {
+    match error {
+        ImageErrors::ImageDecodeErrors(text) => ImageErrors::ImageDecodeErrors(text.clone()),
+        ImageErrors::GenericString(text) => ImageErrors::GenericString(text.clone()),
+        ImageErrors::IoError(io) => ImageErrors::IoError(std::io::Error::new(io.kind(), io.to_string())),
+        other => ImageErrors::GenericString(other.to_string()),
+    }
 }
 
 #[cfg(all(feature = "svg", feature = "resize"))]
@@ -434,6 +625,7 @@ impl AvailableEncoders {
             AvailableEncoders::JpegXl(enc) => enc.encode(img, sink),
             AvailableEncoders::MozJpeg(enc) => enc.encode(img, sink),
             AvailableEncoders::OxiPng(enc) => enc.encode(img, sink),
+            #[cfg(feature = "avif")]
             AvailableEncoders::Avif(enc) => enc.encode(img, sink),
             AvailableEncoders::Webp(enc) => enc.encode(img, sink),
             AvailableEncoders::Png(enc) => enc.encode(img, sink),
@@ -1043,5 +1235,58 @@ mod tests {
         fn oversized_dimensions_are_rejected() {
             assert!(target_size(&["--resize", "4294967396x4294967396"]).is_err());
         }
+    }
+}
+
+#[cfg(all(test, feature = "limits"))]
+mod limit_tests {
+    use super::*;
+
+    /// A JPEG header probe must recover the real dimensions from an ordinary
+    /// file, or the pre-check would silently never fire.
+    #[test]
+    fn a_jpeg_header_probe_reads_the_real_dimensions() {
+        let file = File::open("tests/files/jpg/f1t.jpg").unwrap();
+
+        let probed = probe_dimensions(file, rimage::limits::ImageFormatId::Jpeg);
+
+        let (width, height) = probed.expect("the fixture's header must be readable");
+        assert!(width > 0 && height > 0, "got {width}x{height}");
+    }
+
+    /// A format with no published side limit is not probed here; its ceiling is
+    /// the memory budget, which the decoder applies to the buffer it allocates.
+    #[test]
+    fn formats_without_a_side_limit_are_not_probed() {
+        let file = File::open("tests/files/png/f1t.png").unwrap();
+
+        assert!(
+            probe_dimensions(file, rimage::limits::ImageFormatId::Png).is_none(),
+            "PNG has no published side limit, so there is nothing to pre-check"
+        );
+    }
+
+    /// A file too short to contain a frame header must be reported as
+    /// unprobeable rather than as an error, so decoding still gets its chance.
+    #[test]
+    fn a_truncated_header_is_not_an_error() {
+        let truncated = std::io::Cursor::new(vec![0xFF, 0xD8, 0xFF]);
+
+        assert!(probe_dimensions(truncated, rimage::limits::ImageFormatId::Jpeg).is_none());
+    }
+
+    /// An ordinary image on this machine must pass the pre-check, so the limit
+    /// does not reject files the program is expected to handle.
+    #[test]
+    fn an_ordinary_image_passes_the_pre_check() {
+        check_input_limits(Path::new("tests/files/jpg/f1t.jpg"))
+            .expect("an ordinary fixture must not be rejected");
+    }
+
+    /// A path that does not exist is left for the decoder to report, rather
+    /// than being turned into a size error here.
+    #[test]
+    fn a_missing_file_is_not_a_size_error() {
+        assert!(check_input_limits(Path::new("tests/files/does-not-exist.jpg")).is_ok());
     }
 }

--- a/src/cli/pipeline.rs
+++ b/src/cli/pipeline.rs
@@ -902,17 +902,19 @@ pub fn operations(
                     // log a warning and skip the un-premultiply insertion
                     // rather than aborting the process (which would happen
                     // with `assert!` under `panic = "abort"` in release).
-                    if map.contains_key(&(idx + 3)) {
-                        log::warn!(
-                            "premultiply at index {idx}: position {} already occupied, \
-                             skipping un-premultiply step",
-                            idx + 3
-                        );
-                    } else {
-                        map.insert(
-                            idx + 3,
-                            Box::new(PremultiplyAlpha::new(AlphaState::NonPreMultiplied)),
-                        );
+                    match map.entry(idx + 3) {
+                        std::collections::btree_map::Entry::Occupied(_) => {
+                            log::warn!(
+                                "premultiply at index {idx}: position {} already occupied, \
+                                 skipping un-premultiply step",
+                                idx + 3
+                            );
+                        }
+                        std::collections::btree_map::Entry::Vacant(slot) => {
+                            slot.insert(Box::new(PremultiplyAlpha::new(
+                                AlphaState::NonPreMultiplied,
+                            )));
+                        }
                     }
                 } else {
                     log::warn!("No operation found for premultiply at index {idx}")

--- a/src/cli/pipeline.rs
+++ b/src/cli/pipeline.rs
@@ -456,7 +456,7 @@ pub fn encoder(name: &str, matches: &ArgMatches) -> Result<AvailableEncoders, Im
                     .unwrap_or("ycbcr")
                 {
                     "ycbcr" => mozjpeg::ColorSpace::JCS_YCbCr,
-                    "rgb" => mozjpeg::ColorSpace::JCS_EXT_RGB,
+                    "rgb" => mozjpeg::ColorSpace::JCS_RGB,
                     "grayscale" => mozjpeg::ColorSpace::JCS_GRAYSCALE,
                     cs => {
                         return Err(ImageErrors::GenericString(format!(

--- a/src/cli/pipeline.rs
+++ b/src/cli/pipeline.rs
@@ -682,32 +682,7 @@ fn decode_with_fallback(
 fn classify_decode_failure(
     path: &Path, _matches: &ArgMatches, error: &ImageErrors,
 ) -> rimage::error::RimageError {
-    use rimage::error::{InputError, RimageError, classify_input};
-
-    classify_input(path, error, None).unwrap_or_else(|| {
-        RimageError::Input(InputError::Decode {
-            path: path.to_path_buf(),
-            format: rimage::limits::ImageFormatId::from_extension(
-                path.extension()
-                    .and_then(|ext| ext.to_str())
-                    .unwrap_or_default(),
-            ),
-            cause: clone_for_report(error),
-        })
-    })
-}
-
-/// Rebuild an [`ImageErrors`] so it can be stored in a reported error.
-///
-/// `ImageErrors` has no `Clone`, and the message only ever renders it, so the
-/// text is enough to reproduce it.
-fn clone_for_report(error: &ImageErrors) -> ImageErrors {
-    match error {
-        ImageErrors::ImageDecodeErrors(text) => ImageErrors::ImageDecodeErrors(text.clone()),
-        ImageErrors::GenericString(text) => ImageErrors::GenericString(text.clone()),
-        ImageErrors::IoError(io) => ImageErrors::IoError(std::io::Error::new(io.kind(), io.to_string())),
-        other => ImageErrors::GenericString(other.to_string()),
-    }
+    rimage::error::classify_input(path, error, None)
 }
 
 #[cfg(all(feature = "svg", feature = "resize"))]

--- a/src/cli/pipeline.rs
+++ b/src/cli/pipeline.rs
@@ -517,7 +517,7 @@ const WEBP_HEADER_PROBE_BYTES: usize = 64 * 1024;
 #[cfg(feature = "limits")]
 fn concurrency_from_env(matches: &ArgMatches) -> usize {
     matches
-        .get_one::<u8>("threads")
+        .get_one::<u16>("threads")
         .copied()
         .map(|threads| threads as usize)
         .filter(|threads| *threads > 0)

--- a/src/cli/pipeline.rs
+++ b/src/cli/pipeline.rs
@@ -60,12 +60,9 @@ fn decode_options() -> DecoderOptions {
 ///
 /// Returns `Ok(())` when the format has no readable dimensions for us (an SVG
 /// render target, for instance, which is bounded separately) or when they fit.
-/// The failure is a [`RimageError`] rather than an [`ImageErrors`] because the
-/// violation is resolved here and would otherwise have to be re-parsed out of a
-/// string to be reported.
 #[cfg(feature = "limits")]
-fn check_input_limits(path: &Path) -> Result<(), rimage::error::RimageError> {
-    use rimage::limits::{ImageFormatId, LimitSet, PipelineCost, SystemBudget};
+fn check_input_limits(path: &Path) -> Result<(), ImageErrors> {
+    use rimage::limits::{ImageFormatId, LimitSet, PipelineCost, SystemBudget, ViolationKind};
 
     let extension = path
         .extension()
@@ -74,9 +71,7 @@ fn check_input_limits(path: &Path) -> Result<(), rimage::error::RimageError> {
     let format = ImageFormatId::from_extension(extension);
 
     // Only worth probing for formats we can size up front. Anything else is
-    // rejected later by the decoder or by the SVG point budget. A file that
-    // cannot even be opened is left for the decode step to report, so the
-    // missing-file message keeps coming from one place.
+    // rejected later by the decoder or by the SVG point budget.
     let Ok(reader) = File::open(path) else {
         return Ok(());
     };
@@ -94,11 +89,28 @@ fn check_input_limits(path: &Path) -> Result<(), rimage::error::RimageError> {
         PipelineCost::for_encoder(format),
     );
 
-    limits
-        .check(width, height)
-        .map_err(|violation| {
-            rimage::error::input_size_limit(path, format, Some((width, height)), violation)
-        })
+    match limits.check(width, height) {
+        Ok(()) => Ok(()),
+        Err(violation) => {
+            let measured = match violation.kind {
+                ViolationKind::Width => "width",
+                ViolationKind::Height => "height",
+                ViolationKind::Pixels => "pixel count",
+            };
+
+            // A concrete target is more useful than restating the limit.
+            let side = limits.suggested_side();
+
+            Err(ImageErrors::ImageDecodeErrors(format!(
+                "{} is {width}x{height} ({measured} {}), which exceeds the limit of {} \
+                 (from {}); the largest square that fits is {side}x{side}",
+                path.display(),
+                violation.actual,
+                violation.allowed,
+                violation.binding.describe(),
+            )))
+        }
+    }
 }
 
 /// Read just the dimensions from an image header.
@@ -165,36 +177,22 @@ fn concurrency_from_env() -> usize {
 
 #[allow(unused_variables)]
 #[allow(unused_mut)]
-pub fn decode<P: AsRef<Path>>(f: P, matches: &ArgMatches) -> Result<Image, rimage::error::RimageError> {
-    // The size pre-check already knows which ceiling it broke, so it produces
-    // the structured error directly instead of round-tripping through a string.
+pub fn decode<P: AsRef<Path>>(f: P, matches: &ArgMatches) -> Result<Image, ImageErrors> {
     #[cfg(feature = "limits")]
     check_input_limits(f.as_ref())?;
 
-    Image::open_with_options(f.as_ref(), decode_options())
-        .or_else(|e| decode_with_fallback(f.as_ref(), matches, e))
-        .map_err(|e| classify_decode_failure(f.as_ref(), matches, &e))
-}
-
-/// Retry the decode with the decoders `zune_image` does not own.
-///
-/// Split out of [`decode`] so the fallback chain stays readable and so the
-/// conversion to [`rimage::error::RimageError`] happens in exactly one place.
-fn decode_with_fallback(
-    path: &Path, matches: &ArgMatches, e: ImageErrors,
-) -> Result<Image, ImageErrors> {
-    {
+    Image::open_with_options(f.as_ref(), decode_options()).or_else(|e| {
         if matches!(e, ImageErrors::ImageDecoderNotImplemented(_)) {
             #[cfg(any(feature = "avif", feature = "webp", feature = "svg"))]
-            let mut file = File::open(path)?;
+            let mut file = File::open(f.as_ref())?;
 
             #[cfg(feature = "svg")]
             {
-                if path
+                if f.as_ref()
                     .extension()
                     .is_some_and(|f| f.eq_ignore_ascii_case("svg") | f.eq_ignore_ascii_case("svgz"))
                 {
-                    let resources_dir = path.parent().map(Path::to_path_buf);
+                    let resources_dir = f.as_ref().parent().map(Path::to_path_buf);
 
                     #[cfg(feature = "resize")]
                     let decoder = SvgDecoder::try_new_with_resize(file, resources_dir, |size| {
@@ -236,7 +234,7 @@ fn decode_with_fallback(
 
             #[cfg(feature = "webp")]
             {
-                if path
+                if f.as_ref()
                     .extension()
                     .is_some_and(|f| f.eq_ignore_ascii_case("webp"))
                 {
@@ -252,7 +250,7 @@ fn decode_with_fallback(
 
             #[cfg(feature = "tiff")]
             {
-                if path
+                if f.as_ref()
                     .extension()
                     .is_some_and(|f| f.eq_ignore_ascii_case("tiff") | f.eq_ignore_ascii_case("tif"))
                 {
@@ -266,131 +264,13 @@ fn decode_with_fallback(
                 file.seek(SeekFrom::Start(0))?;
             }
 
-            return Err(ImageErrors::ImageDecoderNotImplemented(
+            Err(ImageErrors::ImageDecoderNotImplemented(
                 ImageFormat::Unknown,
-            ));
+            ))
+        } else {
+            Err(e)
         }
-
-        Err(e)
-    }
-}
-
-/// Turn a decode failure into the structured, side-tagged form the CLI reports.
-///
-/// The resize context is deliberately not reconstructed here. `classify_input`
-/// uses it only to name the requested dimensions in an
-/// `ImageOperationNotImplemented("resize")` failure, and the only resize
-/// failures reachable at decode time are the SVG render-target ones, whose
-/// message already names the offending size. Passing `None` keeps this
-/// function honest instead of inventing a reason it did not observe; the
-/// classification still reports it as an input failure on the right format.
-fn classify_decode_failure(
-    path: &Path, _matches: &ArgMatches, error: &ImageErrors,
-) -> rimage::error::RimageError {
-    use rimage::error::{InputError, RimageError, classify_input};
-
-    classify_input(path, error, None).unwrap_or_else(|| {
-        RimageError::Input(InputError::Decode {
-            path: path.to_path_buf(),
-            format: rimage::limits::ImageFormatId::from_extension(
-                path.extension()
-                    .and_then(|ext| ext.to_str())
-                    .unwrap_or_default(),
-            ),
-            cause: clone_for_report(error),
-        })
     })
-}
-
-/// Rebuild an [`ImageErrors`] so it can be stored in a reported error.
-///
-/// `ImageErrors` has no `Clone`, and the message only ever renders it, so the
-/// text is enough to reproduce it.
-fn clone_for_report(error: &ImageErrors) -> ImageErrors {
-    match error {
-        ImageErrors::ImageDecodeErrors(text) => ImageErrors::ImageDecodeErrors(text.clone()),
-        ImageErrors::GenericString(text) => ImageErrors::GenericString(text.clone()),
-        ImageErrors::IoError(io) => ImageErrors::IoError(std::io::Error::new(io.kind(), io.to_string())),
-        other => ImageErrors::GenericString(other.to_string()),
-    }
-}
-
-#[cfg(all(feature = "svg", feature = "resize"))]
-fn svg_target_size(
-    matches: &ArgMatches,
-    size: (usize, usize),
-) -> Result<Option<(u32, u32)>, ImageErrors> {
-    use crate::cli::preprocessors::ResizeValue;
-
-    let Some(values) = matches.get_many::<ResizeValue>("resize") else {
-        return Ok(None);
-    };
-
-    let downscale = matches.get_flag("downscale") && !matches.get_flag("no-downscale");
-    let upscale = matches.get_flag("upscale") && !matches.get_flag("no-upscale");
-
-    let first_other = first_other_index(matches);
-    let plan = resize_plan(
-        values
-            .into_iter()
-            .zip(matches.indices_of("resize").unwrap())
-            .map(|(value, idx)| (idx, value))
-            .take_while(|(idx, _)| *idx < first_other),
-        size,
-        downscale,
-        upscale,
-    );
-
-    if plan.is_empty() {
-        return Ok(None);
-    }
-
-    let final_size = plan.last().map(|(_, size)| *size).unwrap_or(size);
-    let width = u32::try_from(final_size.0).map_err(|_| {
-        ImageErrors::ImageDecodeErrors(format!(
-            "SVG target width {} exceeds the maximum supported dimension of {}",
-            final_size.0,
-            u32::MAX
-        ))
-    })?;
-    let height = u32::try_from(final_size.1).map_err(|_| {
-        ImageErrors::ImageDecodeErrors(format!(
-            "SVG target height {} exceeds the maximum supported dimension of {}",
-            final_size.1,
-            u32::MAX
-        ))
-    })?;
-
-    Ok(Some((width, height)))
-}
-
-/// Returns the index of the first non-resize preprocessing element.
-///
-/// SVG vector resizing can only be folded into the decode render target for
-/// the resize steps that come before every quantization operation and before
-/// every true `--premultiply` flag. Steps at or after this index must run as
-/// ordinary raster resize operations so command-line order is preserved.
-#[cfg(feature = "resize")]
-fn first_other_index(matches: &ArgMatches) -> usize {
-    let first_premultiply = matches.get_many::<bool>("premultiply").and_then(|values| {
-        values
-            .into_iter()
-            .zip(matches.indices_of("premultiply")?)
-            .find_map(|(value, idx)| if *value { Some(idx) } else { None })
-    });
-
-    #[cfg(feature = "quantization")]
-    let first_quantization = matches
-        .indices_of("quantization")
-        .and_then(|mut indices| indices.next());
-    #[cfg(not(feature = "quantization"))]
-    let first_quantization: Option<usize> = None;
-
-    [first_premultiply, first_quantization]
-        .into_iter()
-        .flatten()
-        .min()
-        .unwrap_or(usize::MAX)
 }
 
 /// Plans a chain of resize operations, returning only the steps that are not

--- a/src/cli/pipeline.rs
+++ b/src/cli/pipeline.rs
@@ -1,3 +1,4 @@
+#[cfg(any(feature = "avif", feature = "webp", feature = "svg", feature = "tiff"))]
 use std::io::{Seek, SeekFrom};
 use std::{collections::BTreeMap, fs::File, path::Path};
 
@@ -573,12 +574,13 @@ fn svg_pixel_budget(matches: &ArgMatches) -> Option<u64> {
 ///
 /// Split out of [`decode`] so the fallback chain stays readable and so the
 /// conversion to [`rimage::error::RimageError`] happens in exactly one place.
+#[allow(unused_variables)]
 fn decode_with_fallback(
     path: &Path, matches: &ArgMatches, e: ImageErrors,
 ) -> Result<Image, ImageErrors> {
     {
         if matches!(e, ImageErrors::ImageDecoderNotImplemented(_)) {
-            #[cfg(any(feature = "avif", feature = "webp", feature = "svg"))]
+            #[cfg(any(feature = "avif", feature = "webp", feature = "svg", feature = "tiff"))]
             let mut file = File::open(path)?;
 
             #[cfg(feature = "svg")]
@@ -1001,10 +1003,13 @@ impl AvailableEncoders {
             AvailableEncoders::FarbFeld(enc) => enc.encode(img, sink),
             AvailableEncoders::Jpeg(enc) => enc.encode(img, sink),
             AvailableEncoders::JpegXl(enc) => enc.encode(img, sink),
+            #[cfg(feature = "mozjpeg")]
             AvailableEncoders::MozJpeg(enc) => enc.encode(img, sink),
+            #[cfg(feature = "oxipng")]
             AvailableEncoders::OxiPng(enc) => enc.encode(img, sink),
             #[cfg(feature = "avif")]
             AvailableEncoders::Avif(enc) => enc.encode(img, sink),
+            #[cfg(feature = "webp")]
             AvailableEncoders::Webp(enc) => enc.encode(img, sink),
             AvailableEncoders::Png(enc) => enc.encode(img, sink),
             AvailableEncoders::Ppm(enc) => enc.encode(img, sink),

--- a/src/cli/pipeline.rs
+++ b/src/cli/pipeline.rs
@@ -728,7 +728,7 @@ fn svg_target_size(
     let plan = resize_plan(
         values
             .into_iter()
-            .zip(matches.indices_of("resize").unwrap())
+            .zip(matches.indices_of("resize").into_iter().flatten())
             .map(|(value, idx)| (idx, value))
             .take_while(|(idx, _)| *idx < first_other),
         size,
@@ -858,7 +858,7 @@ pub fn operations(
             let plan = resize_plan(
                 values
                     .into_iter()
-                    .zip(matches.indices_of("resize").unwrap())
+                    .zip(matches.indices_of("resize").into_iter().flatten())
                     .map(|(value, idx)| (idx, value))
                     .filter(|(idx, _)| !skip_resize || *idx >= first_other),
                 img.dimensions(),
@@ -891,7 +891,7 @@ pub fn operations(
 
             values
                 .into_iter()
-                .zip(matches.indices_of("quantization").unwrap())
+                .zip(matches.indices_of("quantization").into_iter().flatten())
                 .for_each(|(value, idx)| {
                     log::trace!("setup quantization {value} on index {idx}");
 
@@ -906,7 +906,7 @@ pub fn operations(
     if let Some(values) = matches.get_many::<bool>("premultiply") {
         values
             .into_iter()
-            .zip(matches.indices_of("premultiply").unwrap())
+            .zip(matches.indices_of("premultiply").into_iter().flatten())
             .for_each(|(value, idx)| {
                 // Position-sensitive flags inject a trailing default `false`
                 // occurrence when the flag is absent from the command line,
@@ -1551,7 +1551,7 @@ mod tests {
             .map(|(idx, _)| *idx)
             .collect();
 
-        let expected: Vec<usize> = matches.indices_of("resize").unwrap().skip(1).collect();
+        let expected: Vec<usize> = matches.indices_of("resize").into_iter().flatten().skip(1).collect();
         assert_eq!(resize_indices, expected);
     }
 

--- a/src/cli/pipeline.rs
+++ b/src/cli/pipeline.rs
@@ -3,6 +3,7 @@ use std::{collections::BTreeMap, fs::File, io::Read, path::Path};
 
 #[cfg(feature = "resize")]
 use crate::cli::preprocessors::ResizeValue;
+use crate::cli::utils::jpeg::JfifDensity;
 use clap::ArgMatches;
 #[cfg(feature = "avif")]
 use rimage::codecs::avif::AvifEncoder;
@@ -389,6 +390,36 @@ impl AvailableEncoders {
             AvailableEncoders::Png(_) => "png",
             AvailableEncoders::Ppm(_) => "ppm",
             AvailableEncoders::Qoi(_) => "qoi",
+        }
+    }
+
+    pub fn set_jfif_density(&mut self, density: Option<JfifDensity>) {
+        #[cfg(feature = "mozjpeg")]
+        {
+            let Some(density) = density else {
+                return;
+            };
+
+            if let AvailableEncoders::MozJpeg(encoder) = self {
+                use mozjpeg::{PixelDensity, PixelDensityUnit};
+
+                let unit = match density.unit {
+                    0 => PixelDensityUnit::PixelAspectRatio,
+                    1 => PixelDensityUnit::Inches,
+                    2 => PixelDensityUnit::Centimeters,
+                    _ => return,
+                };
+
+                encoder.set_pixel_density(PixelDensity {
+                    unit,
+                    x: density.x_density,
+                    y: density.y_density,
+                });
+            }
+        }
+        #[cfg(not(feature = "mozjpeg"))]
+        {
+            let _ = density;
         }
     }
 

--- a/src/cli/pipeline.rs
+++ b/src/cli/pipeline.rs
@@ -60,9 +60,12 @@ fn decode_options() -> DecoderOptions {
 ///
 /// Returns `Ok(())` when the format has no readable dimensions for us (an SVG
 /// render target, for instance, which is bounded separately) or when they fit.
+/// The failure is a [`RimageError`] rather than an [`ImageErrors`] because the
+/// violation is resolved here and would otherwise have to be re-parsed out of a
+/// string to be reported.
 #[cfg(feature = "limits")]
-fn check_input_limits(path: &Path) -> Result<(), ImageErrors> {
-    use rimage::limits::{ImageFormatId, LimitSet, PipelineCost, SystemBudget, ViolationKind};
+fn check_input_limits(path: &Path) -> Result<(), rimage::error::RimageError> {
+    use rimage::limits::{ImageFormatId, LimitSet, PipelineCost, SystemBudget};
 
     let extension = path
         .extension()
@@ -71,7 +74,9 @@ fn check_input_limits(path: &Path) -> Result<(), ImageErrors> {
     let format = ImageFormatId::from_extension(extension);
 
     // Only worth probing for formats we can size up front. Anything else is
-    // rejected later by the decoder or by the SVG point budget.
+    // rejected later by the decoder or by the SVG point budget. A file that
+    // cannot even be opened is left for the decode step to report, so the
+    // missing-file message keeps coming from one place.
     let Ok(reader) = File::open(path) else {
         return Ok(());
     };
@@ -89,28 +94,11 @@ fn check_input_limits(path: &Path) -> Result<(), ImageErrors> {
         PipelineCost::for_encoder(format),
     );
 
-    match limits.check(width, height) {
-        Ok(()) => Ok(()),
-        Err(violation) => {
-            let measured = match violation.kind {
-                ViolationKind::Width => "width",
-                ViolationKind::Height => "height",
-                ViolationKind::Pixels => "pixel count",
-            };
-
-            // A concrete target is more useful than restating the limit.
-            let side = limits.suggested_side();
-
-            Err(ImageErrors::ImageDecodeErrors(format!(
-                "{} is {width}x{height} ({measured} {}), which exceeds the limit of {} \
-                 (from {}); the largest square that fits is {side}x{side}",
-                path.display(),
-                violation.actual,
-                violation.allowed,
-                violation.binding.describe(),
-            )))
-        }
-    }
+    limits
+        .check(width, height)
+        .map_err(|violation| {
+            rimage::error::input_size_limit(path, format, Some((width, height)), violation)
+        })
 }
 
 /// Read just the dimensions from an image header.
@@ -177,22 +165,36 @@ fn concurrency_from_env() -> usize {
 
 #[allow(unused_variables)]
 #[allow(unused_mut)]
-pub fn decode<P: AsRef<Path>>(f: P, matches: &ArgMatches) -> Result<Image, ImageErrors> {
+pub fn decode<P: AsRef<Path>>(f: P, matches: &ArgMatches) -> Result<Image, rimage::error::RimageError> {
+    // The size pre-check already knows which ceiling it broke, so it produces
+    // the structured error directly instead of round-tripping through a string.
     #[cfg(feature = "limits")]
     check_input_limits(f.as_ref())?;
 
-    Image::open_with_options(f.as_ref(), decode_options()).or_else(|e| {
+    Image::open_with_options(f.as_ref(), decode_options())
+        .or_else(|e| decode_with_fallback(f.as_ref(), matches, e))
+        .map_err(|e| classify_decode_failure(f.as_ref(), matches, &e))
+}
+
+/// Retry the decode with the decoders `zune_image` does not own.
+///
+/// Split out of [`decode`] so the fallback chain stays readable and so the
+/// conversion to [`rimage::error::RimageError`] happens in exactly one place.
+fn decode_with_fallback(
+    path: &Path, matches: &ArgMatches, e: ImageErrors,
+) -> Result<Image, ImageErrors> {
+    {
         if matches!(e, ImageErrors::ImageDecoderNotImplemented(_)) {
             #[cfg(any(feature = "avif", feature = "webp", feature = "svg"))]
-            let mut file = File::open(f.as_ref())?;
+            let mut file = File::open(path)?;
 
             #[cfg(feature = "svg")]
             {
-                if f.as_ref()
+                if path
                     .extension()
                     .is_some_and(|f| f.eq_ignore_ascii_case("svg") | f.eq_ignore_ascii_case("svgz"))
                 {
-                    let resources_dir = f.as_ref().parent().map(Path::to_path_buf);
+                    let resources_dir = path.parent().map(Path::to_path_buf);
 
                     #[cfg(feature = "resize")]
                     let decoder = SvgDecoder::try_new_with_resize(file, resources_dir, |size| {
@@ -234,7 +236,7 @@ pub fn decode<P: AsRef<Path>>(f: P, matches: &ArgMatches) -> Result<Image, Image
 
             #[cfg(feature = "webp")]
             {
-                if f.as_ref()
+                if path
                     .extension()
                     .is_some_and(|f| f.eq_ignore_ascii_case("webp"))
                 {
@@ -250,7 +252,7 @@ pub fn decode<P: AsRef<Path>>(f: P, matches: &ArgMatches) -> Result<Image, Image
 
             #[cfg(feature = "tiff")]
             {
-                if f.as_ref()
+                if path
                     .extension()
                     .is_some_and(|f| f.eq_ignore_ascii_case("tiff") | f.eq_ignore_ascii_case("tif"))
                 {
@@ -264,13 +266,131 @@ pub fn decode<P: AsRef<Path>>(f: P, matches: &ArgMatches) -> Result<Image, Image
                 file.seek(SeekFrom::Start(0))?;
             }
 
-            Err(ImageErrors::ImageDecoderNotImplemented(
+            return Err(ImageErrors::ImageDecoderNotImplemented(
                 ImageFormat::Unknown,
-            ))
-        } else {
-            Err(e)
+            ));
         }
+
+        Err(e)
+    }
+}
+
+/// Turn a decode failure into the structured, side-tagged form the CLI reports.
+///
+/// The resize context is deliberately not reconstructed here. `classify_input`
+/// uses it only to name the requested dimensions in an
+/// `ImageOperationNotImplemented("resize")` failure, and the only resize
+/// failures reachable at decode time are the SVG render-target ones, whose
+/// message already names the offending size. Passing `None` keeps this
+/// function honest instead of inventing a reason it did not observe; the
+/// classification still reports it as an input failure on the right format.
+fn classify_decode_failure(
+    path: &Path, _matches: &ArgMatches, error: &ImageErrors,
+) -> rimage::error::RimageError {
+    use rimage::error::{InputError, RimageError, classify_input};
+
+    classify_input(path, error, None).unwrap_or_else(|| {
+        RimageError::Input(InputError::Decode {
+            path: path.to_path_buf(),
+            format: rimage::limits::ImageFormatId::from_extension(
+                path.extension()
+                    .and_then(|ext| ext.to_str())
+                    .unwrap_or_default(),
+            ),
+            cause: clone_for_report(error),
+        })
     })
+}
+
+/// Rebuild an [`ImageErrors`] so it can be stored in a reported error.
+///
+/// `ImageErrors` has no `Clone`, and the message only ever renders it, so the
+/// text is enough to reproduce it.
+fn clone_for_report(error: &ImageErrors) -> ImageErrors {
+    match error {
+        ImageErrors::ImageDecodeErrors(text) => ImageErrors::ImageDecodeErrors(text.clone()),
+        ImageErrors::GenericString(text) => ImageErrors::GenericString(text.clone()),
+        ImageErrors::IoError(io) => ImageErrors::IoError(std::io::Error::new(io.kind(), io.to_string())),
+        other => ImageErrors::GenericString(other.to_string()),
+    }
+}
+
+#[cfg(all(feature = "svg", feature = "resize"))]
+fn svg_target_size(
+    matches: &ArgMatches,
+    size: (usize, usize),
+) -> Result<Option<(u32, u32)>, ImageErrors> {
+    use crate::cli::preprocessors::ResizeValue;
+
+    let Some(values) = matches.get_many::<ResizeValue>("resize") else {
+        return Ok(None);
+    };
+
+    let downscale = matches.get_flag("downscale") && !matches.get_flag("no-downscale");
+    let upscale = matches.get_flag("upscale") && !matches.get_flag("no-upscale");
+
+    let first_other = first_other_index(matches);
+    let plan = resize_plan(
+        values
+            .into_iter()
+            .zip(matches.indices_of("resize").unwrap())
+            .map(|(value, idx)| (idx, value))
+            .take_while(|(idx, _)| *idx < first_other),
+        size,
+        downscale,
+        upscale,
+    );
+
+    if plan.is_empty() {
+        return Ok(None);
+    }
+
+    let final_size = plan.last().map(|(_, size)| *size).unwrap_or(size);
+    let width = u32::try_from(final_size.0).map_err(|_| {
+        ImageErrors::ImageDecodeErrors(format!(
+            "SVG target width {} exceeds the maximum supported dimension of {}",
+            final_size.0,
+            u32::MAX
+        ))
+    })?;
+    let height = u32::try_from(final_size.1).map_err(|_| {
+        ImageErrors::ImageDecodeErrors(format!(
+            "SVG target height {} exceeds the maximum supported dimension of {}",
+            final_size.1,
+            u32::MAX
+        ))
+    })?;
+
+    Ok(Some((width, height)))
+}
+
+/// Returns the index of the first non-resize preprocessing element.
+///
+/// SVG vector resizing can only be folded into the decode render target for
+/// the resize steps that come before every quantization operation and before
+/// every true `--premultiply` flag. Steps at or after this index must run as
+/// ordinary raster resize operations so command-line order is preserved.
+#[cfg(feature = "resize")]
+fn first_other_index(matches: &ArgMatches) -> usize {
+    let first_premultiply = matches.get_many::<bool>("premultiply").and_then(|values| {
+        values
+            .into_iter()
+            .zip(matches.indices_of("premultiply")?)
+            .find_map(|(value, idx)| if *value { Some(idx) } else { None })
+    });
+
+    #[cfg(feature = "quantization")]
+    let first_quantization = matches
+        .indices_of("quantization")
+        .and_then(|mut indices| indices.next());
+    #[cfg(not(feature = "quantization"))]
+    let first_quantization: Option<usize> = None;
+
+    [first_premultiply, first_quantization]
+        .into_iter()
+        .flatten()
+        .min()
+        .unwrap_or(usize::MAX)
 }
 
 /// Plans a chain of resize operations, returning only the steps that are not

--- a/src/cli/pipeline.rs
+++ b/src/cli/pipeline.rs
@@ -64,7 +64,9 @@ fn decode_options() -> DecoderOptions {
 /// violation is resolved here and would otherwise have to be re-parsed out of a
 /// string to be reported.
 #[cfg(feature = "limits")]
-fn check_input_limits(path: &Path) -> Result<(), rimage::error::RimageError> {
+fn check_input_limits(
+    path: &Path, matches: &ArgMatches,
+) -> Result<(), rimage::error::RimageError> {
     use rimage::limits::{ImageFormatId, LimitSet, PipelineCost, SystemBudget};
 
     let extension = path
@@ -85,7 +87,7 @@ fn check_input_limits(path: &Path) -> Result<(), rimage::error::RimageError> {
         return Ok(());
     };
 
-    let budget = SystemBudget::probe(concurrency_from_env());
+    let budget = SystemBudget::probe(concurrency_from_env(matches));
     let limits = LimitSet::for_input(
         format,
         zune_core::bit_depth::BitDepth::Eight,
@@ -103,42 +105,74 @@ fn check_input_limits(path: &Path) -> Result<(), rimage::error::RimageError> {
 
 /// Read just the dimensions from an image header.
 ///
-/// Only JPEG is handled here. It is the format with a published per-side limit
-/// that a header read can settle cheaply, and it is the one the task names for
-/// the extreme case. Other formats are bounded by memory alone, which the
-/// decoders enforce on the buffer they actually allocate; probing their headers
-/// here would duplicate that check without adding a format limit.
+/// Only the formats with a *published per-side limit* are handled here. They
+/// are the ones a cheap header read can settle, and rejecting them up front is
+/// what turns an oversized input into a message naming the ceiling instead of
+/// an allocation abort inside the codec.
+///
+/// Formats with no published side limit are bounded by the memory budget,
+/// which the decoder applies to the buffer it actually allocates; probing their
+/// headers here would duplicate that check without adding a format limit.
 #[cfg(feature = "limits")]
 fn probe_dimensions<R: std::io::Read>(
     mut reader: R, format: rimage::limits::ImageFormatId,
 ) -> Option<(u64, u64)> {
     use rimage::limits::ImageFormatId;
-    use zune_core::bytestream::ZCursor;
 
     match format {
         ImageFormatId::Jpeg => {
-            // A JPEG header sits at the front of the file, so only a prefix is
-            // needed. Reading a bounded prefix rather than the whole file is
-            // what keeps rejecting an oversized input cheap.
-            let mut prefix = vec![0u8; JPEG_HEADER_PROBE_BYTES];
-            let mut filled = 0;
-            while filled < prefix.len() {
-                match reader.read(&mut prefix[filled..]) {
-                    Ok(0) => break,
-                    Ok(read) => filled += read,
-                    Err(_) => return None,
-                }
-            }
-            prefix.truncate(filled);
+            use zune_core::bytestream::ZCursor;
 
-            let mut decoder =
-                zune_image::codecs::jpeg::JpegDecoder::new(ZCursor::new(prefix));
+            let prefix = read_prefix(&mut reader, JPEG_HEADER_PROBE_BYTES)?;
+
+            let mut decoder = zune_image::codecs::jpeg::JpegDecoder::new(ZCursor::new(prefix));
             decoder.decode_headers().ok()?;
             let (width, height) = decoder.dimensions()?;
             Some((width as u64, height as u64))
         }
+        ImageFormatId::WebP => {
+            // libwebp exposes a bitstream-features probe that parses the RIFF
+            // container and the frame header without decoding any pixels.
+            #[cfg(feature = "webp")]
+            {
+                let prefix = read_prefix(&mut reader, WEBP_HEADER_PROBE_BYTES)?;
+                let features = webp::BitstreamFeatures::new(&prefix)?;
+                Some((features.width() as u64, features.height() as u64))
+            }
+
+            #[cfg(not(feature = "webp"))]
+            {
+                let _ = &mut reader;
+                None
+            }
+        }
         _ => None,
     }
+}
+
+/// Read up to `limit` bytes from the front of `reader`.
+///
+/// Returns `None` when nothing could be read. A short read is not an error: a
+/// file too small to hold a header simply is not pre-checked, and the decoder
+/// gets to report the real problem.
+#[cfg(feature = "limits")]
+fn read_prefix<R: std::io::Read>(reader: &mut R, limit: usize) -> Option<Vec<u8>> {
+    let mut prefix = vec![0u8; limit];
+    let mut filled = 0;
+    while filled < prefix.len() {
+        match reader.read(&mut prefix[filled..]) {
+            Ok(0) => break,
+            Ok(read) => filled += read,
+            Err(_) => return None,
+        }
+    }
+
+    if filled == 0 {
+        return None;
+    }
+
+    prefix.truncate(filled);
+    Some(prefix)
 }
 
 /// Bytes of a file read to recover a JPEG frame header.
@@ -150,15 +184,28 @@ fn probe_dimensions<R: std::io::Read>(
 #[cfg(feature = "limits")]
 const JPEG_HEADER_PROBE_BYTES: usize = 64 * 1024;
 
-/// The concurrency the pipeline will actually use, read from the same argument
-/// the worker pool is sized from.
+/// Bytes of a file read to recover a WebP bitstream header.
 ///
-/// Defaults to 1, matching `--threads`.
+/// The RIFF header and the frame header precede the compressed payload, so a
+/// small prefix is enough for every WebP variant.
+#[cfg(all(feature = "limits", feature = "webp"))]
+const WEBP_HEADER_PROBE_BYTES: usize = 64 * 1024;
+
+/// The concurrency the pipeline will actually use for `matches`.
+///
+/// Read from the same `-t/--threads` argument `main` sizes its worker pool
+/// from, so the memory budget divides by the number of images that will really
+/// be in flight. Defaults to 1, matching the flag's own default.
+///
+/// This is deliberately not read from the environment: a second, silently
+/// different source of truth for the same number is how a budget ends up sized
+/// for one image while four are being decoded.
 #[cfg(feature = "limits")]
-fn concurrency_from_env() -> usize {
-    std::env::var("RIMAGE_THREADS")
-        .ok()
-        .and_then(|value| value.parse().ok())
+fn concurrency_from_env(matches: &ArgMatches) -> usize {
+    matches
+        .get_one::<u8>("threads")
+        .copied()
+        .map(|threads| threads as usize)
         .filter(|threads| *threads > 0)
         .unwrap_or(1)
 }
@@ -169,11 +216,43 @@ pub fn decode<P: AsRef<Path>>(f: P, matches: &ArgMatches) -> Result<Image, rimag
     // The size pre-check already knows which ceiling it broke, so it produces
     // the structured error directly instead of round-tripping through a string.
     #[cfg(feature = "limits")]
-    check_input_limits(f.as_ref())?;
+    check_input_limits(f.as_ref(), matches)?;
 
     Image::open_with_options(f.as_ref(), decode_options())
         .or_else(|e| decode_with_fallback(f.as_ref(), matches, e))
         .map_err(|e| classify_decode_failure(f.as_ref(), matches, &e))
+}
+
+/// Pixel budget an SVG rasterisation may cover, derived from the machine.
+///
+/// The SVG decoder has its own conservative constant for standalone use, but
+/// this program can probe the machine, so the render target is bounded by the
+/// same memory model every other format uses rather than by a fixed 512 MiB.
+/// Returns `None` when the `limits` feature is off, which makes the decoder
+/// fall back to its own constant.
+#[cfg(feature = "svg")]
+fn svg_pixel_budget(matches: &ArgMatches) -> Option<u64> {
+    #[cfg(feature = "limits")]
+    {
+        use rimage::limits::{ImageFormatId, LimitSet, PipelineCost, SystemBudget};
+
+        let budget = SystemBudget::probe(concurrency_from_env(matches));
+        let limits = LimitSet::for_input(
+            ImageFormatId::Svg,
+            zune_core::bit_depth::BitDepth::Eight,
+            zune_core::colorspace::ColorSpace::RGBA,
+            &budget,
+            PipelineCost::for_encoder(ImageFormatId::Svg),
+        );
+
+        Some(limits.max_pixels)
+    }
+
+    #[cfg(not(feature = "limits"))]
+    {
+        let _ = matches;
+        None
+    }
 }
 
 /// Retry the decode with the decoders `zune_image` does not own.
@@ -195,11 +274,13 @@ fn decode_with_fallback(
                     .is_some_and(|f| f.eq_ignore_ascii_case("svg") | f.eq_ignore_ascii_case("svgz"))
                 {
                     let resources_dir = path.parent().map(Path::to_path_buf);
+                    let pixel_budget = svg_pixel_budget(matches);
 
                     #[cfg(feature = "resize")]
-                    let decoder = SvgDecoder::try_new_with_resize(file, resources_dir, |size| {
-                        svg_target_size(matches, size)
-                    })?;
+                    let decoder =
+                        SvgDecoder::try_new_with_resize_and_budget(file, resources_dir, pixel_budget, |size| {
+                            svg_target_size(matches, size)
+                        })?;
 
                     #[cfg(not(feature = "resize"))]
                     let decoder = SvgDecoder::try_new_with_options(
@@ -207,7 +288,7 @@ fn decode_with_fallback(
                         SvgOptions {
                             resources_dir,
                             target_size: None,
-                            pixel_budget: None,
+                            pixel_budget,
                         },
                     )?;
 
@@ -1241,6 +1322,19 @@ mod tests {
 #[cfg(all(test, feature = "limits"))]
 mod limit_tests {
     use super::*;
+    use crate::cli::cli;
+
+    /// Builds the codec subcommand matches the way `main` passes them to
+    /// [`decode`]. Local to this module because the shared helper lives behind
+    /// the `resize` feature, and the limit checks must be testable without it.
+    fn matches_from(args: &[&str]) -> ArgMatches {
+        cli()
+            .get_matches_from(args)
+            .subcommand()
+            .expect("clap ensures a subcommand is always provided")
+            .1
+            .clone()
+    }
 
     /// A JPEG header probe must recover the real dimensions from an ordinary
     /// file, or the pre-check would silently never fire.
@@ -1266,6 +1360,20 @@ mod limit_tests {
         );
     }
 
+    /// WebP has a published 16383-per-side limit, so its header must be
+    /// readable without decoding. The bitstream-features probe is what makes
+    /// that possible; if it ever stops working the check silently goes dead.
+    #[cfg(feature = "webp")]
+    #[test]
+    fn a_webp_header_probe_reads_the_real_dimensions() {
+        let file = File::open("tests/files/webp/f1t.webp").unwrap();
+
+        let (width, height) = probe_dimensions(file, rimage::limits::ImageFormatId::WebP)
+            .expect("the fixture's header must be readable");
+
+        assert!(width > 0 && height > 0, "got {width}x{height}");
+    }
+
     /// A file too short to contain a frame header must be reported as
     /// unprobeable rather than as an error, so decoding still gets its chance.
     #[test]
@@ -1279,7 +1387,9 @@ mod limit_tests {
     /// does not reject files the program is expected to handle.
     #[test]
     fn an_ordinary_image_passes_the_pre_check() {
-        check_input_limits(Path::new("tests/files/jpg/f1t.jpg"))
+        let matches = matches_from(&["rimage", "mozjpeg", "tests/files/jpg/f1t.jpg"]);
+
+        check_input_limits(Path::new("tests/files/jpg/f1t.jpg"), &matches)
             .expect("an ordinary fixture must not be rejected");
     }
 
@@ -1287,6 +1397,22 @@ mod limit_tests {
     /// than being turned into a size error here.
     #[test]
     fn a_missing_file_is_not_a_size_error() {
-        assert!(check_input_limits(Path::new("tests/files/does-not-exist.jpg")).is_ok());
+        let matches = matches_from(&["rimage", "mozjpeg", "tests/files/does-not-exist.jpg"]);
+
+        assert!(
+            check_input_limits(Path::new("tests/files/does-not-exist.jpg"), &matches).is_ok()
+        );
+    }
+
+    /// The budget must divide by the concurrency the pipeline really uses.
+    /// Reading a stale environment variable here would silently size the
+    /// budget for one image while `--threads` ran several.
+    #[test]
+    fn the_memory_budget_follows_the_threads_flag() {
+        let single = matches_from(&["rimage", "mozjpeg", "image.jpg"]);
+        assert_eq!(concurrency_from_env(&single), 1);
+
+        let four = matches_from(&["rimage", "mozjpeg", "--threads", "4", "image.jpg"]);
+        assert_eq!(concurrency_from_env(&four), 4);
     }
 }

--- a/src/cli/pipeline.rs
+++ b/src/cli/pipeline.rs
@@ -1189,7 +1189,11 @@ pub fn encoder(name: &str, matches: &ArgMatches) -> Result<AvailableEncoders, Im
         "webp" => {
             use rimage::codecs::webp::WebPOptions;
 
-            let mut options = WebPOptions::new().unwrap();
+            let mut options = WebPOptions::new().map_err(|_| {
+                ImageErrors::GenericString(
+                    "libwebp encoder configuration failed to initialize".to_string(),
+                )
+            })?;
 
             options.quality = matches.get_one::<u8>("quality").copied().unwrap_or(75) as f32;
             options.lossless = matches.get_flag("lossless") as i32;

--- a/src/cli/pipeline.rs
+++ b/src/cli/pipeline.rs
@@ -923,16 +923,22 @@ pub fn operations(
                         Box::new(PremultiplyAlpha::new(AlphaState::PreMultiplied)),
                     );
 
-                    assert!(
-                        !map.contains_key(&(idx + 3)),
-                        "There is a operation at {} aborting",
-                        idx + 3
-                    );
-
-                    map.insert(
-                        idx + 3,
-                        Box::new(PremultiplyAlpha::new(AlphaState::NonPreMultiplied)),
-                    );
+                    // If a subsequent operation already occupies idx+3,
+                    // log a warning and skip the un-premultiply insertion
+                    // rather than aborting the process (which would happen
+                    // with `assert!` under `panic = "abort"` in release).
+                    if map.contains_key(&(idx + 3)) {
+                        log::warn!(
+                            "premultiply at index {idx}: position {} already occupied, \
+                             skipping un-premultiply step",
+                            idx + 3
+                        );
+                    } else {
+                        map.insert(
+                            idx + 3,
+                            Box::new(PremultiplyAlpha::new(AlphaState::NonPreMultiplied)),
+                        );
+                    }
                 } else {
                     log::warn!("No operation found for premultiply at index {idx}")
                 }

--- a/src/cli/preprocessors/mod.rs
+++ b/src/cli/preprocessors/mod.rs
@@ -1,5 +1,3 @@
-#![allow(unused_imports)]
-
 use clap::{Arg, ArgAction, ArgGroup, Command, arg, value_parser};
 use indoc::indoc;
 

--- a/src/cli/preprocessors/resize/value.rs
+++ b/src/cli/preprocessors/resize/value.rs
@@ -143,12 +143,25 @@ impl std::str::FromStr for ResizeValue {
             s if s.contains('x') => {
                 let dimensions: Vec<&str> = s.split('x').collect();
                 if dimensions.len() > 2 {
-                    return Err(anyhow!("There is more that 2 dimensions"));
+                    return Err(anyhow!("There is more than 2 dimensions"));
                 }
 
-                let width = Some(dimensions[0].parse::<usize>()?);
+                // An empty dimension half (e.g. "x100" or "100x") produces a
+                // parse error with an unhelpful message. Surface a clear
+                // error naming the missing value.
+                let width = Some(dimensions[0].parse::<usize>().map_err(|_| {
+                    anyhow!(
+                        "Invalid resize width '{}': expected a positive integer",
+                        dimensions[0]
+                    )
+                })?);
 
-                let height = Some(dimensions[1].parse::<usize>()?);
+                let height = Some(dimensions[1].parse::<usize>().map_err(|_| {
+                    anyhow!(
+                        "Invalid resize height '{}': expected a positive integer",
+                        dimensions[1]
+                    )
+                })?);
 
                 Ok(Self::Dimensions(width, height))
             }

--- a/src/cli/preprocessors/resize/value.rs
+++ b/src/cli/preprocessors/resize/value.rs
@@ -100,6 +100,28 @@ fn parse_length(s: &str, marker: char) -> Result<usize, anyhow::Error> {
     Ok(length)
 }
 
+/// Parses a positive, finite scale factor for the `@` and `%` forms.
+///
+/// `f32` parsing accepts strings like `nan` and `inf`, and a zero or negative
+/// factor maps every image onto a degenerate target: NaN and negatives become
+/// 0 in the float-to-`usize` cast, and infinity saturates to `usize::MAX`.
+/// Those failures only surface inside the resize operation, far from the
+/// input that caused them, so they are rejected here instead.
+fn parse_scale(s: &str) -> Result<f32, anyhow::Error> {
+    let scale: f32 = s
+        .trim()
+        .parse()
+        .map_err(|_| anyhow!("Invalid resize value"))?;
+
+    if !scale.is_finite() || scale <= 0.0 {
+        return Err(anyhow!(
+            "Resize scale factor should be a positive, finite number"
+        ));
+    }
+
+    Ok(scale)
+}
+
 impl std::fmt::Display for ResizeValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -124,8 +146,8 @@ impl std::str::FromStr for ResizeValue {
         let s = s.trim().to_lowercase();
 
         match s {
-            s if s.starts_with('@') => Ok(Self::Multiplier(s[1..].parse()?)),
-            s if s.ends_with('%') => Ok(Self::Percentage(s[..s.len() - 1].parse()?)),
+            s if s.starts_with('@') => Ok(Self::Multiplier(parse_scale(&s[1..])?)),
+            s if s.ends_with('%') => Ok(Self::Percentage(parse_scale(&s[..s.len() - 1])?)),
             s if ANCHOR_MARKERS
                 .iter()
                 .filter(|marker| s.contains(**marker))
@@ -162,6 +184,13 @@ impl std::str::FromStr for ResizeValue {
                         dimensions[1]
                     )
                 })?);
+
+                // `parse_length` rejects a zero length for the anchored forms
+                // because it can never produce a valid image; the WxH form is
+                // held to the same rule.
+                if width == Some(0) || height == Some(0) {
+                    return Err(anyhow!("Resize dimensions should be greater than 0"));
+                }
 
                 Ok(Self::Dimensions(width, height))
             }
@@ -347,6 +376,32 @@ mod tests {
         assert!("0h".parse::<ResizeValue>().is_err());
         assert!("0l".parse::<ResizeValue>().is_err());
         assert!("0s".parse::<ResizeValue>().is_err());
+    }
+
+    #[test]
+    fn from_str_rejects_zero_dimensions_in_wxh_form() {
+        // The anchored forms reject a zero length; the WxH form follows the
+        // same rule instead of failing later inside the resize operation.
+        for value in ["0x100", "100x0", "0x0"] {
+            assert!(
+                value.parse::<ResizeValue>().is_err(),
+                "{value} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn from_str_rejects_non_positive_or_non_finite_scale_factors() {
+        // NaN and negative factors cast to a zero size, infinity saturates to
+        // usize::MAX; all of them must fail at parse time, not mid-pipeline.
+        for value in [
+            "@0", "@-2", "@nan", "@inf", "@-inf", "0%", "-5%", "nan%", "inf%",
+        ] {
+            assert!(
+                value.parse::<ResizeValue>().is_err(),
+                "{value} should be rejected"
+            );
+        }
     }
 
     #[test]

--- a/src/cli/utils/jpeg.rs
+++ b/src/cli/utils/jpeg.rs
@@ -214,3 +214,6 @@ pub fn insert_jpeg_exif_app1(path: &Path, exif_payload: &[u8]) -> io::Result<()>
 
     std::fs::write(path, out)
 }
+
+#[cfg(test)]
+mod tests;

--- a/src/cli/utils/jpeg.rs
+++ b/src/cli/utils/jpeg.rs
@@ -79,42 +79,37 @@ pub fn read_jpeg_source_metadata(path: &Path) -> io::Result<Option<JpegSourceMet
         }
         let remaining = segment_len - 2;
 
+        // The `is_none()` guards keep the first copy of each segment. A second
+        // one falls through to `_`, which skips it without reading.
         match marker {
             // APP0: JFIF density lives here.
-            0xE0 => {
-                if metadata.jfif_density.is_none() {
-                    let mut prefix = [0u8; 14];
-                    let read = read_up_to(&mut reader, &mut prefix, remaining)?;
-                    if read >= 14 && prefix.starts_with(b"JFIF\0") {
-                        metadata.jfif_density = Some(JfifDensity {
-                            unit: prefix[7],
-                            x_density: u16::from_be_bytes([prefix[8], prefix[9]]),
-                            y_density: u16::from_be_bytes([prefix[10], prefix[11]]),
-                        });
-                    }
-                    skip_remaining(&mut reader, remaining, read)?;
-                } else {
-                    skip_remaining(&mut reader, remaining, 0)?;
+            0xE0 if metadata.jfif_density.is_none() => {
+                let mut prefix = [0u8; 14];
+                let read = read_up_to(&mut reader, &mut prefix, remaining)?;
+                if read >= 14 && prefix.starts_with(b"JFIF\0") {
+                    metadata.jfif_density = Some(JfifDensity {
+                        unit: prefix[7],
+                        x_density: u16::from_be_bytes([prefix[8], prefix[9]]),
+                        y_density: u16::from_be_bytes([prefix[10], prefix[11]]),
+                    });
                 }
+                skip_remaining(&mut reader, remaining, read)?;
             }
             // APP1: the first EXIF segment is the one to preserve.
-            0xE1 => {
-                if metadata.exif_app1.is_none() {
-                    let mut prefix = [0u8; 6];
-                    let read = read_up_to(&mut reader, &mut prefix, remaining)?;
-                    if read >= 6 && prefix.starts_with(b"Exif\0\0") {
-                        let mut payload = Vec::with_capacity(remaining);
-                        payload.extend_from_slice(&prefix);
-                        payload.resize(remaining, 0);
-                        reader.read_exact(&mut payload[6..])?;
-                        metadata.exif_app1 = Some(payload);
-                    } else {
-                        skip_remaining(&mut reader, remaining, read)?;
-                    }
+            0xE1 if metadata.exif_app1.is_none() => {
+                let mut prefix = [0u8; 6];
+                let read = read_up_to(&mut reader, &mut prefix, remaining)?;
+                if read >= 6 && prefix.starts_with(b"Exif\0\0") {
+                    let mut payload = Vec::with_capacity(remaining);
+                    payload.extend_from_slice(&prefix);
+                    payload.resize(remaining, 0);
+                    reader.read_exact(&mut payload[6..])?;
+                    metadata.exif_app1 = Some(payload);
                 } else {
-                    skip_remaining(&mut reader, remaining, 0)?;
+                    skip_remaining(&mut reader, remaining, read)?;
                 }
             }
+            // Every other segment, and any repeat of one already collected.
             _ => {
                 skip_remaining(&mut reader, remaining, 0)?;
             }

--- a/src/cli/utils/jpeg.rs
+++ b/src/cli/utils/jpeg.rs
@@ -1,0 +1,221 @@
+use std::{
+    fs::File,
+    io::{self, BufReader, Read, Seek, SeekFrom},
+    path::Path,
+};
+
+/// JFIF density parsed from a JPEG APP0 segment.
+///
+/// `unit` uses the same values as the JFIF standard:
+/// 0 = aspect ratio only, 1 = dots per inch, 2 = dots per cm.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct JfifDensity {
+    pub unit: u8,
+    pub x_density: u16,
+    pub y_density: u16,
+}
+
+/// Metadata rimage can preserve from a JPEG source file.
+#[derive(Debug)]
+pub struct JpegSourceMetadata {
+    pub jfif_density: Option<JfifDensity>,
+    /// Raw payload of the first APP1 segment starting with `Exif\0\0`.
+    /// The payload does not include the marker or the segment length.
+    pub exif_app1: Option<Vec<u8>>,
+}
+
+/// Scans the beginning of a JPEG file for the JFIF APP0 density and the first
+/// EXIF APP1 segment.
+///
+/// Only the marker header is read; image data after the start-of-scan marker
+/// is never touched. Returns `Ok(None)` when the file is not a JPEG (does not
+/// start with the JPEG SOI marker) and an error when the JPEG segment
+/// structure is malformed.
+pub fn read_jpeg_source_metadata(path: &Path) -> io::Result<Option<JpegSourceMetadata>> {
+    let file = File::open(path)?;
+    let mut reader = BufReader::new(file);
+
+    let mut signature = [0u8; 2];
+    match reader.read_exact(&mut signature) {
+        Ok(_) => {}
+        Err(error) if error.kind() == io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(error) => return Err(error),
+    }
+
+    if signature != [0xFF, 0xD8] {
+        return Ok(None);
+    }
+
+    let mut metadata = JpegSourceMetadata {
+        jfif_density: None,
+        exif_app1: None,
+    };
+
+    loop {
+        let marker = read_marker(&mut reader)?;
+
+        // End of image; nothing after this point matters.
+        if marker == 0xD9 {
+            break;
+        }
+
+        // Standalone markers (including restart markers) carry no length.
+        if marker == 0x01 || (0xD0..=0xD7).contains(&marker) {
+            continue;
+        }
+
+        // A SOI marker here would be malformed, but skipping it keeps the
+        // scanner permissive in the same way the rest of the decoder is.
+        if marker == 0xD8 {
+            continue;
+        }
+
+        let segment_len = read_segment_len(&mut reader)?;
+        if segment_len < 2 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "malformed JPEG segment length",
+            ));
+        }
+        let remaining = segment_len - 2;
+
+        match marker {
+            // APP0: JFIF density lives here.
+            0xE0 => {
+                if metadata.jfif_density.is_none() {
+                    let mut prefix = [0u8; 14];
+                    let read = read_up_to(&mut reader, &mut prefix, remaining)?;
+                    if read >= 14 && prefix.starts_with(b"JFIF\0") {
+                        metadata.jfif_density = Some(JfifDensity {
+                            unit: prefix[7],
+                            x_density: u16::from_be_bytes([prefix[8], prefix[9]]),
+                            y_density: u16::from_be_bytes([prefix[10], prefix[11]]),
+                        });
+                    }
+                    skip_remaining(&mut reader, remaining, read)?;
+                } else {
+                    skip_remaining(&mut reader, remaining, 0)?;
+                }
+            }
+            // APP1: the first EXIF segment is the one to preserve.
+            0xE1 => {
+                if metadata.exif_app1.is_none() {
+                    let mut prefix = [0u8; 6];
+                    let read = read_up_to(&mut reader, &mut prefix, remaining)?;
+                    if read >= 6 && prefix.starts_with(b"Exif\0\0") {
+                        let mut payload = Vec::with_capacity(remaining);
+                        payload.extend_from_slice(&prefix);
+                        payload.resize(remaining, 0);
+                        reader.read_exact(&mut payload[6..])?;
+                        metadata.exif_app1 = Some(payload);
+                    } else {
+                        skip_remaining(&mut reader, remaining, read)?;
+                    }
+                } else {
+                    skip_remaining(&mut reader, remaining, 0)?;
+                }
+            }
+            _ => {
+                skip_remaining(&mut reader, remaining, 0)?;
+            }
+        }
+
+        // Metadata segments only appear before the start of scan.
+        if marker == 0xDA {
+            break;
+        }
+    }
+
+    Ok(Some(metadata))
+}
+
+/// Reads the next marker code after a 0xFF prefix.
+fn read_marker(reader: &mut BufReader<File>) -> io::Result<u8> {
+    let mut byte = [0u8; 1];
+
+    loop {
+        reader.read_exact(&mut byte)?;
+        if byte[0] == 0xFF {
+            break;
+        }
+    }
+
+    // Skip any extra 0xFF fill bytes.
+    loop {
+        reader.read_exact(&mut byte)?;
+        if byte[0] != 0xFF {
+            return Ok(byte[0]);
+        }
+    }
+}
+
+fn read_segment_len(reader: &mut BufReader<File>) -> io::Result<usize> {
+    let mut length = [0u8; 2];
+    reader.read_exact(&mut length)?;
+    Ok(u16::from_be_bytes(length) as usize)
+}
+
+/// Reads up to `buf.len()` bytes, returning how many were actually read before
+/// hitting EOF. A short read is not an error here because the caller decides
+/// how to handle truncated optional segments.
+fn read_up_to(reader: &mut BufReader<File>, buf: &mut [u8], remaining: usize) -> io::Result<usize> {
+    let want = buf.len().min(remaining);
+    let mut read = 0;
+    while read < want {
+        match reader.read(&mut buf[read..want]) {
+            Ok(0) => break,
+            Ok(n) => read += n,
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(read)
+}
+
+fn skip_remaining(
+    reader: &mut BufReader<File>,
+    remaining: usize,
+    already_read: usize,
+) -> io::Result<()> {
+    if remaining > already_read {
+        reader.seek(SeekFrom::Current((remaining - already_read) as i64))?;
+    }
+    Ok(())
+}
+
+/// Inserts a raw EXIF APP1 payload into an encoded JPEG file, right after
+/// the SOI marker.
+///
+/// `exif_payload` must be the APP1 payload (starting with `Exif\0\0`) without
+/// the marker or length bytes, exactly as returned by
+/// [`read_jpeg_source_metadata`].
+pub fn insert_jpeg_exif_app1(path: &Path, exif_payload: &[u8]) -> io::Result<()> {
+    let data = std::fs::read(path)?;
+
+    if !data.starts_with(&[0xFF, 0xD8]) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "encoded output is not a JPEG",
+        ));
+    }
+
+    let payload_len = u16::try_from(exif_payload.len()).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "EXIF APP1 payload is too large for a JPEG segment",
+        )
+    })?;
+    let segment_len = payload_len + 2;
+
+    let mut segment = Vec::with_capacity(4 + exif_payload.len());
+    segment.extend_from_slice(&[0xFF, 0xE1]);
+    segment.extend_from_slice(&segment_len.to_be_bytes());
+    segment.extend_from_slice(exif_payload);
+
+    let mut out = Vec::with_capacity(data.len() + segment.len());
+    out.extend_from_slice(&data[..2]);
+    out.extend_from_slice(&segment);
+    out.extend_from_slice(&data[2..]);
+
+    std::fs::write(path, out)
+}

--- a/src/cli/utils/jpeg.rs
+++ b/src/cli/utils/jpeg.rs
@@ -194,13 +194,19 @@ pub fn insert_jpeg_exif_app1(path: &Path, exif_payload: &[u8]) -> io::Result<()>
         ));
     }
 
-    let payload_len = u16::try_from(exif_payload.len()).map_err(|_| {
-        io::Error::new(
+    // The segment length field covers its own two bytes, so the largest
+    // payload that fits is 65533. Checking against `u16::MAX` directly would
+    // let a 65534/65535-byte payload through and overflow `payload_len + 2` —
+    // a panic in debug builds and a wrapped, malformed length in release.
+    const MAX_APP1_PAYLOAD: usize = u16::MAX as usize - 2;
+
+    if exif_payload.len() > MAX_APP1_PAYLOAD {
+        return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             "EXIF APP1 payload is too large for a JPEG segment",
-        )
-    })?;
-    let segment_len = payload_len + 2;
+        ));
+    }
+    let segment_len = (exif_payload.len() + 2) as u16;
 
     let mut segment = Vec::with_capacity(4 + exif_payload.len());
     segment.extend_from_slice(&[0xFF, 0xE1]);

--- a/src/cli/utils/jpeg/tests.rs
+++ b/src/cli/utils/jpeg/tests.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 use std::path::PathBuf;
 
-use super::{JfifDensity, read_jpeg_source_metadata};
+use super::{JfifDensity, insert_jpeg_exif_app1, read_jpeg_source_metadata};
 
 const SOI: [u8; 2] = [0xFF, 0xD8];
 const EOI: [u8; 2] = [0xFF, 0xD9];
@@ -166,5 +166,37 @@ fn a_jpeg_without_metadata_segments_returns_empty_metadata() {
 
     assert!(metadata.jfif_density.is_none());
     assert!(metadata.exif_app1.is_none());
+    std::fs::remove_file(path).ok();
+}
+
+/// The segment length field covers its own two bytes, so a payload above
+/// 65533 bytes would overflow the u16 length — a panic in debug builds and a
+/// wrapped, malformed segment in release. It must be rejected, leaving the
+/// file untouched.
+#[test]
+fn an_oversized_exif_payload_is_rejected_without_touching_the_file() {
+    let original = jpeg(&[]);
+    let path = scratch("exif-oversized", &original);
+    let payload = vec![0u8; 65534];
+
+    let result = insert_jpeg_exif_app1(&path, &payload);
+
+    assert!(result.is_err());
+    assert_eq!(std::fs::read(&path).unwrap(), original);
+    std::fs::remove_file(path).ok();
+}
+
+/// The largest legal payload is 65533 bytes, making the declared segment
+/// length exactly u16::MAX.
+#[test]
+fn the_largest_legal_exif_payload_is_written() {
+    let path = scratch("exif-max", &jpeg(&[]));
+    let payload = vec![0u8; 65533];
+
+    insert_jpeg_exif_app1(&path, &payload).unwrap();
+
+    let data = std::fs::read(&path).unwrap();
+    assert_eq!(&data[2..4], &[0xFF, 0xE1]);
+    assert_eq!(u16::from_be_bytes([data[4], data[5]]), u16::MAX);
     std::fs::remove_file(path).ok();
 }

--- a/src/cli/utils/jpeg/tests.rs
+++ b/src/cli/utils/jpeg/tests.rs
@@ -1,0 +1,170 @@
+use std::io::Write;
+use std::path::PathBuf;
+
+use super::{JfifDensity, read_jpeg_source_metadata};
+
+const SOI: [u8; 2] = [0xFF, 0xD8];
+const EOI: [u8; 2] = [0xFF, 0xD9];
+
+/// Writes `bytes` to a scratch file and returns its path.
+///
+/// The scanner takes a path rather than a reader, so these tests build real
+/// files. Each test passes a distinct name so they cannot collide.
+fn scratch(name: &str, bytes: &[u8]) -> PathBuf {
+    let path = std::env::temp_dir().join(format!("rimage-jpeg-test-{name}.jpg"));
+    let mut file = std::fs::File::create(&path).expect("create the scratch file");
+    file.write_all(bytes).expect("write the scratch file");
+    path
+}
+
+/// Builds a metadata segment: `FF <marker> <length> <payload>`, where `length`
+/// counts the two length bytes themselves.
+fn segment(marker: u8, payload: &[u8]) -> Vec<u8> {
+    let length = (payload.len() + 2) as u16;
+    let mut out = vec![0xFF, marker, (length >> 8) as u8, (length & 0xFF) as u8];
+    out.extend_from_slice(payload);
+    out
+}
+
+/// Builds an APP0/JFIF payload. The scanner reads `unit` at byte 7 and the two
+/// densities as big-endian at bytes 8..12.
+fn jfif(unit: u8, x_density: u16, y_density: u16) -> Vec<u8> {
+    let mut out = b"JFIF\0".to_vec();
+    out.extend_from_slice(&[1, 2]); // version 1.2
+    out.push(unit);
+    out.extend_from_slice(&x_density.to_be_bytes());
+    out.extend_from_slice(&y_density.to_be_bytes());
+    out.extend_from_slice(&[0, 0]); // no thumbnail
+    out
+}
+
+/// Builds an APP1/EXIF payload whose body identifies it to the assertions.
+fn exif(body: &[u8]) -> Vec<u8> {
+    let mut out = b"Exif\0\0".to_vec();
+    out.extend_from_slice(body);
+    out
+}
+
+/// Wraps metadata segments in SOI/EOI so the scanner has a well-formed file.
+fn jpeg(segments: &[Vec<u8>]) -> Vec<u8> {
+    let mut out = SOI.to_vec();
+    for segment in segments {
+        out.extend_from_slice(segment);
+    }
+    out.extend_from_slice(&EOI);
+    out
+}
+
+#[test]
+fn jfif_density_is_parsed_from_the_app0_segment() {
+    let path = scratch("density", &jpeg(&[segment(0xE0, &jfif(1, 300, 300))]));
+
+    let metadata = read_jpeg_source_metadata(&path).unwrap().expect("is a jpeg");
+
+    assert_eq!(
+        metadata.jfif_density,
+        Some(JfifDensity {
+            unit: 1,
+            x_density: 300,
+            y_density: 300,
+        })
+    );
+    std::fs::remove_file(path).ok();
+}
+
+#[test]
+fn the_first_exif_segment_is_preserved() {
+    let expected = exif(b"first");
+    let path = scratch("exif-first", &jpeg(&[segment(0xE1, &expected)]));
+
+    let metadata = read_jpeg_source_metadata(&path).unwrap().expect("is a jpeg");
+
+    assert_eq!(metadata.exif_app1.as_deref(), Some(expected.as_slice()));
+    std::fs::remove_file(path).ok();
+}
+
+/// The guard that keeps the first copy of a segment is what sends a repeat to
+/// the skip arm. Losing it would let a later segment overwrite the earlier
+/// one, which is what these two tests exist to catch.
+#[test]
+fn a_second_exif_segment_does_not_replace_the_first() {
+    let expected = exif(b"first");
+    let path = scratch(
+        "exif-repeat",
+        &jpeg(&[
+            segment(0xE1, &expected),
+            segment(0xE1, &exif(b"second")),
+        ]),
+    );
+
+    let metadata = read_jpeg_source_metadata(&path).unwrap().expect("is a jpeg");
+
+    assert_eq!(
+        metadata.exif_app1.as_deref(),
+        Some(expected.as_slice()),
+        "a repeated APP1 must be skipped, not overwrite the one already held"
+    );
+    std::fs::remove_file(path).ok();
+}
+
+#[test]
+fn a_second_jfif_segment_does_not_replace_the_first() {
+    let path = scratch(
+        "jfif-repeat",
+        &jpeg(&[
+            segment(0xE0, &jfif(1, 300, 300)),
+            segment(0xE0, &jfif(2, 118, 118)),
+        ]),
+    );
+
+    let metadata = read_jpeg_source_metadata(&path).unwrap().expect("is a jpeg");
+
+    assert_eq!(
+        metadata.jfif_density,
+        Some(JfifDensity {
+            unit: 1,
+            x_density: 300,
+            y_density: 300,
+        }),
+        "a repeated APP0 must be skipped, not overwrite the density already held"
+    );
+    std::fs::remove_file(path).ok();
+}
+
+/// XMP lives in APP1 as well, so an APP1 marker alone does not make a segment
+/// EXIF. A non-EXIF APP1 must not consume the one EXIF slot.
+#[test]
+fn an_app1_that_is_not_exif_does_not_claim_the_exif_slot() {
+    let expected = exif(b"real");
+    let path = scratch(
+        "exif-after-xmp",
+        &jpeg(&[
+            segment(0xE1, b"http://ns.adobe.com/xap/1.0/\0<x:xmpmeta/>"),
+            segment(0xE1, &expected),
+        ]),
+    );
+
+    let metadata = read_jpeg_source_metadata(&path).unwrap().expect("is a jpeg");
+
+    assert_eq!(metadata.exif_app1.as_deref(), Some(expected.as_slice()));
+    std::fs::remove_file(path).ok();
+}
+
+#[test]
+fn a_file_without_the_jpeg_signature_is_reported_as_none() {
+    let path = scratch("not-a-jpeg", b"definitely not a jpeg");
+
+    assert!(read_jpeg_source_metadata(&path).unwrap().is_none());
+    std::fs::remove_file(path).ok();
+}
+
+#[test]
+fn a_jpeg_without_metadata_segments_returns_empty_metadata() {
+    let path = scratch("bare", &jpeg(&[]));
+
+    let metadata = read_jpeg_source_metadata(&path).unwrap().expect("is a jpeg");
+
+    assert!(metadata.jfif_density.is_none());
+    assert!(metadata.exif_app1.is_none());
+    std::fs::remove_file(path).ok();
+}

--- a/src/cli/utils/mod.rs
+++ b/src/cli/utils/mod.rs
@@ -1,2 +1,3 @@
+pub mod jpeg;
 pub mod paths;
 pub mod threads;

--- a/src/cli/utils/paths/mod.rs
+++ b/src/cli/utils/paths/mod.rs
@@ -1,6 +1,7 @@
 use std::{
     ffi::{OsStr, OsString},
     fs,
+    io::Read,
     path::{Component, Path, PathBuf},
 };
 
@@ -259,7 +260,12 @@ fn normalize_lexically(path: &Path) -> PathBuf {
             Component::CurDir => {}
             Component::ParentDir => {
                 if !result.pop() {
-                    log::debug!("path {} escapes its root; clamped", path.display());
+                    // The path is being rewritten to somewhere the user did
+                    // not ask for; that is worth more than a debug line.
+                    log::warn!(
+                        "path {} escapes its root; the leading `..` was dropped",
+                        path.display()
+                    );
                 }
             }
             other => result.push(other.as_os_str()),
@@ -361,30 +367,50 @@ fn is_file_list_path(path: &Path) -> bool {
         .is_some_and(|name| name.eq_ignore_ascii_case(FILE_LIST_NAME))
 }
 
+/// Largest accepted `file.list`, in bytes.
+///
+/// A list is a hand-written or tool-generated manifest of file paths; past
+/// this size something is wrong, and reading it unbounded could exhaust
+/// memory on a hostile or accidental giant file.
+const MAX_FILE_LIST_BYTES: u64 = 64 * 1024 * 1024;
+
 fn read_file_list_entries(path: &Path) -> Result<Vec<PathBuf>, String> {
-    let content = fs::read_to_string(path).map_err(|error| {
-        format!(
-            "Failed to read file list {} as UTF-8: {error}",
-            path.display()
-        )
-    })?;
+    let mut content = String::new();
+    fs::File::open(path)
+        .and_then(|file| {
+            file.take(MAX_FILE_LIST_BYTES + 1)
+                .read_to_string(&mut content)
+        })
+        .map_err(|error| {
+            format!(
+                "Failed to read file list {} as UTF-8: {error}",
+                path.display()
+            )
+        })?;
+    if content.len() as u64 > MAX_FILE_LIST_BYTES {
+        return Err(format!(
+            "File list {} exceeds the {} MiB size limit",
+            path.display(),
+            MAX_FILE_LIST_BYTES / 1024 / 1024
+        ));
+    }
     Ok(content
         .strip_prefix('\u{FEFF}')
         .unwrap_or(&content)
         .lines()
-        .map(|s| {
-            let s = s
-                .trim()
-                .trim_matches(['"', '\''])
-                .trim_end_matches(['\\', '/']);
-
-            if s.contains("\u{FFFD}") {
-                log::warn!(
-                    "Line {s} in `file.list` {} may not encoding with valid UTF-8.",
-                    path.display()
-                );
-            }
-            s
+        .map(|line| {
+            let line = line.trim();
+            // Strip one matched pair of surrounding quotes: Windows tools
+            // export paths quoted, but a file whose name genuinely starts
+            // or ends with a lone quote must keep it.
+            let line = match line.as_bytes() {
+                [b'"', .., b'"'] | [b'\'', .., b'\''] => &line[1..line.len() - 1],
+                _ => line,
+            };
+            // A trailing '/' marks a directory entry in exported lists.
+            // '\' is left alone: it is a legitimate file-name character on
+            // Unix, not a separator.
+            line.trim_end_matches('/')
         })
         .filter(|line| !line.is_empty())
         .map(PathBuf::from)

--- a/src/cli/utils/paths/mod.rs
+++ b/src/cli/utils/paths/mod.rs
@@ -149,7 +149,17 @@ fn validate_output_file_name(name: &OsStr) -> Result<(), String> {
         {
             return Err(format!("Output file name {text:?} is not valid on Windows"));
         }
-        let base = text.split('.').next().unwrap_or_default();
+        // Win32 silently strips trailing dots and spaces from file names,
+        // so "out." and "out " would be written as "out" — a different file
+        // than the one reported, and possibly one that aliases a reserved
+        // device name ("CON .png" normalises to the reserved "CON").
+        let stripped = text.trim_end_matches([' ', '.']);
+        if stripped.len() != text.len() {
+            return Err(format!(
+                "Output file name {text:?} ends with a dot or space, which Windows silently strips"
+            ));
+        }
+        let base = stripped.split('.').next().unwrap_or_default().trim_end();
         let reserved = matches!(
             base.to_ascii_uppercase().as_str(),
             "CON"

--- a/src/cli/utils/paths/tests.rs
+++ b/src/cli/utils/paths/tests.rs
@@ -239,6 +239,54 @@ fn file_list_must_be_readable_utf8() {
 }
 
 #[test]
+fn file_list_strips_only_matched_quote_pairs() {
+    let root = unique_test_dir("file-list-quotes");
+    fs::create_dir_all(&root).unwrap();
+    let list = root.join("file.list");
+    // A quoted path loses the pair; a name with a lone quote keeps it.
+    fs::write(&list, "\"photos/a.jpg\"\n'photos/b.jpg'\n\"odd.jpg\n").unwrap();
+
+    let entries = read_file_list_entries(&list).unwrap();
+    assert_eq!(
+        entries,
+        vec![
+            PathBuf::from("photos/a.jpg"),
+            PathBuf::from("photos/b.jpg"),
+            PathBuf::from("\"odd.jpg"),
+        ]
+    );
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn file_list_keeps_trailing_backslashes() {
+    let root = unique_test_dir("file-list-backslash");
+    fs::create_dir_all(&root).unwrap();
+    let list = root.join("file.list");
+    // `dir\` is a legitimate Unix file name; only '/' marks a directory.
+    fs::write(&list, "dir\\\ndir/\n").unwrap();
+
+    let entries = read_file_list_entries(&list).unwrap();
+    assert_eq!(
+        entries,
+        vec![PathBuf::from("dir\\"), PathBuf::from("dir")]
+    );
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn file_list_beyond_the_size_cap_is_rejected() {
+    let root = unique_test_dir("file-list-huge");
+    fs::create_dir_all(&root).unwrap();
+    let list = root.join("file.list");
+    fs::write(&list, vec![b'x'; (MAX_FILE_LIST_BYTES + 2) as usize]).unwrap();
+
+    let error = read_file_list_entries(&list).unwrap_err();
+    assert!(error.contains("size limit"), "{error}");
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
 fn expand_file_lists_uses_only_lists_and_ignores_other_inputs() {
     let root = unique_test_dir("expand-file-list");
     fs::create_dir_all(root.join("photos")).unwrap();

--- a/src/cli/utils/paths/tests.rs
+++ b/src/cli/utils/paths/tests.rs
@@ -3,6 +3,9 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
+#[cfg(windows)]
+use std::ffi::OsStr;
+
 use super::*;
 
 fn unique_test_dir(name: &str) -> PathBuf {
@@ -339,6 +342,26 @@ fn expand_file_lists_without_lists_keeps_all_inputs() {
     expected.sort();
     assert_eq!(files, expected);
     fs::remove_dir_all(root).unwrap();
+}
+
+/// Win32 strips trailing dots and spaces from file names before writing, so
+/// accepting them would silently redirect the output to a different file —
+/// and "CON .png" would normalise onto the reserved CON device.
+#[cfg(windows)]
+#[test]
+fn windows_output_names_cannot_end_in_a_dot_or_space() {
+    for bad in ["out.", "out ", "out. ", "CON .png", "con.txt", "NUL."] {
+        assert!(
+            validate_output_file_name(OsStr::new(bad)).is_err(),
+            "{bad:?} must be rejected"
+        );
+    }
+    for ok in ["out.jpg", "out .jpg", "out..jpg", "concepts.png", "logo.png"] {
+        assert!(
+            validate_output_file_name(OsStr::new(ok)).is_ok(),
+            "{ok:?} must be accepted"
+        );
+    }
 }
 
 #[cfg(unix)]

--- a/src/codecs/avif/decoder/mod.rs
+++ b/src/codecs/avif/decoder/mod.rs
@@ -212,8 +212,10 @@ fn color_transform(coefficients: MatrixCoefficients) -> Result<ColorTransform, I
             kb: 0.087,
             standard: YuvStandardMatrix::Smpte240,
         }),
-        MatrixCoefficients::BT2020NonConstantLuminance
-        | MatrixCoefficients::BT2020ConstantLuminance => Ok(ColorTransform::Ycbcr {
+        MatrixCoefficients::BT2020ConstantLuminance => Err(decode_error(
+            "unsupported matrix coefficients (BT.2020 constant luminance)",
+        )),
+        MatrixCoefficients::BT2020NonConstantLuminance => Ok(ColorTransform::Ycbcr {
             kr: 0.2627,
             kb: 0.0593,
             standard: YuvStandardMatrix::Bt2020,

--- a/src/codecs/avif/decoder/mod.rs
+++ b/src/codecs/avif/decoder/mod.rs
@@ -1,9 +1,49 @@
 use std::{io::Read, marker::PhantomData};
 
+use dav1d::{
+    Decoder, Error as Dav1dError, Picture, PixelLayout, PlanarImageComponent,
+    pixel::{MatrixCoefficients, YUVRange as Dav1dYuvRange},
+};
+use yuvutils_rs::{
+    YuvGrayImage, YuvPlanarImage, YuvRange, YuvStandardMatrix, ycgco420_to_rgba, ycgco422_to_rgba,
+    ycgco444_to_rgba, yuv400_to_rgba, yuv420_to_rgba, yuv422_to_rgba, yuv444_to_rgba,
+};
 use zune_core::colorspace::ColorSpace;
 use zune_image::{errors::ImageErrors, image::Image, traits::DecoderTrait};
 
-/// A AVIF decoder
+/// Checks whether `data` looks like an AVIF file.
+///
+/// An ISO-BMFF file must start with an `ftyp` box (ISO 14496-12 § 4.3.1) that
+/// carries the `avif` or `avis` brand either as the major brand or somewhere in
+/// the compatible brands list.
+pub fn is_avif(data: &[u8]) -> bool {
+    if data.len() < 12 || &data[4..8] != b"ftyp" {
+        return false;
+    }
+
+    let size = u32::from_be_bytes([data[0], data[1], data[2], data[3]]) as usize;
+    let end = if size == 0 {
+        data.len()
+    } else {
+        size.min(data.len())
+    };
+
+    let brand = |b: &[u8]| b == b"avif" || b == b"avis";
+
+    if brand(&data[8..12]) {
+        return true;
+    }
+
+    // compatible brands start after the 4-byte minor version
+    end >= 16
+        && data[16..end]
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .any(|arg0: &[u8; 4]| brand(arg0))
+}
+
+/// A AVIF decoder that decodes the AV1 bitstream through `dav1d`
 pub struct AvifDecoder<R: Read> {
     inner: Vec<u8>,
     dimensions: Option<(usize, usize)>,
@@ -29,13 +69,22 @@ where
     R: Read,
 {
     fn decode(&mut self) -> Result<Image, ImageErrors> {
-        let img = libavif::decode_rgb(&self.inner)
-            .map_err(|e| ImageErrors::ImageDecodeErrors(e.to_string()))?;
+        let parsed = avif_parse::read_avif(&mut self.inner.as_slice()).map_err(decode_error)?;
 
-        let (w, h) = (img.width() as usize, img.height() as usize);
-        self.dimensions = Some((w, h));
+        let color = decode_av1_stream(&parsed.primary_item)?;
+        let alpha = parsed
+            .alpha_item
+            .as_deref()
+            .filter(|stream| !stream.is_empty())
+            .map(decode_av1_stream)
+            .transpose()?;
 
-        Ok(Image::from_u8(&img, w, h, ColorSpace::RGBA))
+        let rgba = picture_to_rgba(&color, alpha.as_ref(), parsed.premultiplied_alpha)?;
+
+        let (width, height) = (color.width() as usize, color.height() as usize);
+        self.dimensions = Some((width, height));
+
+        Ok(Image::from_u8(&rgba, width, height, ColorSpace::RGBA))
     }
 
     fn dimensions(&self) -> Option<(usize, usize)> {
@@ -47,8 +96,476 @@ where
     }
 
     fn name(&self) -> &'static str {
-        "avif-decoder (aom)"
+        "avif-decoder (dav1d)"
     }
+}
+
+fn decode_error(err: impl std::fmt::Display) -> ImageErrors {
+    ImageErrors::ImageDecodeErrors(format!("avif: {err}"))
+}
+
+/// Decodes a still-picture AV1 bitstream and returns its frame.
+///
+/// Still AVIF carries a single frame, so frame threading is disabled through
+/// `max_frame_delay`: it would otherwise hold the picture back until an
+/// end-of-stream drain, and `dav1d_flush` only discards state instead of
+/// draining it.
+fn decode_av1_stream(data: &[u8]) -> Result<Picture, ImageErrors> {
+    let mut settings = dav1d::Settings::new();
+    settings.set_max_frame_delay(1);
+
+    let mut decoder = Decoder::with_settings(&settings).map_err(decode_error)?;
+
+    match decoder.send_data(data.to_vec(), None, None, None) {
+        // `Again` only means decoded frames are pending retrieval, not rejection
+        Ok(()) | Err(Dav1dError::Again) => {}
+        Err(err) => return Err(decode_error(err)),
+    }
+
+    let mut pending_pushed = false;
+    loop {
+        match decoder.get_picture() {
+            Ok(picture) => return Ok(picture),
+            Err(Dav1dError::Again) => {
+                if pending_pushed {
+                    return Err(ImageErrors::ImageDecodeErrors(
+                        "avif: the bitstream contains no frame".into(),
+                    ));
+                }
+                decoder.send_pending_data().map_err(decode_error)?;
+                pending_pushed = true;
+            }
+            Err(err) => return Err(decode_error(err)),
+        }
+    }
+}
+
+fn picture_to_rgba(
+    color: &Picture,
+    alpha: Option<&Picture>,
+    premultiplied: bool,
+) -> Result<Vec<u8>, ImageErrors> {
+    let (width, height) = (color.width() as usize, color.height() as usize);
+
+    if let Some(alpha) = alpha
+        && (alpha.width() as usize != width || alpha.height() as usize != height)
+    {
+        return Err(ImageErrors::ImageDecodeErrors(
+            "avif: alpha item dimensions do not match the color item".into(),
+        ));
+    }
+
+    let mut rgba = vec![0u8; width * height * 4];
+
+    if color.matrix_coefficients() == MatrixCoefficients::Identity {
+        identity_planes_to_rgba(color, &mut rgba);
+    } else {
+        color_planes_to_rgba(color, &mut rgba)?;
+    }
+
+    if let Some(alpha) = alpha {
+        merge_alpha_plane(&mut rgba, alpha, width, height);
+    }
+
+    if premultiplied {
+        unpremultiply_rgba(&mut rgba);
+    }
+
+    Ok(rgba)
+}
+
+enum ColorTransform {
+    /// YCbCr with the ITU-R kr/kb weights of the bitstream's matrix, plus the
+    /// matching yuvutils preset for the 8-bit path.
+    Ycbcr {
+        kr: f32,
+        kb: f32,
+        standard: YuvStandardMatrix,
+    },
+    /// YCgCo (H.273 matrix 8); full range only.
+    Ycgco,
+}
+
+fn color_transform(coefficients: MatrixCoefficients) -> Result<ColorTransform, ImageErrors> {
+    match coefficients {
+        MatrixCoefficients::BT709 => Ok(ColorTransform::Ycbcr {
+            kr: 0.2126,
+            kb: 0.0722,
+            standard: YuvStandardMatrix::Bt709,
+        }),
+        MatrixCoefficients::BT470M => Ok(ColorTransform::Ycbcr {
+            kr: 0.30,
+            kb: 0.11,
+            standard: YuvStandardMatrix::Custom(0.30, 0.11),
+        }),
+        // BT.470BG and ST-170M are both BT.601; libavif also defaults to BT.601
+        // when the bitstream leaves the matrix unspecified
+        MatrixCoefficients::BT470BG
+        | MatrixCoefficients::ST170M
+        | MatrixCoefficients::Unspecified => Ok(ColorTransform::Ycbcr {
+            kr: 0.299,
+            kb: 0.114,
+            standard: YuvStandardMatrix::Bt601,
+        }),
+        MatrixCoefficients::ST240M => Ok(ColorTransform::Ycbcr {
+            kr: 0.212,
+            kb: 0.087,
+            standard: YuvStandardMatrix::Smpte240,
+        }),
+        MatrixCoefficients::BT2020NonConstantLuminance
+        | MatrixCoefficients::BT2020ConstantLuminance => Ok(ColorTransform::Ycbcr {
+            kr: 0.2627,
+            kb: 0.0593,
+            standard: YuvStandardMatrix::Bt2020,
+        }),
+        MatrixCoefficients::YCgCo => Ok(ColorTransform::Ycgco),
+        other => Err(decode_error(format!(
+            "unsupported matrix coefficients ({other})"
+        ))),
+    }
+}
+
+fn color_planes_to_rgba(color: &Picture, rgba: &mut [u8]) -> Result<(), ImageErrors> {
+    let (width, height) = (color.width() as usize, color.height() as usize);
+    let range = match color.color_range() {
+        Dav1dYuvRange::Full => YuvRange::Full,
+        _ => YuvRange::Limited,
+    };
+    let transform = color_transform(color.matrix_coefficients())?;
+    let layout = color.pixel_layout();
+
+    if layout == PixelLayout::I400 {
+        return monochrome_to_rgba(color, rgba, range);
+    }
+
+    if color.bit_depth() == 8 {
+        let image = YuvPlanarImage {
+            y_plane: &color.plane(PlanarImageComponent::Y),
+            y_stride: color.stride(PlanarImageComponent::Y),
+            u_plane: &color.plane(PlanarImageComponent::U),
+            u_stride: color.stride(PlanarImageComponent::U),
+            v_plane: &color.plane(PlanarImageComponent::V),
+            v_stride: color.stride(PlanarImageComponent::V),
+            width: width as u32,
+            height: height as u32,
+        };
+
+        match (transform, layout) {
+            (ColorTransform::Ycbcr { standard, .. }, PixelLayout::I420) => {
+                yuv420_to_rgba(&image, rgba, rgba_stride(width), range, standard)
+            }
+            (ColorTransform::Ycbcr { standard, .. }, PixelLayout::I422) => {
+                yuv422_to_rgba(&image, rgba, rgba_stride(width), range, standard)
+            }
+            (ColorTransform::Ycbcr { standard, .. }, PixelLayout::I444) => {
+                yuv444_to_rgba(&image, rgba, rgba_stride(width), range, standard)
+            }
+            (ColorTransform::Ycgco, PixelLayout::I420) => {
+                ycgco420_to_rgba(&image, rgba, rgba_stride(width), range)
+            }
+            (ColorTransform::Ycgco, PixelLayout::I422) => {
+                ycgco422_to_rgba(&image, rgba, rgba_stride(width), range)
+            }
+            (ColorTransform::Ycgco, PixelLayout::I444) => {
+                ycgco444_to_rgba(&image, rgba, rgba_stride(width), range)
+            }
+            _ => unreachable!("layout is not monochrome here"),
+        }
+        .map_err(decode_error)
+    } else {
+        // `Plane` owns an `Arc` clone of the picture, so bind the planes here
+        // and hand `Planes` slices of them
+        let y_plane = color.plane(PlanarImageComponent::Y);
+        let u_plane = color.plane(PlanarImageComponent::U);
+        let v_plane = color.plane(PlanarImageComponent::V);
+        let view = Planes {
+            y: &y_plane,
+            y_stride: color.stride(PlanarImageComponent::Y) as usize,
+            u: &u_plane,
+            u_stride: color.stride(PlanarImageComponent::U) as usize,
+            v: &v_plane,
+            v_stride: color.stride(PlanarImageComponent::V) as usize,
+            width,
+            height,
+            layout,
+        };
+        high_depth_ycbcr_to_rgba(
+            &view,
+            color.bits_per_component().map(|bits| bits.0).unwrap_or(8),
+            color.color_range() == Dav1dYuvRange::Full,
+            &transform,
+            rgba,
+        );
+        Ok(())
+    }
+}
+
+/// Monochrome pictures only carry luma; gray expansion never uses the matrix.
+fn monochrome_to_rgba(
+    color: &Picture,
+    rgba: &mut [u8],
+    range: YuvRange,
+) -> Result<(), ImageErrors> {
+    let (width, height) = (color.width() as usize, color.height() as usize);
+
+    if color.bit_depth() == 8 {
+        let gray = YuvGrayImage {
+            y_plane: &color.plane(PlanarImageComponent::Y),
+            y_stride: color.stride(PlanarImageComponent::Y),
+            width: width as u32,
+            height: height as u32,
+        };
+
+        yuv400_to_rgba(
+            &gray,
+            rgba,
+            rgba_stride(width),
+            range,
+            YuvStandardMatrix::Bt601,
+        )
+        .map_err(decode_error)
+    } else {
+        let used = used_bits(color)?;
+        let full_range = color.color_range() == Dav1dYuvRange::Full;
+        let plane = &color.plane(PlanarImageComponent::Y);
+        let stride = color.stride(PlanarImageComponent::Y) as usize;
+
+        for row in 0..height {
+            let source = &plane[row * stride..][..width * 2];
+            let out = &mut rgba[row * width * 4..][..width * 4];
+            for (x, bytes) in source.as_chunks::<2>().0.iter().enumerate() {
+                let sample = u16::from_le_bytes([bytes[0], bytes[1]]) as u32;
+                // clamp: lossy bitstreams can undershoot the limited range
+                let gray = expand_luma(sample, used, full_range).clamp(0.0, 255.0) as u8;
+                out[x * 4] = gray;
+                out[x * 4 + 1] = gray;
+                out[x * 4 + 2] = gray;
+                out[x * 4 + 3] = 255;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// AV1 identity matrix carries RGB directly in the planes: Y=G, U=B, V=R.
+fn identity_planes_to_rgba(color: &Picture, rgba: &mut [u8]) {
+    let (width, height) = (color.width() as usize, color.height() as usize);
+    let g_plane = &color.plane(PlanarImageComponent::Y);
+    let g_stride = color.stride(PlanarImageComponent::Y) as usize;
+    let b_plane = &color.plane(PlanarImageComponent::U);
+    let b_stride = color.stride(PlanarImageComponent::U) as usize;
+    let r_plane = &color.plane(PlanarImageComponent::V);
+    let r_stride = color.stride(PlanarImageComponent::V) as usize;
+
+    if color.bit_depth() == 8 {
+        for y in 0..height {
+            let row = &mut rgba[y * width * 4..][..width * 4];
+            for (x, px) in row.as_chunks_mut::<4>().0.iter_mut().enumerate() {
+                px[0] = r_plane[y * r_stride + x];
+                px[1] = g_plane[y * g_stride + x];
+                px[2] = b_plane[y * b_stride + x];
+                px[3] = 255;
+            }
+        }
+    } else {
+        let used = used_bits(color).unwrap_or(16);
+        for y in 0..height {
+            let row = &mut rgba[y * width * 4..][..width * 4];
+            for (x, px) in row.as_chunks_mut::<4>().0.iter_mut().enumerate() {
+                px[0] = sample_u8(&r_plane[y * r_stride + x * 2..], used);
+                px[1] = sample_u8(&g_plane[y * g_stride + x * 2..], used);
+                px[2] = sample_u8(&b_plane[y * b_stride + x * 2..], used);
+                px[3] = 255;
+            }
+        }
+    }
+}
+
+/// Copies the alpha stream's luma plane into the RGBA alpha channel.
+fn merge_alpha_plane(rgba: &mut [u8], alpha: &Picture, width: usize, height: usize) {
+    let plane = &alpha.plane(PlanarImageComponent::Y);
+    let stride = alpha.stride(PlanarImageComponent::Y) as usize;
+
+    if alpha.bit_depth() == 8 {
+        for y in 0..height {
+            let source = &plane[y * stride..][..width];
+            let row = &mut rgba[y * width * 4..][..width * 4];
+            for (x, &a) in source.iter().enumerate() {
+                row[x * 4 + 3] = a;
+            }
+        }
+    } else {
+        let used = used_bits(alpha).unwrap_or(16);
+        for y in 0..height {
+            let source = &plane[y * stride..][..width * 2];
+            let row = &mut rgba[y * width * 4..][..width * 4];
+            for (x, bytes) in source.as_chunks::<2>().0.iter().enumerate() {
+                row[x * 4 + 3] = sample_u8(bytes, used);
+            }
+        }
+    }
+}
+
+/// Recovers straight alpha from premultiplied color (MIAF § 7.3.5.2).
+fn unpremultiply_rgba(rgba: &mut [u8]) {
+    for px in rgba.as_chunks_mut::<4>().0 {
+        let a = px[3] as u32;
+        if a > 0 && a < 255 {
+            px[0] = ((px[0] as u32 * 255 + a / 2) / a).min(255) as u8;
+            px[1] = ((px[1] as u32 * 255 + a / 2) / a).min(255) as u8;
+            px[2] = ((px[2] as u32 * 255 + a / 2) / a).min(255) as u8;
+        }
+    }
+}
+
+/// Raw planar slices of a picture, valid as long as the borrowed `Plane`s.
+struct Planes<'a> {
+    y: &'a [u8],
+    y_stride: usize,
+    u: &'a [u8],
+    u_stride: usize,
+    v: &'a [u8],
+    v_stride: usize,
+    width: usize,
+    height: usize,
+    layout: PixelLayout,
+}
+
+impl Planes<'_> {
+    fn sample(&self, component: Sample, x: usize, y: usize) -> u16 {
+        let (plane, stride) = match component {
+            Sample::Y => (self.y, self.y_stride),
+            Sample::U => (self.u, self.u_stride),
+            Sample::V => (self.v, self.v_stride),
+        };
+        let offset = y * stride + x * 2;
+        u16::from_le_bytes([plane[offset], plane[offset + 1]])
+    }
+}
+
+enum Sample {
+    Y,
+    U,
+    V,
+}
+
+/// Scalar YCbCr/YCgCo -> RGBA8 conversion for >8-bit pictures.
+///
+/// Done by hand because yuvutils-rs 0.8.3 gets >8-bit conversions wrong: its
+/// SIMD kernels corrupt the alpha channel and its BT.2020 inverse mis-scales
+/// the red channel.
+///
+/// Chroma is nearest-neighbor upsampled; BT.2020 constant luminance is treated
+/// as non-constant luminance.
+fn high_depth_ycbcr_to_rgba(
+    planes: &Planes,
+    used: usize,
+    full_range: bool,
+    transform: &ColorTransform,
+    rgba: &mut [u8],
+) {
+    let width = planes.width;
+    let height = planes.height;
+    // chroma sits at half resolution horizontally for 4:2:0/4:2:2 and
+    // vertically only for 4:2:0
+    let chroma_down_x = planes.layout != PixelLayout::I444;
+    let chroma_down_y = planes.layout == PixelLayout::I420;
+
+    for row in 0..height {
+        let chroma_row = if chroma_down_y { row / 2 } else { row };
+        let out = &mut rgba[row * width * 4..][..width * 4];
+        for (x, px) in out.as_chunks_mut::<4>().0.iter_mut().enumerate() {
+            let chroma_x = if chroma_down_x { x / 2 } else { x };
+
+            let y = expand_luma(planes.sample(Sample::Y, x, row) as u32, used, full_range);
+
+            let (r, g, b) = match transform {
+                ColorTransform::Ycbcr { kr, kb, .. } => {
+                    let cb = expand_chroma(
+                        planes.sample(Sample::U, chroma_x, chroma_row) as u32,
+                        used,
+                        full_range,
+                    );
+                    let cr = expand_chroma(
+                        planes.sample(Sample::V, chroma_x, chroma_row) as u32,
+                        used,
+                        full_range,
+                    );
+                    let kb_g = 2.0 * kb * (1.0 - kb) / (1.0 - kr - kb);
+                    let kr_g = 2.0 * kr * (1.0 - kr) / (1.0 - kr - kb);
+                    (
+                        y + (2.0 - 2.0 * kr) * cr,
+                        y - kb_g * cb - kr_g * cr,
+                        y + (2.0 - 2.0 * kb) * cb,
+                    )
+                }
+                ColorTransform::Ycgco => {
+                    let cg = expand_chroma(
+                        planes.sample(Sample::U, chroma_x, chroma_row) as u32,
+                        used,
+                        full_range,
+                    );
+                    let co = expand_chroma(
+                        planes.sample(Sample::V, chroma_x, chroma_row) as u32,
+                        used,
+                        full_range,
+                    );
+                    (y - cg + co, y + cg, y - cg - co)
+                }
+            };
+
+            px[0] = clamp_u8(r);
+            px[1] = clamp_u8(g);
+            px[2] = clamp_u8(b);
+            px[3] = 255;
+        }
+    }
+}
+
+/// Maps a luma sample to the 8-bit domain.
+fn expand_luma(sample: u32, used: usize, full_range: bool) -> f32 {
+    if full_range {
+        sample as f32 * 255.0 / (((1u32 << used) - 1) as f32)
+    } else {
+        let floor = 16u32 << (used - 8);
+        let span = 219u32 << (used - 8);
+        (sample.saturating_sub(floor)) as f32 * 255.0 / span as f32
+    }
+}
+
+/// Maps a chroma sample to a signed offset in the 8-bit domain.
+fn expand_chroma(sample: u32, used: usize, full_range: bool) -> f32 {
+    let mid = 1u32 << (used - 1);
+    if full_range {
+        (sample as i32 - mid as i32) as f32 * 255.0 / mid as f32
+    } else {
+        let floor = 16u32 << (used - 8);
+        let span = 224u32 << (used - 8);
+        (sample.saturating_sub(floor) as i32 - (span / 2) as i32) as f32 * 255.0 / span as f32
+    }
+}
+
+fn clamp_u8(value: f32) -> u8 {
+    (value + 0.5).clamp(0.0, 255.0) as u8
+}
+
+fn rgba_stride(width: usize) -> u32 {
+    (width * 4) as u32
+}
+
+/// Number of bits actually used by the samples of a picture.
+fn used_bits(picture: &Picture) -> Result<usize, ImageErrors> {
+    picture
+        .bits_per_component()
+        .map(|bits| bits.0)
+        .ok_or_else(|| decode_error("unknown bit depth"))
+}
+
+/// Reads a little-endian sample and scales it down to 8 bits.
+fn sample_u8(bytes: &[u8], used: usize) -> u8 {
+    let value = u16::from_le_bytes([bytes[0], bytes[1]]) as u32;
+    let max = ((1u32 << used) - 1).max(1);
+    ((value * 255 + max / 2) / max) as u8
 }
 
 #[cfg(test)]

--- a/src/codecs/avif/decoder/mod.rs
+++ b/src/codecs/avif/decoder/mod.rs
@@ -167,13 +167,13 @@ fn picture_to_rgba(
     let mut rgba = vec![0u8; rgba_len];
 
     if color.matrix_coefficients() == MatrixCoefficients::Identity {
-        identity_planes_to_rgba(color, &mut rgba);
+        identity_planes_to_rgba(color, &mut rgba)?;
     } else {
         color_planes_to_rgba(color, &mut rgba)?;
     }
 
     if let Some(alpha) = alpha {
-        merge_alpha_plane(&mut rgba, alpha, width, height);
+        merge_alpha_plane(&mut rgba, alpha, width, height)?;
     }
 
     if premultiplied {
@@ -302,7 +302,7 @@ fn color_planes_to_rgba(color: &Picture, rgba: &mut [u8]) -> Result<(), ImageErr
         };
         high_depth_ycbcr_to_rgba(
             &view,
-            color.bits_per_component().map(|bits| bits.0).unwrap_or(8),
+            color.bits_per_component().map(|bits| bits.0.clamp(8, 16)).unwrap_or(8),
             color.color_range() == Dav1dYuvRange::Full,
             &transform,
             rgba,
@@ -341,6 +341,8 @@ fn monochrome_to_rgba(
         let plane = &color.plane(PlanarImageComponent::Y);
         let stride = color.stride(PlanarImageComponent::Y) as usize;
 
+        check_plane(plane, stride, height, width * 2)?;
+
         for row in 0..height {
             let source = &plane[row * stride..][..width * 2];
             let out = &mut rgba[row * width * 4..][..width * 4];
@@ -359,7 +361,7 @@ fn monochrome_to_rgba(
 }
 
 /// AV1 identity matrix carries RGB directly in the planes: Y=G, U=B, V=R.
-fn identity_planes_to_rgba(color: &Picture, rgba: &mut [u8]) {
+fn identity_planes_to_rgba(color: &Picture, rgba: &mut [u8]) -> Result<(), ImageErrors> {
     let (width, height) = (color.width() as usize, color.height() as usize);
     let g_plane = &color.plane(PlanarImageComponent::Y);
     let g_stride = color.stride(PlanarImageComponent::Y) as usize;
@@ -367,6 +369,15 @@ fn identity_planes_to_rgba(color: &Picture, rgba: &mut [u8]) {
     let b_stride = color.stride(PlanarImageComponent::U) as usize;
     let r_plane = &color.plane(PlanarImageComponent::V);
     let r_stride = color.stride(PlanarImageComponent::V) as usize;
+
+    let bytes_per_sample = if color.bit_depth() == 8 { 1 } else { 2 };
+    for (plane, stride) in [
+        (&r_plane[..], r_stride),
+        (&g_plane[..], g_stride),
+        (&b_plane[..], b_stride),
+    ] {
+        check_plane(plane, stride, height, width * bytes_per_sample)?;
+    }
 
     if color.bit_depth() == 8 {
         for y in 0..height {
@@ -390,12 +401,19 @@ fn identity_planes_to_rgba(color: &Picture, rgba: &mut [u8]) {
             }
         }
     }
+
+    Ok(())
 }
 
 /// Copies the alpha stream's luma plane into the RGBA alpha channel.
-fn merge_alpha_plane(rgba: &mut [u8], alpha: &Picture, width: usize, height: usize) {
+fn merge_alpha_plane(
+    rgba: &mut [u8], alpha: &Picture, width: usize, height: usize,
+) -> Result<(), ImageErrors> {
     let plane = &alpha.plane(PlanarImageComponent::Y);
     let stride = alpha.stride(PlanarImageComponent::Y) as usize;
+
+    let bytes_per_sample = if alpha.bit_depth() == 8 { 1 } else { 2 };
+    check_plane(plane, stride, height, width * bytes_per_sample)?;
 
     if alpha.bit_depth() == 8 {
         for y in 0..height {
@@ -414,6 +432,30 @@ fn merge_alpha_plane(rgba: &mut [u8], alpha: &Picture, width: usize, height: usi
                 row[x * 4 + 3] = sample_u8(bytes, used);
             }
         }
+    }
+
+    Ok(())
+}
+
+/// Verify a plane holds `height` rows of `row_bytes` at `stride`, so the
+/// conversion loops can index it without per-pixel bounds checks.
+///
+/// dav1d promises a stride of at least the row width, but a short plane is
+/// not worth a panic in a worker thread, where the release profile's
+/// `panic = "abort"` would take down the whole process.
+fn check_plane(
+    plane: &[u8], stride: usize, height: usize, row_bytes: usize,
+) -> Result<(), ImageErrors> {
+    let needed = height
+        .checked_sub(1)
+        .map_or(Some(0), |last_row| last_row.checked_mul(stride))
+        .and_then(|offset| offset.checked_add(row_bytes));
+
+    match needed {
+        Some(needed) if plane.len() >= needed => Ok(()),
+        _ => Err(decode_error(
+            "decoded plane is smaller than its dimensions imply",
+        )),
     }
 }
 
@@ -571,10 +613,14 @@ fn rgba_stride(width: usize) -> u32 {
 }
 
 /// Number of bits actually used by the samples of a picture.
+///
+/// dav1d only ever reports 8, 10 or 12, but the value is clamped to 8..=16
+/// anyway: below 8 the `used - 8` shifts in `expand_luma`/`expand_chroma`
+/// underflow, and above 16 the `1 << used` shifts overflow.
 fn used_bits(picture: &Picture) -> Result<usize, ImageErrors> {
     picture
         .bits_per_component()
-        .map(|bits| bits.0)
+        .map(|bits| bits.0.clamp(8, 16))
         .ok_or_else(|| decode_error("unknown bit depth"))
 }
 

--- a/src/codecs/avif/decoder/mod.rs
+++ b/src/codecs/avif/decoder/mod.rs
@@ -155,7 +155,16 @@ fn picture_to_rgba(
         ));
     }
 
-    let mut rgba = vec![0u8; width * height * 4];
+    let rgba_len = width
+        .checked_mul(height)
+        .and_then(|pixels| pixels.checked_mul(4))
+        .ok_or_else(|| {
+            ImageErrors::ImageDecodeErrors(
+                "avif: decoded dimensions overflow the output buffer size".into(),
+            )
+        })?;
+
+    let mut rgba = vec![0u8; rgba_len];
 
     if color.matrix_coefficients() == MatrixCoefficients::Identity {
         identity_planes_to_rgba(color, &mut rgba);
@@ -441,6 +450,12 @@ impl Planes<'_> {
             Sample::V => (self.v, self.v_stride),
         };
         let offset = y * stride + x * 2;
+        // Bounds-check the 2-byte sample: if the plane is shorter than
+        // expected (corrupted bitstream or mismatched stride), return 0
+        // rather than panicking across the FFI boundary.
+        if offset + 2 > plane.len() {
+            return 0;
+        }
         u16::from_le_bytes([plane[offset], plane[offset + 1]])
     }
 }
@@ -564,8 +579,15 @@ fn used_bits(picture: &Picture) -> Result<usize, ImageErrors> {
 }
 
 /// Reads a little-endian sample and scales it down to 8 bits.
+///
+/// Returns 0 when the slice is too short to hold a full 2-byte sample, which
+/// can happen with a corrupted bitstream or mismatched stride. Returning a
+/// neutral value is safer than panicking across the dav1d FFI boundary.
 fn sample_u8(bytes: &[u8], used: usize) -> u8 {
-    let value = u16::from_le_bytes([bytes[0], bytes[1]]) as u32;
+    let Some(arr) = bytes.get(..2) else {
+        return 0;
+    };
+    let value = u16::from_le_bytes([arr[0], arr[1]]) as u32;
     let max = ((1u32 << used) - 1).max(1);
     ((value * 255 + max / 2) / max) as u8
 }

--- a/src/codecs/avif/decoder/tests.rs
+++ b/src/codecs/avif/decoder/tests.rs
@@ -13,3 +13,128 @@ fn decode() {
     assert_eq!(img.dimensions(), (48, 80));
     assert_eq!(img.colorspace(), ColorSpace::RGBA);
 }
+
+/// Packs samples into little-endian 16-bit rows; `stride` is in bytes.
+fn u16_plane(samples: &[u16], stride: usize, rows: usize) -> Vec<u8> {
+    let mut plane = vec![0u8; stride * rows];
+    for (row, sample_row) in samples.chunks(stride / 2).take(rows).enumerate() {
+        for (column, &sample) in sample_row.iter().enumerate() {
+            let bytes = sample.to_le_bytes();
+            plane[row * stride + column * 2] = bytes[0];
+            plane[row * stride + column * 2 + 1] = bytes[1];
+        }
+    }
+    plane
+}
+
+#[test]
+fn high_depth_bt2020_limited() {
+    // values taken from a real 10-bit sample; yuvutils-rs 0.8.3 mis-scales the
+    // red channel for exactly this input (limited range, BT.2020, positive Cr)
+    let y = u16_plane(&[834; 32], 16, 4);
+    let u = u16_plane(&[491; 8], 8, 2);
+    let v = u16_plane(&[586; 8], 8, 2);
+    let planes = Planes {
+        y: &y,
+        y_stride: 16,
+        u: &u,
+        u_stride: 8,
+        v: &v,
+        v_stride: 8,
+        width: 8,
+        height: 4,
+        layout: PixelLayout::I420,
+    };
+
+    let mut rgba = vec![0u8; 8 * 4 * 4];
+    high_depth_ycbcr_to_rgba(
+        &planes,
+        10,
+        false,
+        &ColorTransform::Ycbcr {
+            kr: 0.2627,
+            kb: 0.0593,
+            standard: YuvStandardMatrix::Bt2020,
+        },
+        &mut rgba,
+    );
+
+    // Y8=224, Cb8=-6.0, Cr8=+21.0 -> R clamps to 255, G=213, B=213
+    for px in rgba.as_chunks::<4>().0 {
+        assert_eq!(px[0], 255, "red");
+        assert_eq!(px[1], 213, "green");
+        assert_eq!(px[2], 213, "blue");
+        assert_eq!(px[3], 255, "alpha");
+    }
+}
+
+#[test]
+fn high_depth_ycgco_round_trip() {
+    // forward YCgCo (H.273 matrix 8) of R=200 G=50 B=100 in the 8-bit domain:
+    // Y=100, Cg=-50, Co=+50, scaled into full-range 10-bit samples
+    let y = u16_plane(&[400; 32], 16, 4);
+    let u = u16_plane(&[412; 8], 8, 2);
+    let v = u16_plane(&[612; 8], 8, 2);
+    let planes = Planes {
+        y: &y,
+        y_stride: 16,
+        u: &u,
+        u_stride: 8,
+        v: &v,
+        v_stride: 8,
+        width: 8,
+        height: 4,
+        layout: PixelLayout::I420,
+    };
+
+    let mut rgba = vec![0u8; 8 * 4 * 4];
+    high_depth_ycbcr_to_rgba(&planes, 10, true, &ColorTransform::Ycgco, &mut rgba);
+
+    for px in rgba.as_chunks::<4>().0 {
+        assert!((px[0] as i32 - 200).abs() <= 2, "red: {}", px[0]);
+        assert!((px[1] as i32 - 50).abs() <= 2, "green: {}", px[1]);
+        assert!((px[2] as i32 - 100).abs() <= 2, "blue: {}", px[2]);
+        assert_eq!(px[3], 255);
+    }
+}
+
+#[test]
+fn high_depth_luma_expansion_bounds() {
+    // limited-range 10-bit luma spans [64, 940]
+    assert_eq!(expand_luma(64, 10, false), 0.0);
+    assert!((expand_luma(940, 10, false) - 255.0).abs() < 0.01);
+    // full-range 10-bit spans [0, 1023]
+    assert_eq!(expand_luma(0, 10, true), 0.0);
+    assert!((expand_luma(1023, 10, true) - 255.0).abs() < 0.01);
+    // limited-range chroma is neutral at 512
+    assert_eq!(expand_chroma(512, 10, false), 0.0);
+    // full-range chroma is neutral at 512
+    assert_eq!(expand_chroma(512, 10, true), 0.0);
+}
+
+fn ftyp(major: &[u8; 4], compatible: &[*const [u8; 4]]) -> Vec<u8> {
+    let mut box_data = vec![0u8; 8 + 4 + 4 + 4 * compatible.len()];
+    let size = box_data.len() as u32;
+    box_data[..4].copy_from_slice(&size.to_be_bytes());
+    box_data[4..8].copy_from_slice(b"ftyp");
+    box_data[8..12].copy_from_slice(major);
+    for (index, brand) in compatible.iter().enumerate() {
+        let start = 16 + index * 4;
+        box_data[start..start + 4].copy_from_slice(unsafe { &**brand });
+    }
+    box_data
+}
+
+#[test]
+fn avif_sniffing() {
+    assert!(is_avif(&ftyp(b"avif", &[b"mif1" as *const [u8; 4]])));
+    // `avis` (image sequences) as major brand
+    assert!(is_avif(&ftyp(b"avis", &[b"mif1" as *const [u8; 4]])));
+    // brand listed only in the compatible brands
+    assert!(is_avif(&ftyp(b"mif1", &[b"avif" as *const [u8; 4]])));
+
+    assert!(!is_avif(&ftyp(b"isom", &[b"mif1" as *const [u8; 4]])));
+    assert!(!is_avif(&[]));
+    assert!(!is_avif(&[0; 12]));
+    assert!(!is_avif(b"RIFF0000WEBPVP8 "));
+}

--- a/src/codecs/avif/decoder/tests.rs
+++ b/src/codecs/avif/decoder/tests.rs
@@ -14,6 +14,11 @@ fn decode() {
     assert_eq!(img.colorspace(), ColorSpace::RGBA);
 }
 
+#[test]
+fn bt2020_constant_luminance_is_rejected() {
+    assert!(color_transform(MatrixCoefficients::BT2020ConstantLuminance).is_err());
+}
+
 /// Packs samples into little-endian 16-bit rows; `stride` is in bytes.
 fn u16_plane(samples: &[u16], stride: usize, rows: usize) -> Vec<u8> {
     let mut plane = vec![0u8; stride * rows];

--- a/src/codecs/avif/decoder/tests.rs
+++ b/src/codecs/avif/decoder/tests.rs
@@ -117,7 +117,7 @@ fn high_depth_luma_expansion_bounds() {
     assert_eq!(expand_chroma(512, 10, true), 0.0);
 }
 
-fn ftyp(major: &[u8; 4], compatible: &[*const [u8; 4]]) -> Vec<u8> {
+fn ftyp(major: &[u8; 4], compatible: &[&[u8; 4]]) -> Vec<u8> {
     let mut box_data = vec![0u8; 8 + 4 + 4 + 4 * compatible.len()];
     let size = box_data.len() as u32;
     box_data[..4].copy_from_slice(&size.to_be_bytes());
@@ -125,20 +125,20 @@ fn ftyp(major: &[u8; 4], compatible: &[*const [u8; 4]]) -> Vec<u8> {
     box_data[8..12].copy_from_slice(major);
     for (index, brand) in compatible.iter().enumerate() {
         let start = 16 + index * 4;
-        box_data[start..start + 4].copy_from_slice(unsafe { &**brand });
+        box_data[start..start + 4].copy_from_slice(brand.as_slice());
     }
     box_data
 }
 
 #[test]
 fn avif_sniffing() {
-    assert!(is_avif(&ftyp(b"avif", &[b"mif1" as *const [u8; 4]])));
+    assert!(is_avif(&ftyp(b"avif", &[b"mif1"])));
     // `avis` (image sequences) as major brand
-    assert!(is_avif(&ftyp(b"avis", &[b"mif1" as *const [u8; 4]])));
+    assert!(is_avif(&ftyp(b"avis", &[b"mif1"])));
     // brand listed only in the compatible brands
-    assert!(is_avif(&ftyp(b"mif1", &[b"avif" as *const [u8; 4]])));
+    assert!(is_avif(&ftyp(b"mif1", &[b"avif"])));
 
-    assert!(!is_avif(&ftyp(b"isom", &[b"mif1" as *const [u8; 4]])));
+    assert!(!is_avif(&ftyp(b"isom", &[b"mif1"])));
     assert!(!is_avif(&[]));
     assert!(!is_avif(&[0; 12]));
     assert!(!is_avif(b"RIFF0000WEBPVP8 "));

--- a/src/codecs/avif/encoder/mod.rs
+++ b/src/codecs/avif/encoder/mod.rs
@@ -86,6 +86,29 @@ impl EncoderTrait for AvifEncoder {
 
         let mut writer = ZWriter::new(sink);
 
+        // `as_rgb()`/`as_rgba()` panic when the buffer length is not a
+        // multiple of the channel count, and ravif trusts the dimensions it
+        // is handed. An `Image` whose buffer disagrees with its own
+        // dimensions would otherwise panic in a worker thread — an abort
+        // under the release profile — so check the buffer against the
+        // dimensions first.
+        let components = image.colorspace().num_components();
+        let expected = width
+            .checked_mul(height)
+            .and_then(|pixels| pixels.checked_mul(components));
+        if expected != Some(data.len()) {
+            return Err(ImageErrors::EncodeErrors(
+                ImgEncodeErrors::ImageEncodeErrors(format!(
+                    "image buffer holds {} bytes, but {}x{} {:?} requires {}",
+                    data.len(),
+                    width,
+                    height,
+                    image.colorspace(),
+                    expected.map_or_else(|| "more than usize::MAX".to_string(), |n| n.to_string()),
+                )),
+            ));
+        }
+
         let encoder = ravif::Encoder::new()
             .with_quality(self.options.quality)
             .with_alpha_quality(self.options.alpha_quality.unwrap_or(self.options.quality))
@@ -128,6 +151,8 @@ impl EncoderTrait for AvifEncoder {
         &[ColorSpace::RGB, ColorSpace::RGBA]
     }
 
+    // zune's `ImageFormat` has no AVIF variant, so `Unknown` is the only
+    // honest answer until one exists upstream.
     fn format(&self) -> ImageFormat {
         ImageFormat::Unknown
     }

--- a/src/codecs/mozjpeg/encoder/mod.rs
+++ b/src/codecs/mozjpeg/encoder/mod.rs
@@ -35,6 +35,7 @@ pub struct MozJpegOptions {
 #[derive(Default)]
 pub struct MozJpegEncoder {
     options: MozJpegOptions,
+    pixel_density: Option<mozjpeg::PixelDensity>,
 }
 
 struct TempVt<T: ZByteWriterTrait> {
@@ -92,7 +93,19 @@ impl MozJpegEncoder {
 
     /// Create a new encoder with specified options
     pub fn new_with_options(options: MozJpegOptions) -> MozJpegEncoder {
-        MozJpegEncoder { options }
+        MozJpegEncoder {
+            options,
+            pixel_density: None,
+        }
+    }
+
+    /// Set the JFIF pixel density written into the encoded JPEG.
+    ///
+    /// When this is not called, mozjpeg writes its default 1x1 aspect-ratio
+    /// JFIF header, which shows up as X/Y Resolution 1 and Resolution Unit
+    /// None in tools like ExifTool.
+    pub fn set_pixel_density(&mut self, density: mozjpeg::PixelDensity) {
+        self.pixel_density = Some(density);
     }
 }
 
@@ -203,6 +216,10 @@ impl EncoderTrait for MozJpegEncoder {
 
             if let Some(qtable) = chroma_qtable {
                 comp.set_chroma_qtable(qtable)
+            }
+
+            if let Some(density) = self.pixel_density.take() {
+                comp.set_pixel_density(density);
             }
 
             let writer = TempVt {

--- a/src/codecs/mozjpeg/encoder/mod.rs
+++ b/src/codecs/mozjpeg/encoder/mod.rs
@@ -1,4 +1,4 @@
-use std::{io, mem, panic::AssertUnwindSafe};
+use std::{io, panic::AssertUnwindSafe};
 
 use mozjpeg::qtable::QTable;
 use zune_core::{bit_depth::BitDepth, bytestream::ZByteWriterTrait, colorspace::ColorSpace};
@@ -101,6 +101,9 @@ impl MozJpegEncoder {
 
     /// Set the JFIF pixel density written into the encoded JPEG.
     ///
+    /// The value is consumed by the next encode: an encoder used for more
+    /// than one image writes the density only into the first file.
+    ///
     /// When this is not called, mozjpeg writes its default 1x1 aspect-ratio
     /// JFIF header, which shows up as X/Y Resolution 1 and Resolution Unit
     /// None in tools like ExifTool.
@@ -120,6 +123,21 @@ impl EncoderTrait for MozJpegEncoder {
         sink: T,
     ) -> Result<usize, ImageErrors> {
         let (width, height) = image.dimensions();
+
+        // The CLI restricts quality to 1..=100, but the library API accepts
+        // any f32. mozjpeg's own range assertion would panic — unwindable
+        // only because of the catch below, and fatal under the release
+        // profile's panic = "abort" — so validate before touching the FFI.
+        // Range::contains is false for NaN, which rules that out too.
+        if !(1.0..=100.0).contains(&self.options.quality) {
+            return Err(ImageErrors::EncodeErrors(ImgEncodeErrors::Generic(
+                format!(
+                    "mozjpeg quality must be in 1..=100, got {}",
+                    self.options.quality
+                ),
+            )));
+        }
+
         if image.is_animated() {
             log::warn!(
                 "MozJpeg does not support animated images, only the first frame will be encoded"
@@ -146,7 +164,6 @@ impl EncoderTrait for MozJpegEncoder {
                 ColorSpace::BGR => mozjpeg::ColorSpace::JCS_EXT_BGR,
                 ColorSpace::BGRA => mozjpeg::ColorSpace::JCS_EXT_BGRA,
                 ColorSpace::ARGB => mozjpeg::ColorSpace::JCS_EXT_ARGB,
-                ColorSpace::Unknown => mozjpeg::ColorSpace::JCS_UNKNOWN,
                 _ => mozjpeg::ColorSpace::JCS_UNKNOWN,
             };
 
@@ -241,14 +258,22 @@ impl EncoderTrait for MozJpegEncoder {
             Ok(comp.finish()?.bytes_written)
         }))
         .map_err(|err| {
-            if let Ok(mut err) = err.downcast::<String>() {
-                ImageErrors::EncodeErrors(zune_image::errors::ImgEncodeErrors::Generic(mem::take(
-                    &mut *err,
-                )))
-            } else {
-                ImageErrors::EncodeErrors(zune_image::errors::ImgEncodeErrors::GenericStatic(
-                    "Unknown error occurred during encoding",
-                ))
+            // Preserve the panic payload whether it was raised as a String
+            // or a &'static str; only a foreign payload type falls back to
+            // the generic message.
+            let message = err
+                .downcast_ref::<String>()
+                .cloned()
+                .or_else(|| err.downcast_ref::<&'static str>().map(|text| (*text).to_string()));
+            match message {
+                Some(text) => {
+                    ImageErrors::EncodeErrors(zune_image::errors::ImgEncodeErrors::Generic(text))
+                }
+                None => ImageErrors::EncodeErrors(
+                    zune_image::errors::ImgEncodeErrors::GenericStatic(
+                        "Unknown error occurred during encoding",
+                    ),
+                ),
             }
         })?
     }

--- a/src/codecs/oxipng/encoder/mod.rs
+++ b/src/codecs/oxipng/encoder/mod.rs
@@ -42,6 +42,14 @@ impl EncoderTrait for OxiPngEncoder {
     ) -> Result<usize, ImageErrors> {
         let (width, height) = image.dimensions();
 
+        // PNG stores dimensions as 32-bit; `width as u32` would silently
+        // truncate on a hypothetical >4 Gpx image and hand oxipng wrong
+        // dimensions with the full buffer. Reject it instead.
+        let (width_u32, height_u32) = (
+            u32::try_from(width).map_err(|_| dimension_overflow(width, height))?,
+            u32::try_from(height).map_err(|_| dimension_overflow(width, height))?,
+        );
+
         if image.is_animated() {
             log::warn!(
                 "OxiPNG does not support animated images, only the first frame will be encoded"
@@ -73,8 +81,8 @@ impl EncoderTrait for OxiPngEncoder {
 
         #[allow(unused_mut)]
         let mut img = oxipng::RawImage::new(
-            width as u32,
-            height as u32,
+            width_u32,
+            height_u32,
             match image.colorspace() {
                 ColorSpace::Luma => oxipng::ColorType::Grayscale {
                     transparent_shade: None,
@@ -150,6 +158,13 @@ impl EncoderTrait for OxiPngEncoder {
             _ => BitDepth::Eight,
         }
     }
+}
+
+/// Build the encode error for a dimension that does not fit in PNG's u32.
+fn dimension_overflow(width: usize, height: usize) -> ImageErrors {
+    ImageErrors::EncodeErrors(ImgEncodeErrors::ImageEncodeErrors(format!(
+        "image dimensions {width}x{height} exceed the PNG u32 limit"
+    )))
 }
 
 #[cfg(test)]

--- a/src/codecs/svg/decoder.rs
+++ b/src/codecs/svg/decoder.rs
@@ -25,7 +25,12 @@ const SVG_BYTES_PER_PIXEL: u64 = 4;
 
 const SVG_SIMULTANEOUS_PIXEL_BUFFERS: u64 = 3;
 
-/// Maximum number of pixels an SVG render target may cover.
+/// Maximum number of pixels an SVG render target may cover by default.
+///
+/// Used when a caller does not supply its own budget through
+/// [`SvgOptions::pixel_budget`]. The runtime-derived limit from
+/// `rimage::limits` is preferred; this constant is the fallback so the decoder
+/// is still safe when used on its own.
 pub const MAX_TARGET_PIXELS: u64 =
     MAX_SVG_DECODE_BYTES / (SVG_BYTES_PER_PIXEL * SVG_SIMULTANEOUS_PIXEL_BUFFERS);
 
@@ -40,8 +45,15 @@ pub struct SvgOptions {
     /// Explicit render target in pixels. When `None`, the SVG is rendered
     /// at its intrinsic size.
     ///
-    /// The resolved render target may not exceed [`MAX_TARGET_PIXELS`] pixels.
+    /// The resolved render target may not exceed the pixel budget.
     pub target_size: Option<(u32, u32)>,
+    /// Maximum pixels the render target may cover.
+    ///
+    /// `None` falls back to [`MAX_TARGET_PIXELS`]. Callers that can probe the
+    /// machine should pass a budget derived from
+    /// [`crate::limits::SystemBudget`] instead, so the ceiling tracks the
+    /// memory actually available rather than a constant.
+    pub pixel_budget: Option<u64>,
 }
 
 /// A decoder that renders SVG images into raster pixels using `resvg`.
@@ -113,6 +125,7 @@ impl SvgDecoder {
             &SvgOptions {
                 resources_dir,
                 target_size,
+                pixel_budget: None,
             },
             size,
         )?;
@@ -184,9 +197,10 @@ fn resolve_target_size(
     // The area is computed in u64 because width and height can each approach
     // u32::MAX, whose product overflows usize.
     let area = (width as u64) * (height as u64);
-    if area > MAX_TARGET_PIXELS {
+    let budget = options.pixel_budget.unwrap_or(MAX_TARGET_PIXELS);
+    if area > budget {
         return Err(ImageErrors::ImageDecodeErrors(format!(
-            "SVG target size {width}x{height} ({area} pixels) exceeds the limit of {MAX_TARGET_PIXELS} pixels ({MAX_SVG_DECODE_BYTES} byte decode budget), reduce the --resize target or the intrinsic size",
+            "SVG target size {width}x{height} ({area} pixels) exceeds the limit of {budget} pixels ({MAX_SVG_DECODE_BYTES} byte decode budget per {SVG_SIMULTANEOUS_PIXEL_BUFFERS} pixel buffers), reduce the --resize target or the intrinsic size",
         )));
     }
 

--- a/src/codecs/svg/decoder.rs
+++ b/src/codecs/svg/decoder.rs
@@ -285,8 +285,17 @@ impl DecoderTrait for SvgDecoder {
         resvg::render(&self.tree, transform, &mut pixmap.as_mut());
 
         // tiny-skia stores premultiplied alpha while zune_image expects
-        // straight alpha.
-        let mut pixels = Vec::with_capacity(width * height * 4);
+        // straight alpha. Use checked_mul to avoid usize overflow on
+        // 32-bit targets or extremely large render targets.
+        let pixel_count = width
+            .checked_mul(height)
+            .and_then(|px| px.checked_mul(4))
+            .ok_or_else(|| {
+                ImageErrors::ImageDecodeErrors(format!(
+                    "SVG render target {width}x{height} overflows the output buffer size"
+                ))
+            })?;
+        let mut pixels = Vec::with_capacity(pixel_count);
         for pixel in pixmap.pixels() {
             let color = pixel.demultiply();
             pixels.extend_from_slice(&[color.red(), color.green(), color.blue(), color.alpha()]);

--- a/src/codecs/svg/decoder.rs
+++ b/src/codecs/svg/decoder.rs
@@ -218,12 +218,51 @@ fn resolve_target_size(
     let area = (width as u64) * (height as u64);
     let budget = options.pixel_budget.unwrap_or(MAX_TARGET_PIXELS);
     if area > budget {
-        return Err(ImageErrors::ImageDecodeErrors(format!(
-            "SVG target size {width}x{height} ({area} pixels) exceeds the limit of {budget} pixels ({MAX_SVG_DECODE_BYTES} byte decode budget per {SVG_SIMULTANEOUS_PIXEL_BUFFERS} pixel buffers), reduce the --resize target or the intrinsic size",
-        )));
+        return Err(size_limit_error(width, height, area, budget));
     }
 
     Ok((width, height))
+}
+
+/// Marker prefix identifying an SVG render-target rejection.
+///
+/// `zune_image::errors::ImageErrors` has no variant for "too large", and it is
+/// an external type this crate cannot extend. A string is the only channel
+/// available, so the one this decoder controls carries a stable marker and the
+/// numbers, and [`crate::error::classify_input`] turns it back into a
+/// structured failure. Prose alone would force the classifier to pattern-match
+/// a human-readable message, which breaks the moment the wording changes.
+pub const SIZE_LIMIT_MARKER: &str = "rimage-svg-size-limit:";
+
+/// Build the rejection for a render target that exceeds the pixel budget.
+fn size_limit_error(width: usize, height: usize, area: u64, budget: u64) -> ImageErrors {
+    ImageErrors::ImageDecodeErrors(format!(
+        "{SIZE_LIMIT_MARKER}{width}x{height}:{area}:{budget}: SVG target size {width}x{height} \
+         ({area} pixels) exceeds the limit of {budget} pixels, reduce the --resize target or \
+         the intrinsic size",
+    ))
+}
+
+/// Parse a [`SIZE_LIMIT_MARKER`] message back into its numbers.
+///
+/// Returns `(width, height, actual_pixels, allowed_pixels)`.
+pub fn parse_size_limit(message: &str) -> Option<(u64, u64, u64, u64)> {
+    let rest = message.strip_prefix(SIZE_LIMIT_MARKER)?;
+    // Fields are `WxH:actual:allowed`, terminated by the prose that follows.
+    let rest = rest.split_whitespace().next()?;
+
+    let mut fields = rest.split(':');
+    let dimensions = fields.next()?;
+    let actual = fields.next()?.parse().ok()?;
+    let allowed = fields.next()?.parse().ok()?;
+
+    let (width, height) = dimensions.split_once('x')?;
+    Some((
+        width.parse().ok()?,
+        height.parse().ok()?,
+        actual,
+        allowed,
+    ))
 }
 
 impl DecoderTrait for SvgDecoder {

--- a/src/codecs/svg/decoder.rs
+++ b/src/codecs/svg/decoder.rs
@@ -114,6 +114,25 @@ impl SvgDecoder {
         R: Read,
         F: FnOnce((usize, usize)) -> Result<Option<(u32, u32)>, ImageErrors>,
     {
+        Self::try_new_with_resize_and_budget(source, resources_dir, None, target_for_size)
+    }
+
+    /// Same as [`SvgDecoder::try_new_with_resize`], but with an explicit pixel
+    /// budget instead of the module's fallback constant.
+    ///
+    /// Callers that can probe the machine pass a limit derived from
+    /// [`crate::limits::SystemBudget`] here, so an SVG render target is bounded
+    /// by the same memory model every other format uses.
+    pub fn try_new_with_resize_and_budget<R, F>(
+        source: R,
+        resources_dir: Option<PathBuf>,
+        pixel_budget: Option<u64>,
+        target_for_size: F,
+    ) -> Result<Self, ImageErrors>
+    where
+        R: Read,
+        F: FnOnce((usize, usize)) -> Result<Option<(u32, u32)>, ImageErrors>,
+    {
         let tree = parse_tree(source, resources_dir.clone())?;
         let size = tree.size();
         let intrinsic = (
@@ -125,7 +144,7 @@ impl SvgDecoder {
             &SvgOptions {
                 resources_dir,
                 target_size,
-                pixel_budget: None,
+                pixel_budget,
             },
             size,
         )?;

--- a/src/codecs/svg/decoder.rs
+++ b/src/codecs/svg/decoder.rs
@@ -73,6 +73,13 @@ pub struct SvgDecoder {
     target: (usize, usize),
 }
 
+/// Upper bound on an SVG/SVGZ document read into memory before parsing.
+///
+/// `Tree::from_data` reads the whole buffer, and a hostile multi-gigabyte
+/// "svg" would exhaust memory before the pixel budget check could run. 256
+/// MiB is far beyond any real SVG; the render target is bounded separately.
+const MAX_SVG_BYTES: u64 = 256 * 1024 * 1024;
+
 /// Parses an SVG document into a `resvg` tree.
 ///
 /// Reads the whole source, configures `resvg` with the SVG's resource
@@ -80,13 +87,20 @@ pub struct SvgDecoder {
 /// document. `Tree::from_data` detects and decompresses gzip (SVGZ)
 /// automatically.
 fn parse_tree<R: Read>(
-    mut source: R,
+    source: R,
     resources_dir: Option<PathBuf>,
 ) -> Result<usvg::Tree, ImageErrors> {
     let mut data = Vec::new();
     source
+        .take(MAX_SVG_BYTES + 1)
         .read_to_end(&mut data)
         .map_err(|e| ImageErrors::ImageDecodeErrors(format!("Unable to read SVG data - {e}")))?;
+    if data.len() as u64 > MAX_SVG_BYTES {
+        return Err(ImageErrors::ImageDecodeErrors(format!(
+            "SVG input exceeds the {} MiB read limit",
+            MAX_SVG_BYTES / 1024 / 1024
+        )));
+    }
 
     let mut usvg_options = usvg::Options {
         resources_dir,

--- a/src/codecs/svg/decoder.rs
+++ b/src/codecs/svg/decoder.rs
@@ -62,6 +62,13 @@ pub struct SvgOptions {
 /// quality of the source instead of resampling a rasterized image.
 pub struct SvgDecoder {
     tree: usvg::Tree,
+    /// The raw, unrounded intrinsic size.
+    ///
+    /// Kept as f32 because the decode-time scale factor must use the exact
+    /// value: rendering a 99.6px-wide vector into a 100px target calls for a
+    /// scale of 100/99.6, not 100/100. Callers that need integer pixels (the
+    /// resize callback) get their own rounded, `.max(1)`-clamped copy at the
+    /// call site.
     intrinsic: (f32, f32),
     target: (usize, usize),
 }

--- a/src/codecs/svg/decoder/tests.rs
+++ b/src/codecs/svg/decoder/tests.rs
@@ -3,7 +3,7 @@ use std::fs::File;
 use zune_core::colorspace::ColorSpace;
 use zune_image::image::Image;
 
-use super::{MAX_TARGET_PIXELS, SvgDecoder, SvgOptions};
+use super::{parse_size_limit, MAX_TARGET_PIXELS, SIZE_LIMIT_MARKER, SvgDecoder, SvgOptions};
 
 #[test]
 fn max_target_pixels_fits_the_decode_byte_budget() {
@@ -169,4 +169,31 @@ fn decode_with_oversized_target_size_errors() {
     let decoder = SvgDecoder::try_new_with_options(file, options);
 
     assert!(decoder.is_err());
+}
+
+#[test]
+fn decode_oversized_svg_carries_a_size_limit_marker() {
+    // The huge-canvas fixture's intrinsic dimensions (200000 x 100000) push
+    // the render target well past `MAX_TARGET_PIXELS`. The error must carry
+    // the structured marker so `error::classify_input` can recover a
+    // `SizeLimit` failure instead of a generic decode error.
+    let file = File::open("tests/files/svg/huge-canvas.svg").unwrap();
+    let err = SvgDecoder::try_new(file).err().expect("expected size-limit error");
+    let message = err.to_string();
+
+    assert!(
+        message.starts_with(SIZE_LIMIT_MARKER),
+        "message must start with the structured marker; got: {message}"
+    );
+    let parsed = parse_size_limit(&message).expect("marker must be parseable");
+    let (width, height, actual, allowed) = parsed;
+    assert!(actual > allowed, "actual={actual} must exceed allowed={allowed}");
+    assert_eq!(width * height, actual);
+}
+
+#[test]
+fn parse_size_limit_rejects_messages_without_the_marker() {
+    assert!(parse_size_limit("plain text").is_none());
+    assert!(parse_size_limit("100x100:10000:8000 trailing").is_none());
+    assert!(parse_size_limit("").is_none());
 }

--- a/src/codecs/svg/mod.rs
+++ b/src/codecs/svg/mod.rs
@@ -4,4 +4,4 @@ pub mod decoder;
 
 pub(crate) mod fonts;
 
-pub use decoder::{SvgDecoder, SvgOptions};
+pub use decoder::{parse_size_limit, SvgDecoder, SvgOptions, SIZE_LIMIT_MARKER};

--- a/src/codecs/tiff/decoder/mod.rs
+++ b/src/codecs/tiff/decoder/mod.rs
@@ -3,6 +3,14 @@ use std::io::{Read, Seek};
 use zune_core::colorspace::ColorSpace;
 use zune_image::{errors::ImageErrors, image::Image, traits::DecoderTrait};
 
+/// Upper bound on the pixel count of a TIFF this decoder will accept.
+///
+/// The CLI pre-checks dimensions via `limits`, but the library entry point is
+/// reachable directly. A file that declares gigantic dimensions would make
+/// `read_image` allocate them before the tiff crate's own checks run. 100 MP
+/// is generous for photography and blocks the gigapixel OOM attack.
+const MAX_TIFF_PIXELS: u64 = 100_000_000;
+
 /// A Tiff decoder
 pub struct TiffDecoder<R: Read + Seek> {
     inner: tiff::decoder::Decoder<R>,
@@ -35,23 +43,37 @@ where
         })?;
 
         let (width, height) = (width as usize, height as usize);
+
+        // Reject an oversized image before `read_image` allocates it. The
+        // tiff crate trusts the declared dimensions.
+        let pixels = (width as u64).checked_mul(height as u64);
+        match pixels {
+            Some(p) if p <= MAX_TIFF_PIXELS => {}
+            _ => {
+                return Err(ImageErrors::ImageDecodeErrors(format!(
+                    "TIFF dimensions {width}x{height} exceed the {MAX_TIFF_PIXELS} pixel limit"
+                )));
+            }
+        }
+
         self.dimensions = Some((width, height));
 
-        let colorspace = self
-            .inner
-            .colortype()
-            .map(|colortype| match colortype {
-                tiff::ColorType::RGB(_) => ColorSpace::RGB,
-                tiff::ColorType::RGBA(_) => ColorSpace::RGBA,
-                tiff::ColorType::CMYK(_) => ColorSpace::CMYK,
-                tiff::ColorType::Gray(_) => ColorSpace::Luma,
-                tiff::ColorType::GrayA(_) => ColorSpace::LumaA,
-                tiff::ColorType::YCbCr(_) => ColorSpace::YCbCr,
-                _ => ColorSpace::Unknown,
-            })
-            .map_err(|e| {
-                ImageErrors::ImageDecodeErrors(format!("Unable to read colorspace - {e}"))
-            })?;
+        let colortype = self.inner.colortype().map_err(|e| {
+            ImageErrors::ImageDecodeErrors(format!("Unable to read colorspace - {e}"))
+        })?;
+        let colorspace = match colortype {
+            tiff::ColorType::RGB(_) => ColorSpace::RGB,
+            tiff::ColorType::RGBA(_) => ColorSpace::RGBA,
+            tiff::ColorType::CMYK(_) => ColorSpace::CMYK,
+            tiff::ColorType::Gray(_) => ColorSpace::Luma,
+            tiff::ColorType::GrayA(_) => ColorSpace::LumaA,
+            tiff::ColorType::YCbCr(_) => ColorSpace::YCbCr,
+            other => {
+                return Err(ImageErrors::ImageDecodeErrors(format!(
+                    "Unsupported TIFF color type: {other:?}"
+                )));
+            }
+        };
 
         self.colorspace = colorspace;
 

--- a/src/codecs/webp/decoder/mod.rs
+++ b/src/codecs/webp/decoder/mod.rs
@@ -24,6 +24,14 @@ pub struct WebPDecoder<R: Read> {
     phantom: PhantomData<R>,
 }
 
+/// Upper bound on a WebP file read into memory before decoding.
+///
+/// libwebp has no file-size ceiling, and the static decoder path reads the
+/// whole file before it can tell whether the bitstream is valid, so a hostile
+/// multi-gigabyte "webp" would exhaust memory before any format check ran.
+/// 256 MiB is far beyond any real WebP and matches the SVG decoder's cap.
+const MAX_WEBP_BYTES: u64 = 256 * 1024 * 1024;
+
 impl<R: Read> WebPDecoder<R> {
     /// Create a new webp decoder that reads data from `source`
     pub fn try_new(source: R) -> Result<WebPDecoder<R>, ImageErrors> {
@@ -32,10 +40,16 @@ impl<R: Read> WebPDecoder<R> {
 
     /// Create a new webp decoder with explicit [`DecoderOptions`].
     pub fn try_new_with_options(
-        mut source: R, _options: DecoderOptions
+        source: R, _options: DecoderOptions
     ) -> Result<WebPDecoder<R>, ImageErrors> {
         let mut buf = Vec::new();
-        source.read_to_end(&mut buf)?;
+        source.take(MAX_WEBP_BYTES + 1).read_to_end(&mut buf)?;
+        if buf.len() as u64 > MAX_WEBP_BYTES {
+            return Err(ImageErrors::ImageDecodeErrors(format!(
+                "WebP input exceeds the {} MiB read limit",
+                MAX_WEBP_BYTES / 1024 / 1024
+            )));
+        }
 
         // `Decoder::decode` returns `None` for animated files as well as for
         // any other failure, so it cannot be the only path: it is the cheap

--- a/src/codecs/webp/decoder/mod.rs
+++ b/src/codecs/webp/decoder/mod.rs
@@ -1,26 +1,60 @@
 use std::{io::Read, marker::PhantomData};
 
-use webp::{AnimDecoder, DecodeAnimImage};
-use zune_core::{bit_depth::BitDepth, colorspace::ColorSpace};
+use webp::{AnimDecoder, DecodeAnimImage, Decoder, WebPImage};
+use zune_core::{bit_depth::BitDepth, colorspace::ColorSpace, options::DecoderOptions};
 use zune_image::{errors::ImageErrors, frame::Frame, image::Image, traits::DecoderTrait};
 
 /// A WebP decoder
+///
+/// Only the first frame of an animated file is decoded. libwebp's animation
+/// decoder materialises *every* frame before handing anything back, and this
+/// program has no use for the rest: it re-encodes a single still image. On a
+/// long animation that difference is the whole memory budget, so the static
+/// decoder is preferred whenever it applies.
+///
+/// Note that `DecoderOptions` are accepted but barely apply here: libwebp
+/// decides the output layout from the bitstream, and this decoder reports that
+/// layout rather than converting. The parameter exists so the shared decode
+/// entry point can pass one set of options to every decoder uniformly.
 pub struct WebPDecoder<R: Read> {
-    inner: DecodeAnimImage,
+    /// A still image decoded by libwebp's non-animated entry point.
+    still: Option<WebPImage>,
+    /// Animated path, used only when `still` is empty.
+    animated: Option<DecodeAnimImage>,
     phantom: PhantomData<R>,
 }
 
 impl<R: Read> WebPDecoder<R> {
     /// Create a new webp decoder that reads data from `source`
-    pub fn try_new(mut source: R) -> Result<WebPDecoder<R>, ImageErrors> {
+    pub fn try_new(source: R) -> Result<WebPDecoder<R>, ImageErrors> {
+        Self::try_new_with_options(source, DecoderOptions::default())
+    }
+
+    /// Create a new webp decoder with explicit [`DecoderOptions`].
+    pub fn try_new_with_options(
+        mut source: R, _options: DecoderOptions
+    ) -> Result<WebPDecoder<R>, ImageErrors> {
         let mut buf = Vec::new();
         source.read_to_end(&mut buf)?;
+
+        // `Decoder::decode` returns `None` for animated files as well as for
+        // any other failure, so it cannot be the only path: it is the cheap
+        // first attempt, and `AnimDecoder` is the fallback that also tells us
+        // *why* something failed.
+        if let Some(still) = Decoder::new(&buf).decode() {
+            return Ok(WebPDecoder {
+                still: Some(still),
+                animated: None,
+                phantom: PhantomData,
+            });
+        }
 
         let decoder = AnimDecoder::new(&buf);
         let img = decoder.decode().map_err(ImageErrors::ImageDecodeErrors)?;
 
         Ok(WebPDecoder {
-            inner: img,
+            still: None,
+            animated: Some(img),
             phantom: PhantomData,
         })
     }
@@ -36,38 +70,34 @@ where
         })?;
         let color = self.out_colorspace();
 
-        let decoded_frames = self.inner.into_iter().collect::<Vec<_>>();
-        let timestamps = decoded_frames
-            .iter()
-            .map(|frame| frame.get_time_ms().max(0) as usize)
-            .collect::<Vec<_>>();
-        let fallback_duration = timestamps
-            .windows(2)
-            .filter_map(|pair| pair[1].checked_sub(pair[0]))
-            .rfind(|duration| *duration > 0)
-            .unwrap_or(100);
+        // A still image: one frame, no timestamp to reason about.
+        if let Some(still) = self.still.take() {
+            let frame = Frame::from_u8(&still, color, 1, 1);
 
-        let frames = decoded_frames
-            .into_iter()
-            .enumerate()
-            .map(|(index, frame)| {
-                let duration_ms = timestamps
-                    .get(index + 1)
-                    .and_then(|next| next.checked_sub(timestamps[index]))
-                    .filter(|duration| *duration > 0)
-                    .unwrap_or(fallback_duration);
-                Frame::from_u8(frame.get_image(), color, duration_ms, 1000)
-            })
-            .collect::<Vec<_>>();
-
-        if frames.is_empty() {
-            return Err(ImageErrors::ImageDecodeErrors(
-                "WebP image contains no frames".to_string(),
+            return Ok(Image::new_frames(
+                vec![frame],
+                BitDepth::Eight,
+                width,
+                height,
+                color,
             ));
         }
 
+        let animated = self
+            .animated
+            .take()
+            .ok_or_else(|| ImageErrors::ImageDecodeErrors("WebP image has no frames".to_string()))?;
+
+        // Only the first frame is needed, so the remaining frames are not
+        // walked: `get_frame` gives one without collecting the rest.
+        let first = animated.get_frame(0).ok_or_else(|| {
+            ImageErrors::ImageDecodeErrors("WebP image contains no frames".to_string())
+        })?;
+
+        let frame = Frame::from_u8(first.get_image(), color, 1, 1);
+
         Ok(Image::new_frames(
-            frames,
+            vec![frame],
             BitDepth::Eight,
             width,
             height,
@@ -76,19 +106,30 @@ where
     }
 
     fn dimensions(&self) -> Option<(usize, usize)> {
-        let frame = self.inner.get_frame(0)?;
+        if let Some(still) = &self.still {
+            return Some((still.width() as usize, still.height() as usize));
+        }
+
+        let frame = self.animated.as_ref()?.get_frame(0)?;
 
         Some((frame.width() as usize, frame.height() as usize))
     }
 
     fn out_colorspace(&self) -> ColorSpace {
-        self.inner
-            .get_frame(0)
-            .map(|frame| match frame.get_layout() {
-                webp::PixelLayout::Rgb => ColorSpace::RGB,
-                webp::PixelLayout::Rgba => ColorSpace::RGBA,
-            })
-            .unwrap_or(ColorSpace::RGBA)
+        let layout = match (&self.still, &self.animated) {
+            (Some(still), _) => Some(still.layout()),
+            (None, Some(animated)) => animated.get_frame(0).map(|frame| frame.get_layout()),
+            (None, None) => None,
+        };
+
+        // libwebp chose the buffer layout, and `Frame::from_u8` reinterprets the
+        // bytes with whichever colorspace we declare, so report the layout that
+        // was actually produced rather than a guess.
+        match layout {
+            Some(webp::PixelLayout::Rgb) => ColorSpace::RGB,
+            Some(webp::PixelLayout::Rgba) => ColorSpace::RGBA,
+            None => ColorSpace::RGBA,
+        }
     }
 
     fn name(&self) -> &'static str {

--- a/src/codecs/webp/decoder/tests.rs
+++ b/src/codecs/webp/decoder/tests.rs
@@ -11,5 +11,56 @@ fn decode() {
     let img = Image::from_decoder(decoder).unwrap();
 
     assert_eq!(img.dimensions(), (48, 80));
-    assert_eq!(img.colorspace(), ColorSpace::RGBA);
+    // This file has no alpha channel, and the static decoder reports the layout
+    // it actually produced rather than assuming RGBA.
+    assert_eq!(img.colorspace(), ColorSpace::RGB);
+}
+
+/// A file without alpha must not be silently widened to four channels: doing so
+/// allocates a third more memory than the image needs.
+#[test]
+fn a_file_without_alpha_stays_rgb() {
+    let file_content = File::open("tests/files/webp/f1t.webp").unwrap();
+
+    let decoder = WebPDecoder::try_new(file_content).unwrap();
+
+    assert_eq!(decoder.out_colorspace(), ColorSpace::RGB);
+    let (width, height) = decoder.dimensions().unwrap();
+    assert_eq!((width, height), (48, 80));
+}
+
+/// A still file is served by the non-animated decoder, which is the whole point
+/// of the change: libwebp's animation decoder materialises every frame, and the
+/// static one never does.
+///
+/// The animated branch is not covered here because no animated WebP fixture is
+/// committed and the shipped encoder writes only a still image. The dispatch
+/// itself is asserted by checking which field was populated.
+#[test]
+fn a_still_file_takes_the_non_animated_path() {
+    let file_content = File::open("tests/files/webp/f1t.webp").unwrap();
+
+    let decoder = WebPDecoder::try_new(file_content).unwrap();
+
+    assert!(
+        decoder.still.is_some(),
+        "a still WebP must be decoded by libwebp's static decoder"
+    );
+    assert!(
+        decoder.animated.is_none(),
+        "the animation decoder must not run for a still image"
+    );
+}
+
+/// Animated and corrupt inputs both make `Decoder::decode` return `None`, so the
+/// animation decoder has to be the fallback that reports *why* the file failed.
+#[test]
+fn an_undecodable_file_reports_the_animation_decoder_error() {
+    let garbage = vec![0u8; 32];
+
+    let Err(error) = WebPDecoder::try_new(garbage.as_slice()) else {
+        panic!("garbage must not decode");
+    };
+
+    assert!(!error.to_string().is_empty());
 }

--- a/src/codecs/webp/encoder/mod.rs
+++ b/src/codecs/webp/encoder/mod.rs
@@ -15,13 +15,17 @@ pub type WebPOptions = webp::WebPConfig;
 
 /// A WebP encoder
 pub struct WebPEncoder {
-    options: WebPOptions,
+    /// `WebPConfig::new` can fail when libwebp initialisation fails, and
+    /// `Default` has no way to report that — so the failure is stored and
+    /// surfaced at encode time instead of panicking in a worker thread,
+    /// where `panic = "abort"` would take the whole process down.
+    options: Option<WebPOptions>,
 }
 
 impl Default for WebPEncoder {
     fn default() -> Self {
         Self {
-            options: WebPOptions::new().unwrap(),
+            options: WebPOptions::new().ok(),
         }
     }
 }
@@ -34,7 +38,9 @@ impl WebPEncoder {
 
     /// Create a new encoder with specified options
     pub fn new_with_options(options: WebPOptions) -> WebPEncoder {
-        WebPEncoder { options }
+        WebPEncoder {
+            options: Some(options),
+        }
     }
 }
 
@@ -75,7 +81,13 @@ impl EncoderTrait for WebPEncoder {
             }
         };
 
-        let res = encoder.encode_advanced(&self.options).map_err(|e| {
+        let options = self.options.as_ref().ok_or(ImageErrors::EncodeErrors(
+            ImgEncodeErrors::ImageEncodeErrors(
+                "libwebp encoder configuration failed to initialize".to_string(),
+            ),
+        ))?;
+
+        let res = encoder.encode_advanced(options).map_err(|e| {
             ImgEncodeErrors::ImageEncodeErrors(format!("webp encoding failed: {e:?}"))
         })?;
 

--- a/src/codecs/webp/encoder/mod.rs
+++ b/src/codecs/webp/encoder/mod.rs
@@ -56,6 +56,14 @@ impl EncoderTrait for WebPEncoder {
     ) -> Result<usize, ImageErrors> {
         let (width, height) = image.dimensions();
 
+        // WebP's API takes u32 dimensions; `width as u32` would silently
+        // truncate a >4 Gpx image and hand libwebp wrong dimensions with the
+        // full buffer. Reject it instead.
+        let (width_u32, height_u32) = (
+            u32::try_from(width).map_err(|_| dimension_overflow(width, height))?,
+            u32::try_from(height).map_err(|_| dimension_overflow(width, height))?,
+        );
+
         let mut writer = ZWriter::new(sink);
 
         if image.is_animated() {
@@ -72,8 +80,8 @@ impl EncoderTrait for WebPEncoder {
         })?;
 
         let encoder = match image.colorspace() {
-            ColorSpace::RGB => webp::Encoder::from_rgb(data, width as u32, height as u32),
-            ColorSpace::RGBA => webp::Encoder::from_rgba(data, width as u32, height as u32),
+            ColorSpace::RGB => webp::Encoder::from_rgb(data, width_u32, height_u32),
+            ColorSpace::RGBA => webp::Encoder::from_rgba(data, width_u32, height_u32),
             cs => {
                 return Err(ImageErrors::EncodeErrors(
                     ImgEncodeErrors::UnsupportedColorspace(cs, self.supported_colorspaces()),
@@ -114,6 +122,13 @@ impl EncoderTrait for WebPEncoder {
     fn default_depth(&self, _depth: BitDepth) -> BitDepth {
         BitDepth::Eight
     }
+}
+
+/// Build the encode error for a dimension that does not fit in WebP's u32.
+fn dimension_overflow(width: usize, height: usize) -> ImageErrors {
+    ImageErrors::EncodeErrors(ImgEncodeErrors::ImageEncodeErrors(format!(
+        "image dimensions {width}x{height} exceed the WebP u32 limit"
+    )))
 }
 
 #[cfg(test)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,17 +18,18 @@
 //! └── Output(OutputError)  the file we were asked to write
 //! ```
 //!
-//! # Output path stays closed
+//! # Output direction
 //!
-//! The user asked for every format to have an explicit message. That is
-//! implemented for the input direction, where the file extension is fully under
-//! our control. For the output direction [`classify_output`] deliberately
-//! returns `None` for anything it cannot name with confidence: the encoders
-//! build error text from `${e:?}` on upstream error types, some route a write
-//! failure through `ImgEncodeErrors::ImageEncodeErrors`, and guessing a format
-//! from those strings would invent detail the error does not carry. `None`
-//! means "unclassified", which still prints the verbatim upstream text. Closing
-//! that properly belongs with the `encoder.rs` rework, not here.
+//! Output failures are classified by the format inferred from the output path's
+//! extension. Unlike input paths, output paths are always under our control:
+//! the encoder chooses the extension, so `.jpg` → jpeg, `.png` → png, etc. The
+//! format tag is therefore authoritative at output, even though the underlying
+//! `ImageErrors` value does not carry it.
+//!
+//! Call sites that know the encoder name (the CLI subcommand) can use
+//! [`output_encode_error`] for an even more authoritative tag, and
+//! [`output_io_error`] for direct `io::Error` values from directory creation,
+//! temp-file allocation, and file publishing.
 //!
 //! [`Display`]: std::fmt::Display
 //!
@@ -297,6 +298,9 @@ impl RimageError {
             RimageError::Output(OutputError::Io { cause, .. }) => match cause.kind() {
                 std::io::ErrorKind::PermissionDenied => {
                     Some("check write permissions on the output directory".to_string())
+                }
+                std::io::ErrorKind::StorageFull => {
+                    Some("free up space on the destination volume or write elsewhere".to_string())
                 }
                 _ => None,
             },
@@ -661,11 +665,67 @@ pub fn classify_input(
 
 /// Classify something that went wrong while writing `path`.
 ///
-/// Returns `None` rather than guessing, for the reasons in the module docs: the
-/// encoders stringify upstream errors, so the format cannot always be recovered
-/// from the value we are handed. `None` means "print the original text".
-pub fn classify_output(_path: &Path, _error: &ImageErrors) -> Option<RimageError> {
-    None
+/// The format is inferred from the output path's extension, which is
+/// authoritative at output: the encoder selects the extension, so `.jpg` is
+/// jpeg, `.png` is png, etc. The underlying `ImageErrors` value does not carry
+/// the format, but the path does.
+///
+/// `ImageErrors::IoError` is routed to [`OutputError::Io`] — directory
+/// creation, temp-file allocation, or publish/rename failures that happened
+/// during encoding. Everything else is an encoder failure →
+/// [`OutputError::Encode`].
+pub fn classify_output(path: &Path, error: &ImageErrors) -> Option<RimageError> {
+    let format = path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(ImageFormatId::from_extension)
+        .unwrap_or(ImageFormatId::Other);
+
+    let error_val = match error {
+        ImageErrors::IoError(io) => RimageError::Output(OutputError::Io {
+            path: path.to_path_buf(),
+            cause: std::io::Error::new(io.kind(), io.to_string()),
+        }),
+        _ => RimageError::Output(OutputError::Encode {
+            path: path.to_path_buf(),
+            format,
+            cause: clone_image_errors(error),
+        }),
+    };
+
+    Some(error_val)
+}
+
+/// Build an encode failure from a known encoder name.
+///
+/// Used at call sites where the encoder name is known (the CLI subcommand),
+/// so the format tag is authoritative rather than inferred from the path
+/// extension. The path extension and the encoder name usually agree, but
+/// `mozjpeg` writes `.jpg` and `oxipng` writes `.png`, so the encoder name
+/// is the more direct source.
+pub fn output_encode_error(
+    path: &Path, encoder_name: &str, error: &ImageErrors,
+) -> RimageError {
+    RimageError::Output(OutputError::Encode {
+        path: path.to_path_buf(),
+        format: ImageFormatId::from_encoder_name(encoder_name),
+        cause: clone_image_errors(error),
+    })
+}
+
+/// Build an IO failure on the output side.
+///
+/// Used at call sites that produce `io::Error` directly (directory creation,
+/// temp-file allocation, file publishing, metadata writing), so they are
+/// reported with the same structured form as encoder failures. The path is the
+/// file that was being written when the IO failed.
+pub fn output_io_error(
+    path: &Path, error: &std::io::Error,
+) -> RimageError {
+    RimageError::Output(OutputError::Io {
+        path: path.to_path_buf(),
+        cause: std::io::Error::new(error.kind(), error.to_string()),
+    })
 }
 
 /// Clone an [`InputError`] so it can be re-wrapped for `Display`.

--- a/src/error.rs
+++ b/src/error.rs
@@ -344,7 +344,15 @@ impl RimageError {
                 ImageErrors::EncodeErrors(ImgEncodeErrors::UnsupportedColorspace(..)) => {
                     Some("choose an output format that accepts this image's colorspace".to_string())
                 }
-                _ => Some("check that the file is not truncated or corrupt".to_string()),
+                // An encode failure is a property of the output side — the
+                // input decoded fine — so the input-side "truncated or
+                // corrupt" advice would send the user looking at the wrong
+                // file.
+                _ => Some(
+                    "check that this encoder supports the image's dimensions and bit depth, \
+                     or choose another output format"
+                        .to_string(),
+                ),
             },
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -45,6 +45,11 @@ use zune_image::errors::{ImageErrors, ImgEncodeErrors};
 
 use crate::limits::{ImageFormatId, LimitViolation, ViolationKind};
 
+#[cfg(feature = "svg")]
+use crate::codecs::svg::parse_size_limit;
+#[cfg(feature = "svg")]
+use crate::limits::Binding;
+
 /// Which side of the pipeline a failure happened on.
 ///
 /// Kept separate from the specific error so callers can branch on direction
@@ -603,6 +608,31 @@ pub fn classify_input(
                 reason: UnsupportedReason::FeatureNotEnabled,
             },
         ),
+        // The SVG decoder has no variant for "render target is too large" on the
+        // upstream `ImageErrors` enum, so it stamps a structured marker on the
+        // decode-error string and `classify_input` rehydrates the structured
+        // failure here. The budget always comes from the memory-derived
+        // `LimitSet` in `cli::pipeline`, so `Binding::Memory` is the honest label
+        // for where the ceiling originated.
+        #[cfg(feature = "svg")]
+        ImageErrors::ImageDecodeErrors(message) if format == ImageFormatId::Svg => match parse_size_limit(message) {
+            Some((width, height, actual, allowed)) => RimageError::Input(InputError::SizeLimit {
+                path: path.to_path_buf(),
+                format,
+                dimensions: Some((width, height)),
+                violation: LimitViolation {
+                    kind: ViolationKind::Pixels,
+                    actual,
+                    allowed,
+                    binding: Binding::Memory,
+                },
+            }),
+            None => RimageError::Input(InputError::Decode {
+                path: path.to_path_buf(),
+                format,
+                cause: clone_image_errors(error),
+            }),
+        },
         ImageErrors::ImageOperationNotImplemented(operation, _) if *operation == "resize" => {
             // Without the caller's context there is nothing to say beyond "the
             // resize failed", so fall through to a decode error rather than

--- a/src/error.rs
+++ b/src/error.rs
@@ -369,18 +369,29 @@ fn size_limit_hint(
     violation: &LimitViolation,
     verb: &str,
 ) -> String {
+    // A volume running out of space is not something resizing the image fixes
+    // in general: the destination is the thing that has to change. Naming the
+    // free space to aim for is more useful than restating the pixel ceiling.
+    if violation.kind == ViolationKind::Bytes {
+        return format!(
+            "free up space on the destination volume, or write elsewhere; \
+             writing this image needs about {} but only {} is allowed (from {})",
+            human_bytes(violation.actual),
+            human_bytes(violation.allowed),
+            violation.binding.describe()
+        );
+    }
+
     let measured = match violation.kind {
         ViolationKind::Width => "width",
         ViolationKind::Height => "height",
         ViolationKind::Pixels => "total pixel count",
+        ViolationKind::Bytes => unreachable!("handled above"),
     };
 
     format!(
         "{verb} the image so its {measured} is at most {}; this limit comes from {}",
-        match violation.kind {
-            ViolationKind::Width | ViolationKind::Height => human_count(violation.allowed),
-            ViolationKind::Pixels => human_count(violation.allowed),
-        },
+        human_count(violation.allowed),
         violation.binding.describe()
     ) + &match dimensions {
         Some((w, h)) => format!(" (this image is {w}x{h})"),
@@ -500,13 +511,21 @@ fn write_violation(f: &mut Formatter<'_>, violation: &LimitViolation) -> fmt::Re
         ViolationKind::Width => "width",
         ViolationKind::Height => "height",
         ViolationKind::Pixels => "pixel count",
+        ViolationKind::Bytes => "estimated size",
+    };
+
+    let (actual, allowed) = if violation.kind == ViolationKind::Bytes {
+        (human_bytes(violation.actual), human_bytes(violation.allowed))
+    } else {
+        (
+            human_count(violation.actual),
+            human_count(violation.allowed),
+        )
     };
 
     write!(
         f,
-        "{measured} {} exceeds the limit of {} (from {})",
-        human_count(violation.actual),
-        human_count(violation.allowed),
+        "{measured} {actual} exceeds the limit of {allowed} (from {})",
         violation.binding.describe()
     )
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,706 @@
+//! Structured, side-tagged errors for the decode and encode pipeline.
+//!
+//! [`zune_image::errors::ImageErrors`] is a single flat enum: a failure to read
+//! a truncated input and a failure to write into a full disk are both
+//! `String`s, and neither names the format we were working with. The CLI needs
+//! to tell those apart to pick a message, a hint and an exit code.
+//!
+//! [`RimageError`] wraps rather than replaces it. [`RimageError::source`]
+//! carries the original value, so nothing is lost, and [`Display`] renders the
+//! chain so existing `{error}` call sites keep printing something equivalent to
+//! what `ImageErrors` produced.
+//!
+//! # Layers
+//!
+//! ```text
+//! RimageError
+//! ├── Input(InputError)    the file we were asked to read
+//! └── Output(OutputError)  the file we were asked to write
+//! ```
+//!
+//! # Output path stays closed
+//!
+//! The user asked for every format to have an explicit message. That is
+//! implemented for the input direction, where the file extension is fully under
+//! our control. For the output direction [`classify_output`] deliberately
+//! returns `None` for anything it cannot name with confidence: the encoders
+//! build error text from `${e:?}` on upstream error types, some route a write
+//! failure through `ImgEncodeErrors::ImageEncodeErrors`, and guessing a format
+//! from those strings would invent detail the error does not carry. `None`
+//! means "unclassified", which still prints the verbatim upstream text. Closing
+//! that properly belongs with the `encoder.rs` rework, not here.
+//!
+//! [`Display`]: std::fmt::Display
+//!
+//! # Scope note
+//!
+//! This module is additive. The CLI reports failures through
+//! [`RimageError::log`], which keeps the `{error}`-style line it printed before
+//! and appends the hint when there is one.
+
+use std::fmt::{self, Display, Formatter};
+use std::path::{Path, PathBuf};
+
+use zune_image::errors::{ImageErrors, ImgEncodeErrors};
+
+use crate::limits::{ImageFormatId, LimitViolation, ViolationKind};
+
+/// Which side of the pipeline a failure happened on.
+///
+/// Kept separate from the specific error so callers can branch on direction
+/// without matching every variant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Direction {
+    /// Reading, parsing or validating an existing file.
+    Input,
+    /// Materialising data, encoding, or writing a new file.
+    Output,
+}
+
+impl Direction {
+    /// Human-readable direction, used in messages.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Direction::Input => "input",
+            Direction::Output => "output",
+        }
+    }
+
+    /// The verb the pipeline was performing when this direction failed.
+    pub const fn verb(self) -> &'static str {
+        match self {
+            Direction::Input => "reading",
+            Direction::Output => "writing",
+        }
+    }
+}
+
+impl Display for Direction {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// What went wrong with a file we were reading.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum InputError {
+    /// The file could not be opened, or its bytes could not be read.
+    Open {
+        /// The file we were trying to open.
+        path: PathBuf,
+        /// Why the open failed.
+        cause: std::io::Error,
+    },
+    /// The file existed and was readable, but its contents could not be decoded
+    /// into pixels.
+    Decode {
+        /// The file we were trying to decode.
+        path: PathBuf,
+        /// The format we identified, from the extension.
+        format: ImageFormatId,
+        /// The decoder's own report.
+        cause: ImageErrors,
+    },
+    /// The file is a recognised image format whose decoder was not compiled in,
+    /// or which this program does not implement.
+    UnsupportedFormat {
+        /// The file we were asked to read.
+        path: PathBuf,
+        /// The format we identified.
+        format: ImageFormatId,
+        /// Whether the decoder is missing from the build or absent entirely.
+        reason: UnsupportedReason,
+    },
+    /// The image is larger than this machine or this format can handle.
+    ///
+    /// Distinct from [`InputError::Decode`] because it is a property of the
+    /// input's size, not of its contents, and is decided before any decoding.
+    SizeLimit {
+        /// The file we were asked to read.
+        path: PathBuf,
+        /// The format we identified.
+        format: ImageFormatId,
+        /// The dimensions, when the header could be read.
+        ///
+        /// `None` when the limit was derived from the file's byte length rather
+        /// than from its header.
+        dimensions: Option<(u64, u64)>,
+        /// Which ceiling was exceeded, and by how much.
+        violation: LimitViolation,
+    },
+    /// A `--resize` value cannot be represented by the resize operation.
+    InvalidResize {
+        /// The dimensions that were requested or computed.
+        requested: (u64, u64),
+        /// Why they are unusable.
+        reason: &'static str,
+    },
+}
+
+/// Why a format could not be handed to a decoder.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnsupportedReason {
+    /// The required cargo feature was not enabled when this binary was built.
+    FeatureNotEnabled,
+    /// No decoder exists for this format in this program.
+    NotImplemented,
+}
+
+impl UnsupportedReason {
+    /// Human-readable explanation, used in messages and hints.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            UnsupportedReason::FeatureNotEnabled => "its decoder was not enabled at build time",
+            UnsupportedReason::NotImplemented => "no decoder for this format is implemented",
+        }
+    }
+}
+
+/// What went wrong with a file we were writing.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum OutputError {
+    /// Creating, writing to, or renaming the output file failed.
+    Io {
+        /// The file we were trying to write.
+        path: PathBuf,
+        /// Why the write failed.
+        cause: std::io::Error,
+    },
+    /// The encoder for the requested output format failed.
+    Encode {
+        /// The intended destination.
+        path: PathBuf,
+        /// The format we were asked to produce.
+        format: ImageFormatId,
+        /// The encoder's own report.
+        cause: ImageErrors,
+    },
+    /// An image cannot be produced at the requested size.
+    SizeLimit {
+        /// The intended destination.
+        path: PathBuf,
+        /// The output format.
+        format: ImageFormatId,
+        /// Which ceiling was exceeded, and by how much.
+        violation: LimitViolation,
+    },
+    /// There is not enough room on the destination volume.
+    ///
+    /// Reported separately from [`OutputError::Io`] because the fix is
+    /// different: freeing space, not repairing the path.
+    OutOfSpace {
+        /// The intended destination.
+        path: PathBuf,
+        /// The format we were asked to produce.
+        format: ImageFormatId,
+        /// Bytes the encoded image is estimated to need.
+        needed: u64,
+        /// Bytes the volume has room for.
+        available: u64,
+    },
+}
+
+/// A failure anywhere in the pipeline, tagged with the side it happened on.
+#[derive(Debug)]
+pub enum RimageError {
+    /// A file could not be read, parsed, or accepted.
+    Input(InputError),
+    /// A result could not be produced or written.
+    Output(OutputError),
+}
+
+impl RimageError {
+    /// Which side of the pipeline failed.
+    pub const fn direction(&self) -> Direction {
+        match self {
+            RimageError::Input(_) => Direction::Input,
+            RimageError::Output(_) => Direction::Output,
+        }
+    }
+
+    /// A stable, machine-readable slug for this failure.
+    ///
+    /// Intended for logs and tests; the human-facing text comes from
+    /// [`Display`](std::fmt::Display).
+    pub const fn kind(&self) -> &'static str {
+        match self {
+            RimageError::Input(InputError::Open { .. }) => "input.open",
+            RimageError::Input(InputError::Decode { .. }) => "input.decode",
+            RimageError::Input(InputError::UnsupportedFormat { .. }) => "input.unsupported-format",
+            RimageError::Input(InputError::SizeLimit { .. }) => "input.size-limit",
+            RimageError::Input(InputError::InvalidResize { .. }) => "input.invalid-resize",
+            RimageError::Output(OutputError::Io { .. }) => "output.io",
+            RimageError::Output(OutputError::Encode { .. }) => "output.encode",
+            RimageError::Output(OutputError::SizeLimit { .. }) => "output.size-limit",
+            RimageError::Output(OutputError::OutOfSpace { .. }) => "output.out-of-space",
+        }
+    }
+
+    /// The file this failure concerns.
+    pub fn path(&self) -> &Path {
+        match self {
+            RimageError::Input(InputError::Open { path, .. })
+            | RimageError::Input(InputError::Decode { path, .. })
+            | RimageError::Input(InputError::UnsupportedFormat { path, .. })
+            | RimageError::Input(InputError::SizeLimit { path, .. }) => path,
+            RimageError::Input(InputError::InvalidResize { .. }) => Path::new(""),
+            RimageError::Output(OutputError::Io { path, .. })
+            | RimageError::Output(OutputError::Encode { path, .. })
+            | RimageError::Output(OutputError::SizeLimit { path, .. })
+            | RimageError::Output(OutputError::OutOfSpace { path, .. }) => path,
+        }
+    }
+
+    /// A concrete next step, when one exists.
+    ///
+    /// `None` when the failure has no actionable advice beyond fixing the file,
+    /// so callers can omit an empty "hint:" line.
+    pub fn hint(&self) -> Option<String> {
+        match self {
+            RimageError::Input(InputError::UnsupportedFormat { format, reason, .. }) => {
+                Some(match reason {
+                    UnsupportedReason::FeatureNotEnabled => format!(
+                        "rebuild with the feature that provides the {} decoder",
+                        format.name()
+                    ),
+                    UnsupportedReason::NotImplemented => {
+                        "convert the file to a supported format (jpeg, png, webp, avif, tiff or \
+                         svg) before optimizing it"
+                            .to_string()
+                    }
+                })
+            }
+            RimageError::Input(InputError::SizeLimit { dimensions, violation, .. }) => {
+                Some(size_limit_hint(*dimensions, violation, "shrink"))
+            }
+            RimageError::Input(InputError::InvalidResize { requested, .. }) => Some(format!(
+                "choose a --resize value that fits in {}x{} pixels",
+                requested.0, requested.1
+            )),
+            RimageError::Output(OutputError::SizeLimit { violation, .. }) => {
+                Some(size_limit_hint(None, violation, "shrink"))
+            }
+            RimageError::Output(OutputError::OutOfSpace { needed, available, .. }) => {
+                Some(format!(
+                    "free at least {} on the destination volume, raise -t to process fewer \
+                     images at once, or lower --speed",
+                    human_bytes(needed.saturating_sub(*available))
+                ))
+            }
+            RimageError::Output(OutputError::Io { cause, .. }) => match cause.kind() {
+                std::io::ErrorKind::PermissionDenied => {
+                    Some("check write permissions on the output directory".to_string())
+                }
+                _ => None,
+            },
+            RimageError::Input(InputError::Open { cause, .. }) => match cause.kind() {
+                std::io::ErrorKind::NotFound => {
+                    Some("check that the path exists and the spelling is correct".to_string())
+                }
+                std::io::ErrorKind::PermissionDenied => {
+                    Some("check read permissions on the file".to_string())
+                }
+                _ => None,
+            },
+            RimageError::Input(InputError::Decode { .. }) => {
+                Some("check that the file is not truncated or corrupt".to_string())
+            }
+            RimageError::Output(OutputError::Encode { cause, .. }) => match cause {
+                ImageErrors::EncodeErrors(ImgEncodeErrors::UnsupportedColorspace(..)) => {
+                    Some("choose an output format that accepts this image's colorspace".to_string())
+                }
+                _ => Some("check that the file is not truncated or corrupt".to_string()),
+            },
+        }
+    }
+
+    /// Report this failure through the `log` crate.
+    ///
+    /// The message line is the [`Display`](std::fmt::Display) text, so it stays
+    /// a single grep-able line, and the hint follows on its own `hint: ` line
+    /// because it names a different thing to do rather than more context about
+    /// what broke. The [`kind`](RimageError::kind) slug is included so a log
+    /// capture can be filtered by failure class without matching prose.
+    ///
+    /// Kept here rather than in `main.rs` so every call site formats failures
+    /// identically, including the ones inside the worker threads.
+    pub fn log(&self) {
+        log::error!("{}: {} [{}]", self.path().display(), self, self.kind());
+
+        // A failure with no actionable advice prints one line, not two with an
+        // empty second one.
+        if let Some(hint) = self.hint() {
+            log::error!("  hint: {hint}");
+        }
+    }
+}
+
+/// Build an "the input is too large" failure from a resolved limit check.
+///
+/// Convenience for the pre-decode size check, which knows the path, the format
+/// and the dimensions but has no `ImageErrors` to classify.
+pub fn input_size_limit(
+    path: &Path, format: ImageFormatId, dimensions: Option<(u64, u64)>, violation: LimitViolation,
+) -> RimageError {
+    RimageError::Input(InputError::SizeLimit {
+        path: path.to_path_buf(),
+        format,
+        dimensions,
+        violation,
+    })
+}
+
+/// Build an "the output cannot be produced" failure from a resolved limit check.
+pub fn output_size_limit(
+    path: &Path, format: ImageFormatId, violation: LimitViolation,
+) -> RimageError {
+    RimageError::Output(OutputError::SizeLimit {
+        path: path.to_path_buf(),
+        format,
+        violation,
+    })
+}
+
+/// Build a hint naming the violated ceiling and a size that would fit.
+fn size_limit_hint(
+    dimensions: Option<(u64, u64)>,
+    violation: &LimitViolation,
+    verb: &str,
+) -> String {
+    let measured = match violation.kind {
+        ViolationKind::Width => "width",
+        ViolationKind::Height => "height",
+        ViolationKind::Pixels => "total pixel count",
+    };
+
+    format!(
+        "{verb} the image so its {measured} is at most {}; this limit comes from {}",
+        match violation.kind {
+            ViolationKind::Width | ViolationKind::Height => human_count(violation.allowed),
+            ViolationKind::Pixels => human_count(violation.allowed),
+        },
+        violation.binding.describe()
+    ) + &match dimensions {
+        Some((w, h)) => format!(" (this image is {w}x{h})"),
+        None => String::new(),
+    }
+}
+
+/// Render a byte count with a binary unit suffix.
+pub fn human_bytes(bytes: u64) -> String {
+    const UNITS: [&str; 6] = ["B", "KiB", "MiB", "GiB", "TiB", "PiB"];
+
+    let mut value = bytes as f64;
+    let mut unit = 0;
+    while value >= 1024.0 && unit + 1 < UNITS.len() {
+        value /= 1024.0;
+        unit += 1;
+    }
+
+    if unit == 0 {
+        format!("{bytes} B")
+    } else {
+        format!("{value:.1} {}", UNITS[unit])
+    }
+}
+
+/// Render a large count with a billion/million suffix.
+pub fn human_count(count: u64) -> String {
+    if count >= 1_000_000_000 {
+        format!("{:.1} billion", count as f64 / 1e9)
+    } else if count >= 1_000_000 {
+        format!("{:.1} million", count as f64 / 1e6)
+    } else {
+        count.to_string()
+    }
+}
+
+impl Display for RimageError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            RimageError::Input(InputError::Open { path, cause }) => write!(
+                f,
+                "input: cannot open {}: {cause}",
+                path.display()
+            ),
+            RimageError::Input(InputError::Decode { path, format, cause }) => write!(
+                f,
+                "input: cannot decode {} as {}: {}",
+                path.display(),
+                format.name(),
+                flatten(cause)
+            ),
+            RimageError::Input(InputError::UnsupportedFormat { path, format, reason }) => write!(
+                f,
+                "input: {} is a {} file, but {}",
+                path.display(),
+                format.name(),
+                reason.as_str()
+            ),
+            RimageError::Input(InputError::SizeLimit { path, format, dimensions, violation }) => {
+                write!(
+                    f,
+                    "input: {} is too large to process as {}: ",
+                    path.display(),
+                    format.name()
+                )?;
+                write_violation(f, violation)?;
+                if let Some((w, h)) = dimensions {
+                    write!(f, " (image is {w}x{h})")?;
+                }
+                Ok(())
+            }
+            RimageError::Input(InputError::InvalidResize { requested, reason }) => write!(
+                f,
+                "input: cannot resize to {}x{}: {reason}",
+                requested.0, requested.1
+            ),
+            RimageError::Output(OutputError::Io { path, cause }) => {
+                write!(f, "output: cannot write {}: {cause}", path.display())
+            }
+            RimageError::Output(OutputError::Encode { path, format, cause }) => write!(
+                f,
+                "output: cannot encode {} as {}: {}",
+                path.display(),
+                format.name(),
+                flatten(cause)
+            ),
+            RimageError::Output(OutputError::SizeLimit { path, format, violation }) => {
+                write!(
+                    f,
+                    "output: cannot produce {} as {}: ",
+                    path.display(),
+                    format.name()
+                )?;
+                write_violation(f, violation)
+            }
+            RimageError::Output(OutputError::OutOfSpace { path, format, needed, available }) => {
+                write!(
+                    f,
+                    "output: not enough space for {} as {}: ",
+                    path.display(),
+                    format.name()
+                )?;
+                write!(
+                    f,
+                    "needs about {} but the destination volume has {} free",
+                    human_bytes(*needed),
+                    human_bytes(*available)
+                )
+            }
+        }
+    }
+}
+
+/// Render the shared "exceeded N (limit L from BINDING)" phrasing.
+fn write_violation(f: &mut Formatter<'_>, violation: &LimitViolation) -> fmt::Result {
+    let measured = match violation.kind {
+        ViolationKind::Width => "width",
+        ViolationKind::Height => "height",
+        ViolationKind::Pixels => "pixel count",
+    };
+
+    write!(
+        f,
+        "{measured} {} exceeds the limit of {} (from {})",
+        human_count(violation.actual),
+        human_count(violation.allowed),
+        violation.binding.describe()
+    )
+}
+
+/// Collapse the trailing newline `ImageErrors` bakes into every `Debug`/`Display`.
+///
+/// `ImageErrors`' `Debug` writes `writeln!` at every level, so the nested
+/// variants (encode errors, operation errors) end up with more than one
+/// trailing newline. Trimming all trailing whitespace is what keeps a log line
+/// a single line.
+fn flatten(error: &ImageErrors) -> String {
+    error.to_string().trim_end().to_string()
+}
+
+impl Display for InputError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        Display::fmt(&RimageError::Input(clone_input(self)), f)
+    }
+}
+
+impl Display for OutputError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        Display::fmt(&RimageError::Output(clone_output(self)), f)
+    }
+}
+
+impl std::error::Error for RimageError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            RimageError::Input(InputError::Open { cause, .. }) => Some(cause),
+            RimageError::Input(InputError::Decode { cause, .. }) => Some(cause),
+            RimageError::Input(
+                InputError::UnsupportedFormat { .. }
+                | InputError::SizeLimit { .. }
+                | InputError::InvalidResize { .. },
+            ) => None,
+            RimageError::Output(OutputError::Io { cause, .. }) => Some(cause),
+            RimageError::Output(OutputError::Encode { cause, .. }) => Some(cause),
+            RimageError::Output(OutputError::SizeLimit { .. } | OutputError::OutOfSpace { .. }) => {
+                None
+            }
+        }
+    }
+}
+
+/// Classify something that went wrong while reading `path`.
+///
+/// `format` is resolved from the file extension, so the message can name it
+/// even when the decoder could not get far enough to report one. Returns `None`
+/// only if `path` is not a file we know how to describe, which lets callers
+/// fall back to printing the original error unchanged.
+pub fn classify_input(
+    path: &Path,
+    error: &ImageErrors,
+    resize: Option<(&'static str, (u64, u64))>,
+) -> Option<RimageError> {
+    let format = path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(ImageFormatId::from_extension)
+        .unwrap_or(ImageFormatId::Other);
+
+    let error = match error {
+        ImageErrors::ImageDecoderNotImplemented(_) => RimageError::Input(
+            InputError::UnsupportedFormat {
+                path: path.to_path_buf(),
+                format,
+                reason: UnsupportedReason::NotImplemented,
+            },
+        ),
+        ImageErrors::ImageDecoderNotIncluded(_) => RimageError::Input(
+            InputError::UnsupportedFormat {
+                path: path.to_path_buf(),
+                format,
+                reason: UnsupportedReason::FeatureNotEnabled,
+            },
+        ),
+        ImageErrors::ImageOperationNotImplemented(operation, _) if *operation == "resize" => {
+            // Without the caller's context there is nothing to say beyond "the
+            // resize failed", so fall through to a decode error rather than
+            // returning `None`, which would lose the error at the call site.
+            match resize {
+                Some((reason, requested)) => RimageError::Input(InputError::InvalidResize {
+                    requested,
+                    reason,
+                }),
+                None => RimageError::Input(InputError::Decode {
+                    path: path.to_path_buf(),
+                    format,
+                    cause: clone_image_errors(error),
+                }),
+            }
+        }
+        other => RimageError::Input(InputError::Decode {
+            path: path.to_path_buf(),
+            format,
+            cause: clone_image_errors(other),
+        }),
+    };
+
+    Some(error)
+}
+
+/// Classify something that went wrong while writing `path`.
+///
+/// Returns `None` rather than guessing, for the reasons in the module docs: the
+/// encoders stringify upstream errors, so the format cannot always be recovered
+/// from the value we are handed. `None` means "print the original text".
+pub fn classify_output(_path: &Path, _error: &ImageErrors) -> Option<RimageError> {
+    None
+}
+
+/// Clone an [`InputError`] so it can be re-wrapped for `Display`.
+///
+/// `ImageErrors` has no `Clone`, so the variants holding one are rebuilt from
+/// their rendered text; that is exactly what the message is going to print
+/// anyway.
+fn clone_input(error: &InputError) -> InputError {
+    match error {
+        InputError::Open { path, cause } => InputError::Open {
+            path: path.clone(),
+            cause: std::io::Error::new(cause.kind(), cause.to_string()),
+        },
+        InputError::Decode { path, format, cause } => InputError::Decode {
+            path: path.clone(),
+            format: *format,
+            cause: clone_image_errors(cause),
+        },
+        InputError::UnsupportedFormat { path, format, reason } => {
+            InputError::UnsupportedFormat {
+                path: path.clone(),
+                format: *format,
+                reason: *reason,
+            }
+        }
+        InputError::SizeLimit { path, format, dimensions, violation } => InputError::SizeLimit {
+            path: path.clone(),
+            format: *format,
+            dimensions: *dimensions,
+            violation: *violation,
+        },
+        InputError::InvalidResize { requested, reason } => InputError::InvalidResize {
+            requested: *requested,
+            reason,
+        },
+    }
+}
+
+/// Clone an [`OutputError`] so it can be re-wrapped for `Display`.
+fn clone_output(error: &OutputError) -> OutputError {
+    match error {
+        OutputError::Io { path, cause } => OutputError::Io {
+            path: path.clone(),
+            cause: std::io::Error::new(cause.kind(), cause.to_string()),
+        },
+        OutputError::Encode { path, format, cause } => OutputError::Encode {
+            path: path.clone(),
+            format: *format,
+            cause: clone_image_errors(cause),
+        },
+        OutputError::SizeLimit { path, format, violation } => OutputError::SizeLimit {
+            path: path.clone(),
+            format: *format,
+            violation: *violation,
+        },
+        OutputError::OutOfSpace { path, format, needed, available } => OutputError::OutOfSpace {
+            path: path.clone(),
+            format: *format,
+            needed: *needed,
+            available: *available,
+        },
+    }
+}
+
+/// Rebuild an [`ImageErrors`] from its rendered text.
+fn clone_image_errors(error: &ImageErrors) -> ImageErrors {
+    match error {
+        ImageErrors::GenericStr(s) => ImageErrors::GenericStr(s),
+        other => ImageErrors::GenericString(other.to_string().trim_end().to_string()),
+    }
+}
+
+/// Bridge for the format-agnostic wrappers that only carry a message.
+impl From<InputError> for RimageError {
+    fn from(error: InputError) -> Self {
+        RimageError::Input(error)
+    }
+}
+
+impl From<OutputError> for RimageError {
+    fn from(error: OutputError) -> Self {
+        RimageError::Output(error)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/error.rs
+++ b/src/error.rs
@@ -679,7 +679,7 @@ pub fn classify_input(
         .map(ImageFormatId::from_extension)
         .unwrap_or(ImageFormatId::Other);
 
-    let error = match error {
+    match error {
         ImageErrors::ImageDecoderNotImplemented(_) => RimageError::Input(
             InputError::UnsupportedFormat {
                 path: path.to_path_buf(),
@@ -740,9 +740,7 @@ pub fn classify_input(
             format,
             cause: clone_image_errors(other),
         }),
-    };
-
-    error
+    }
 }
 
 /// Classify something that went wrong while writing `path`.

--- a/src/error.rs
+++ b/src/error.rs
@@ -359,16 +359,19 @@ impl RimageError {
 
     /// Report this failure through the `log` crate.
     ///
-    /// The message line is the [`Display`](std::fmt::Display) text, so it stays
-    /// a single grep-able line, and the hint follows on its own `hint: ` line
-    /// because it names a different thing to do rather than more context about
-    /// what broke. The [`kind`](RimageError::kind) slug is included so a log
-    /// capture can be filtered by failure class without matching prose.
+    /// The message line is the [`Display`](std::fmt::Display) text — which
+    /// already names the file — so it stays a single grep-able line without
+    /// printing the path twice. (A leading `path: ` prefix also produced a
+    /// bare `": "` for the path-less `InvalidResize`.) The hint follows on its
+    /// own `hint: ` line because it names a different thing to do rather than
+    /// more context about what broke. The [`kind`](RimageError::kind) slug is
+    /// included so a log capture can be filtered by failure class without
+    /// matching prose.
     ///
     /// Kept here rather than in `main.rs` so every call site formats failures
     /// identically, including the ones inside the worker threads.
     pub fn log(&self) {
-        log::error!("{}: {} [{}]", self.path().display(), self, self.kind());
+        log::error!("{self} [{}]", self.kind());
 
         // A failure with no actionable advice prints one line, not two with an
         // empty second one.

--- a/src/error.rs
+++ b/src/error.rs
@@ -443,7 +443,6 @@ pub fn input_config_error(
 /// requirements; `classify_input` already handles the resize-specific case.
 pub fn input_operation_error(path: &Path, error: &ImageErrors) -> RimageError {
     classify_input(path, error, None)
-        .expect("classify_input always returns Some for any ImageErrors variant")
 }
 
 /// Build a hint naming the violated ceiling and a size that would fit.
@@ -665,14 +664,15 @@ impl std::error::Error for RimageError {
 /// Classify something that went wrong while reading `path`.
 ///
 /// `format` is resolved from the file extension, so the message can name it
-/// even when the decoder could not get far enough to report one. Returns `None`
-/// only if `path` is not a file we know how to describe, which lets callers
-/// fall back to printing the original error unchanged.
+/// even when the decoder could not get far enough to report one. Every
+/// [`ImageErrors`] variant maps onto a structured input failure — unknown
+/// ones become [`InputError::Decode`] with the original text preserved — so
+/// the result is the error itself, not an `Option`.
 pub fn classify_input(
     path: &Path,
     error: &ImageErrors,
     resize: Option<(&'static str, (u64, u64))>,
-) -> Option<RimageError> {
+) -> RimageError {
     let format = path
         .extension()
         .and_then(|ext| ext.to_str())
@@ -722,7 +722,7 @@ pub fn classify_input(
         ImageErrors::ImageOperationNotImplemented(operation, _) if *operation == "resize" => {
             // Without the caller's context there is nothing to say beyond "the
             // resize failed", so fall through to a decode error rather than
-            // returning `None`, which would lose the error at the call site.
+            // dropping the failure's format tag and hint.
             match resize {
                 Some((reason, requested)) => RimageError::Input(InputError::InvalidResize {
                     requested,
@@ -742,7 +742,7 @@ pub fn classify_input(
         }),
     };
 
-    Some(error)
+    error
 }
 
 /// Classify something that went wrong while writing `path`.

--- a/src/error.rs
+++ b/src/error.rs
@@ -142,6 +142,19 @@ pub enum InputError {
         /// Why they are unusable.
         reason: &'static str,
     },
+    /// The encoder for the requested output format could not be configured.
+    ///
+    /// Distinct from [`InputError::Decode`] because the file was read
+    /// successfully; the failure is in matching the user's configuration
+    /// (quality, colorspace, sampling) to the encoder's capabilities.
+    Configuration {
+        /// The file being processed.
+        path: PathBuf,
+        /// The output format that was being set up.
+        format: ImageFormatId,
+        /// The encoder's own report.
+        cause: ImageErrors,
+    },
 }
 
 /// Why a format could not be handed to a decoder.
@@ -237,6 +250,7 @@ impl RimageError {
             RimageError::Input(InputError::UnsupportedFormat { .. }) => "input.unsupported-format",
             RimageError::Input(InputError::SizeLimit { .. }) => "input.size-limit",
             RimageError::Input(InputError::InvalidResize { .. }) => "input.invalid-resize",
+            RimageError::Input(InputError::Configuration { .. }) => "input.configuration",
             RimageError::Output(OutputError::Io { .. }) => "output.io",
             RimageError::Output(OutputError::Encode { .. }) => "output.encode",
             RimageError::Output(OutputError::SizeLimit { .. }) => "output.size-limit",
@@ -250,7 +264,8 @@ impl RimageError {
             RimageError::Input(InputError::Open { path, .. })
             | RimageError::Input(InputError::Decode { path, .. })
             | RimageError::Input(InputError::UnsupportedFormat { path, .. })
-            | RimageError::Input(InputError::SizeLimit { path, .. }) => path,
+            | RimageError::Input(InputError::SizeLimit { path, .. })
+            | RimageError::Input(InputError::Configuration { path, .. }) => path,
             RimageError::Input(InputError::InvalidResize { .. }) => Path::new(""),
             RimageError::Output(OutputError::Io { path, .. })
             | RimageError::Output(OutputError::Encode { path, .. })
@@ -316,6 +331,15 @@ impl RimageError {
             RimageError::Input(InputError::Decode { .. }) => {
                 Some("check that the file is not truncated or corrupt".to_string())
             }
+            RimageError::Input(InputError::Configuration { cause, .. }) => {
+                // The cause text already names the invalid value and the
+                // constraint (e.g. "Unsupported mozjpeg colorspace: foo"),
+                // so there is nothing actionable to add beyond restating it.
+                // Returning None avoids a generic "check the docs" hint that
+                // is less useful than the error text itself.
+                let _ = cause;
+                None
+            }
             RimageError::Output(OutputError::Encode { cause, .. }) => match cause {
                 ImageErrors::EncodeErrors(ImgEncodeErrors::UnsupportedColorspace(..)) => {
                     Some("choose an output format that accepts this image's colorspace".to_string())
@@ -370,6 +394,45 @@ pub fn output_size_limit(
         format,
         violation,
     })
+}
+
+/// Build an input IO failure (cannot open or read the file).
+///
+/// Used at call sites that produce `io::Error` while reading the input file,
+/// such as `Path::metadata()`, so they are reported with the same structured
+/// form as decode failures.
+pub fn input_open_error(path: &Path, error: &std::io::Error) -> RimageError {
+    RimageError::Input(InputError::Open {
+        path: path.to_path_buf(),
+        cause: std::io::Error::new(error.kind(), error.to_string()),
+    })
+}
+
+/// Build an encoder-configuration failure.
+///
+/// Used when `encoder()` rejects a CLI argument (e.g. an unsupported
+/// `--colorspace`). The file was read successfully — the failure is in
+/// matching the user's configuration to the encoder's capabilities, which is
+/// why it has its own variant rather than being labelled a decode error.
+pub fn input_config_error(
+    path: &Path, encoder_name: &str, error: &ImageErrors,
+) -> RimageError {
+    RimageError::Input(InputError::Configuration {
+        path: path.to_path_buf(),
+        format: ImageFormatId::from_encoder_name(encoder_name),
+        cause: clone_image_errors(error),
+    })
+}
+
+/// Build an operation-execution failure.
+///
+/// Wraps `op.execute()` errors through [`classify_input`] so they get a
+/// format tag and hint. Operations like resize and quantize fail when the
+/// image's bit depth or colorspace does not match the operation's
+/// requirements; `classify_input` already handles the resize-specific case.
+pub fn input_operation_error(path: &Path, error: &ImageErrors) -> RimageError {
+    classify_input(path, error, None)
+        .expect("classify_input always returns Some for any ImageErrors variant")
 }
 
 /// Build a hint naming the violated ceiling and a size that would fit.
@@ -477,6 +540,13 @@ impl Display for RimageError {
                 "input: cannot resize to {}x{}: {reason}",
                 requested.0, requested.1
             ),
+            RimageError::Input(InputError::Configuration { path, format, cause }) => write!(
+                f,
+                "input: cannot configure {} encoder for {}: {}",
+                format.name(),
+                path.display(),
+                flatten(cause)
+            ),
             RimageError::Output(OutputError::Io { path, cause }) => {
                 write!(f, "output: cannot write {}: {cause}", path.display())
             }
@@ -571,6 +641,7 @@ impl std::error::Error for RimageError {
                 | InputError::SizeLimit { .. }
                 | InputError::InvalidResize { .. },
             ) => None,
+            RimageError::Input(InputError::Configuration { cause, .. }) => Some(cause),
             RimageError::Output(OutputError::Io { cause, .. }) => Some(cause),
             RimageError::Output(OutputError::Encode { cause, .. }) => Some(cause),
             RimageError::Output(OutputError::SizeLimit { .. } | OutputError::OutOfSpace { .. }) => {
@@ -760,6 +831,11 @@ fn clone_input(error: &InputError) -> InputError {
         InputError::InvalidResize { requested, reason } => InputError::InvalidResize {
             requested: *requested,
             reason,
+        },
+        InputError::Configuration { path, format, cause } => InputError::Configuration {
+            path: path.clone(),
+            format: *format,
+            cause: clone_image_errors(cause),
         },
     }
 }

--- a/src/error/tests.rs
+++ b/src/error/tests.rs
@@ -25,7 +25,7 @@ fn decoder_not_implemented_becomes_an_unsupported_format_input_error() {
         zune_image::codecs::ImageFormat::Unknown,
     );
 
-    let classified = classify_input(&jpeg_path(), &error, None).unwrap();
+    let classified = classify_input(&jpeg_path(), &error, None);
 
     assert_eq!(classified.direction(), Direction::Input);
     assert_eq!(classified.kind(), "input.unsupported-format");
@@ -39,7 +39,7 @@ fn decoder_not_implemented_becomes_an_unsupported_format_input_error() {
 fn missing_decoder_feature_is_distinguished_from_a_missing_decoder() {
     let error = ImageErrors::ImageDecoderNotIncluded(zune_image::codecs::ImageFormat::JPEG);
 
-    let classified = classify_input(&jpeg_path(), &error, None).unwrap();
+    let classified = classify_input(&jpeg_path(), &error, None);
     let message = classified.to_string();
 
     assert!(message.contains("build time"), "{message}");
@@ -54,8 +54,7 @@ fn a_resize_refusal_is_an_input_error_not_a_decode_error() {
         &jpeg_path(),
         &error,
         Some(("the result does not fit in 32 bits", (70_000, 70_000))),
-    )
-    .unwrap();
+    );
 
     assert_eq!(classified.kind(), "input.invalid-resize");
     let message = classified.to_string();
@@ -68,14 +67,14 @@ fn a_resize_refusal_without_context_falls_back_to_a_decode_error() {
     // Dropping the caller's context must not lose the error entirely.
     let error = ImageErrors::ImageOperationNotImplemented("resize", depth_of_first_supported());
 
-    let classified = classify_input(&jpeg_path(), &error, None).unwrap();
+    let classified = classify_input(&jpeg_path(), &error, None);
 
     assert_eq!(classified.kind(), "input.decode");
 }
 
 #[test]
 fn a_generic_decode_failure_names_the_file_and_format() {
-    let classified = classify_input(&jpeg_path(), &decode_failure(), None).unwrap();
+    let classified = classify_input(&jpeg_path(), &decode_failure(), None);
 
     assert_eq!(classified.kind(), "input.decode");
     let message = classified.to_string();
@@ -88,7 +87,7 @@ fn a_generic_decode_failure_names_the_file_and_format() {
 fn the_message_does_not_end_in_a_stray_newline() {
     // `ImageErrors`' Display adds a trailing newline; ours must not inherit it,
     // or every log line gains a blank line after it.
-    let classified = classify_input(&jpeg_path(), &decode_failure(), None).unwrap();
+    let classified = classify_input(&jpeg_path(), &decode_failure(), None);
 
     assert!(!classified.to_string().ends_with('\n'));
 }
@@ -96,7 +95,7 @@ fn the_message_does_not_end_in_a_stray_newline() {
 #[test]
 fn an_unknown_extension_is_reported_as_a_generic_image() {
     let error = decode_failure();
-    let classified = classify_input(Path::new("mystery.qoi"), &error, None).unwrap();
+    let classified = classify_input(Path::new("mystery.qoi"), &error, None);
 
     assert!(classified.to_string().contains("image"), "{classified}");
 }
@@ -194,8 +193,7 @@ fn an_svg_size_limit_marker_becomes_a_structured_size_limit() {
          or the intrinsic size",
     ));
 
-    let classified = classify_input(&path, &error, None)
-        .expect("SVG marker is a recognised, classified input failure");
+    let classified = classify_input(&path, &error, None);
 
     match classified {
         RimageError::Input(InputError::SizeLimit {
@@ -233,7 +231,7 @@ fn an_svg_decode_error_without_the_marker_still_routes_to_decode() {
     let path = PathBuf::from("poster.svg");
     let error = ImageErrors::ImageDecodeErrors("Unable to parse SVG - oops".to_string());
 
-    let classified = classify_input(&path, &error, None).expect("classifies");
+    let classified = classify_input(&path, &error, None);
     assert!(matches!(
         classified,
         RimageError::Input(InputError::Decode { .. })

--- a/src/error/tests.rs
+++ b/src/error/tests.rs
@@ -347,6 +347,11 @@ fn err_kinds_are_unique_per_variant() {
             requested: (1, 1),
             reason: "x",
         }),
+        RimageError::Input(InputError::Configuration {
+            path: PathBuf::from("a"),
+            format: ImageFormatId::Jpeg,
+            cause: decode_failure(),
+        }),
         RimageError::Output(OutputError::Io {
             path: PathBuf::from("a"),
             cause: std::io::Error::other("x"),
@@ -501,4 +506,56 @@ fn an_error_without_a_hint_still_formats() {
 
     assert!(error.hint().is_none());
     assert_eq!(error.kind(), "output.io");
+}
+
+#[test]
+fn input_open_error_classifies_io_failures_on_the_input_side() {
+    let error = input_open_error(
+        &jpeg_path(),
+        &std::io::Error::new(std::io::ErrorKind::NotFound, "gone"),
+    );
+
+    assert_eq!(error.direction(), Direction::Input);
+    assert_eq!(error.kind(), "input.open");
+    assert_eq!(error.path(), jpeg_path());
+    assert!(error.hint().unwrap().contains("exists"));
+}
+
+#[test]
+fn input_config_error_tags_the_format_from_the_encoder_name() {
+    let cause = ImageErrors::GenericString(
+        "Unsupported mozjpeg colorspace: neon".to_string(),
+    );
+
+    let error = input_config_error(&jpeg_path(), "mozjpeg", &cause);
+
+    assert_eq!(error.direction(), Direction::Input);
+    assert_eq!(error.kind(), "input.configuration");
+    let message = error.to_string();
+    assert!(message.contains("photo.jpg"), "{message}");
+    assert!(message.contains("jpeg"), "{message}");
+    assert!(message.contains("neon"), "{message}");
+    // The cause already explains the bad value, so no generic hint is added.
+    assert!(error.hint().is_none());
+}
+
+#[test]
+fn input_operation_error_routes_resize_failures_to_invalid_resize() {
+    let error = ImageErrors::ImageOperationNotImplemented("resize", depth_of_first_supported());
+
+    let classified = input_operation_error(&jpeg_path(), &error);
+
+    assert_eq!(classified.kind(), "input.decode");
+    // Without caller context the resize failure degrades to a decode label,
+    // but the error is not lost.
+    assert!(classified.to_string().contains("photo.jpg"));
+}
+
+#[test]
+fn a_configuration_error_preserves_its_cause_as_source() {
+    let cause = ImageErrors::GenericString("bad value".to_string());
+
+    let error = input_config_error(&jpeg_path(), "mozjpeg", &cause);
+
+    assert!(std::error::Error::source(&error).is_some());
 }

--- a/src/error/tests.rs
+++ b/src/error/tests.rs
@@ -112,6 +112,66 @@ fn classify_output_declines_rather_than_guessing_the_format() {
     assert!(classify_output(&jpeg_path(), &error).is_none());
 }
 
+#[cfg(feature = "svg")]
+#[test]
+fn an_svg_size_limit_marker_becomes_a_structured_size_limit() {
+    use crate::codecs::svg::SIZE_LIMIT_MARKER;
+
+    let path = PathBuf::from("poster.svg");
+    // Mirrors `codecs::svg::decoder::size_limit_error` shape exactly.
+    let error = ImageErrors::ImageDecodeErrors(format!(
+        "{SIZE_LIMIT_MARKER}132778x5000:663890000:268435456: SVG target size 132778x5000 \
+         (663890000 pixels) exceeds the limit of 268435456 pixels, reduce the --resize target \
+         or the intrinsic size",
+    ));
+
+    let classified = classify_input(&path, &error, None)
+        .expect("SVG marker is a recognised, classified input failure");
+
+    match classified {
+        RimageError::Input(InputError::SizeLimit {
+            format,
+            dimensions,
+            violation,
+            ..
+        }) => {
+            assert_eq!(format, ImageFormatId::Svg);
+            assert_eq!(dimensions, Some((132_778, 5_000)));
+            assert_eq!(violation.kind, ViolationKind::Pixels);
+            assert_eq!(violation.actual, 663_890_000);
+            assert_eq!(violation.allowed, 268_435_456);
+            // The SVG render target is always bounded by the memory budget the
+            // pipeline derived, so the violation is honestly labelled `Memory`
+            // — never `Format` (SVG has no fixed dimension cap) and never
+            // `Disk` (free space is the output volume's job).
+            assert_eq!(violation.binding, Binding::Memory);
+        }
+        other => panic!("expected Input::SizeLimit, got {other:?}"),
+    }
+
+    // The marker prefix must not leak into the human-readable text.
+    let rendered = classified.to_string();
+    assert!(!rendered.contains(SIZE_LIMIT_MARKER), "{rendered}");
+    assert!(classified.kind() == "input.size-limit");
+}
+
+#[cfg(feature = "svg")]
+#[test]
+fn an_svg_decode_error_without_the_marker_still_routes_to_decode() {
+    // Without the marker the classifier cannot know the failure is a size
+    // limit, so the safer default is to surface the upstream message under
+    // `input.decode` rather than guess.
+    let path = PathBuf::from("poster.svg");
+    let error = ImageErrors::ImageDecodeErrors("Unable to parse SVG - oops".to_string());
+
+    let classified = classify_input(&path, &error, None).expect("classifies");
+    assert!(matches!(
+        classified,
+        RimageError::Input(InputError::Decode { .. })
+    ));
+    assert_eq!(classified.kind(), "input.decode");
+}
+
 #[test]
 fn a_size_limit_violation_explains_which_ceiling_bound() {
     let error = RimageError::Input(InputError::SizeLimit {

--- a/src/error/tests.rs
+++ b/src/error/tests.rs
@@ -1,0 +1,375 @@
+use super::*;
+use crate::limits::{Binding, LimitViolation, ViolationKind};
+
+fn jpeg_path() -> PathBuf {
+    PathBuf::from("/tmp/photo.jpg")
+}
+
+fn decode_failure() -> ImageErrors {
+    // Mirrors the trailing newline `ImageErrors` produces for real failures.
+    ImageErrors::ImageDecodeErrors("unexpected end of file".to_string())
+}
+
+fn limit_violation() -> LimitViolation {
+    LimitViolation {
+        kind: ViolationKind::Pixels,
+        actual: 4_290_250_000,
+        allowed: 1_908_874_353,
+        binding: Binding::Memory,
+    }
+}
+
+#[test]
+fn decoder_not_implemented_becomes_an_unsupported_format_input_error() {
+    let error = ImageErrors::ImageDecoderNotImplemented(
+        zune_image::codecs::ImageFormat::Unknown,
+    );
+
+    let classified = classify_input(&jpeg_path(), &error, None).unwrap();
+
+    assert_eq!(classified.direction(), Direction::Input);
+    assert_eq!(classified.kind(), "input.unsupported-format");
+    // The format comes from the extension, because the decoder never reported one.
+    let message = classified.to_string();
+    assert!(message.contains("jpeg"), "{message}");
+    assert!(message.contains("no decoder"), "{message}");
+}
+
+#[test]
+fn missing_decoder_feature_is_distinguished_from_a_missing_decoder() {
+    let error = ImageErrors::ImageDecoderNotIncluded(zune_image::codecs::ImageFormat::JPEG);
+
+    let classified = classify_input(&jpeg_path(), &error, None).unwrap();
+    let message = classified.to_string();
+
+    assert!(message.contains("build time"), "{message}");
+    assert_eq!(classified.kind(), "input.unsupported-format");
+}
+
+#[test]
+fn a_resize_refusal_is_an_input_error_not_a_decode_error() {
+    let error = ImageErrors::ImageOperationNotImplemented("resize", depth_of_first_supported());
+
+    let classified = classify_input(
+        &jpeg_path(),
+        &error,
+        Some(("the result does not fit in 32 bits", (70_000, 70_000))),
+    )
+    .unwrap();
+
+    assert_eq!(classified.kind(), "input.invalid-resize");
+    let message = classified.to_string();
+    assert!(message.contains("70000x70000"), "{message}");
+    assert!(message.contains("32 bits"), "{message}");
+}
+
+#[test]
+fn a_resize_refusal_without_context_falls_back_to_a_decode_error() {
+    // Dropping the caller's context must not lose the error entirely.
+    let error = ImageErrors::ImageOperationNotImplemented("resize", depth_of_first_supported());
+
+    let classified = classify_input(&jpeg_path(), &error, None).unwrap();
+
+    assert_eq!(classified.kind(), "input.decode");
+}
+
+#[test]
+fn a_generic_decode_failure_names_the_file_and_format() {
+    let classified = classify_input(&jpeg_path(), &decode_failure(), None).unwrap();
+
+    assert_eq!(classified.kind(), "input.decode");
+    let message = classified.to_string();
+    assert!(message.contains("photo.jpg"), "{message}");
+    assert!(message.contains("jpeg"), "{message}");
+    assert!(message.contains("unexpected end of file"), "{message}");
+}
+
+#[test]
+fn the_message_does_not_end_in_a_stray_newline() {
+    // `ImageErrors`' Display adds a trailing newline; ours must not inherit it,
+    // or every log line gains a blank line after it.
+    let classified = classify_input(&jpeg_path(), &decode_failure(), None).unwrap();
+
+    assert!(!classified.to_string().ends_with('\n'));
+}
+
+#[test]
+fn an_unknown_extension_is_reported_as_a_generic_image() {
+    let error = decode_failure();
+    let classified = classify_input(Path::new("mystery.qoi"), &error, None).unwrap();
+
+    assert!(classified.to_string().contains("image"), "{classified}");
+}
+
+#[test]
+fn classify_output_declines_rather_than_guessing_the_format() {
+    let error = ImageErrors::EncodeErrors(ImgEncodeErrors::ImageEncodeErrors(
+        "webp encoding failed".to_string(),
+    ));
+
+    // Documented contract: an encoder failure cannot be attributed to a format
+    // from the value alone, so it is left unclassified on purpose.
+    assert!(classify_output(&jpeg_path(), &error).is_none());
+}
+
+#[test]
+fn a_size_limit_violation_explains_which_ceiling_bound() {
+    let error = RimageError::Input(InputError::SizeLimit {
+        path: PathBuf::from("panorama.png"),
+        format: ImageFormatId::Png,
+        dimensions: Some((65_500, 65_500)),
+        violation: limit_violation(),
+    });
+
+    let message = error.to_string();
+    assert!(message.contains("too large"), "{message}");
+    assert!(message.contains("pixel count"), "{message}");
+    assert!(message.contains("65500x65500"), "{message}");
+    // The binding is what makes the message actionable: it says *why* this
+    // limit and not a format constant.
+    assert!(message.contains("available memory budget"), "{message}");
+}
+
+#[test]
+fn every_violation_kind_is_described() {
+    for kind in [ViolationKind::Width, ViolationKind::Height, ViolationKind::Pixels] {
+        let error = RimageError::Input(InputError::SizeLimit {
+            path: PathBuf::from("x.png"),
+            format: ImageFormatId::Png,
+            dimensions: None,
+            violation: LimitViolation {
+                kind,
+                actual: 200,
+                allowed: 100,
+                binding: Binding::Format,
+            },
+        });
+
+        assert!(!error.to_string().is_empty(), "{kind:?} produced no message");
+        assert!(error.hint().is_some(), "{kind:?} produced no hint");
+    }
+}
+
+#[test]
+fn out_of_space_names_both_figures() {
+    let error = RimageError::Output(OutputError::OutOfSpace {
+        path: PathBuf::from("out.png"),
+        format: ImageFormatId::Png,
+        needed: 3 * 1024 * 1024 * 1024,
+        available: 512 * 1024 * 1024,
+    });
+
+    let message = error.to_string();
+    assert!(message.contains("3.0 GiB"), "{message}");
+    assert!(message.contains("512.0 MiB"), "{message}");
+
+    let hint = error.hint().unwrap();
+    assert!(hint.contains("2.5 GiB"), "{hint}");
+}
+
+#[test]
+fn io_errors_report_the_path_that_failed() {
+    let error = RimageError::Output(OutputError::Io {
+        path: PathBuf::from("readonly/out.png"),
+        cause: std::io::Error::new(std::io::ErrorKind::PermissionDenied, "access denied"),
+    });
+
+    assert_eq!(error.direction(), Direction::Output);
+    assert_eq!(error.path(), Path::new("readonly/out.png"));
+    assert!(error.to_string().contains("readonly/out.png"));
+    assert!(error.hint().unwrap().contains("permission"));
+}
+
+#[test]
+fn a_missing_input_points_at_the_path() {
+    let error = RimageError::Input(InputError::Open {
+        path: PathBuf::from("gone.jpg"),
+        cause: std::io::Error::new(std::io::ErrorKind::NotFound, "no such file"),
+    });
+
+    assert_eq!(error.direction(), Direction::Input);
+    assert!(error.hint().unwrap().contains("exists"));
+}
+
+#[test]
+fn err_kinds_are_unique_per_variant() {
+    let errors = [
+        RimageError::Input(InputError::Open {
+            path: PathBuf::from("a"),
+            cause: std::io::Error::other("x"),
+        }),
+        RimageError::Input(InputError::Decode {
+            path: PathBuf::from("a"),
+            format: ImageFormatId::Png,
+            cause: decode_failure(),
+        }),
+        RimageError::Input(InputError::UnsupportedFormat {
+            path: PathBuf::from("a"),
+            format: ImageFormatId::Png,
+            reason: UnsupportedReason::NotImplemented,
+        }),
+        RimageError::Input(InputError::SizeLimit {
+            path: PathBuf::from("a"),
+            format: ImageFormatId::Png,
+            dimensions: None,
+            violation: limit_violation(),
+        }),
+        RimageError::Input(InputError::InvalidResize {
+            requested: (1, 1),
+            reason: "x",
+        }),
+        RimageError::Output(OutputError::Io {
+            path: PathBuf::from("a"),
+            cause: std::io::Error::other("x"),
+        }),
+        RimageError::Output(OutputError::Encode {
+            path: PathBuf::from("a"),
+            format: ImageFormatId::Png,
+            cause: decode_failure(),
+        }),
+        RimageError::Output(OutputError::SizeLimit {
+            path: PathBuf::from("a"),
+            format: ImageFormatId::Png,
+            violation: limit_violation(),
+        }),
+        RimageError::Output(OutputError::OutOfSpace {
+            path: PathBuf::from("a"),
+            format: ImageFormatId::Png,
+            needed: 1,
+            available: 0,
+        }),
+    ];
+
+    let mut kinds: Vec<&str> = errors.iter().map(|e| e.kind()).collect();
+    let total = kinds.len();
+    kinds.sort_unstable();
+    kinds.dedup();
+    assert_eq!(kinds.len(), total, "kind slugs collide");
+}
+
+#[test]
+fn source_preserves_the_upstream_error() {
+    let error = RimageError::Input(InputError::Decode {
+        path: jpeg_path(),
+        format: ImageFormatId::Jpeg,
+        cause: decode_failure(),
+    });
+
+    // The wrapper has to keep the original reachable, or callers that matched
+    // on `ImageErrors` lose their ability to do so.
+    assert!(std::error::Error::source(&error).is_some());
+
+    // Errors with no underlying OS or decoder cause report none.
+    let error = RimageError::Output(OutputError::OutOfSpace {
+        path: PathBuf::from("a"),
+        format: ImageFormatId::Png,
+        needed: 1,
+        available: 0,
+    });
+    assert!(std::error::Error::source(&error).is_none());
+}
+
+#[test]
+fn display_matches_what_displaying_the_inner_variants_produces() {
+    let error = InputError::Decode {
+        path: jpeg_path(),
+        format: ImageFormatId::Jpeg,
+        cause: decode_failure(),
+    };
+
+    assert_eq!(error.to_string(), RimageError::Input(clone_input(&error)).to_string());
+}
+
+#[test]
+fn hints_are_absent_when_there_is_nothing_actionable() {
+    let error = RimageError::Output(OutputError::Io {
+        path: PathBuf::from("out.png"),
+        cause: std::io::Error::other("disk on fire"),
+    });
+
+    assert!(error.hint().is_none());
+}
+
+#[test]
+fn human_bytes_uses_binary_units() {
+    assert_eq!(human_bytes(0), "0 B");
+    assert_eq!(human_bytes(1023), "1023 B");
+    assert_eq!(human_bytes(1024), "1.0 KiB");
+    assert_eq!(human_bytes(1536), "1.5 KiB");
+    assert_eq!(human_bytes(1024 * 1024), "1.0 MiB");
+    assert_eq!(human_bytes(1024 * 1024 * 1024), "1.0 GiB");
+}
+
+#[test]
+fn human_count_switches_to_words_for_large_values() {
+    assert_eq!(human_count(999), "999");
+    assert_eq!(human_count(1_500_000), "1.5 million");
+    assert_eq!(human_count(4_290_250_000), "4.3 billion");
+}
+
+/// The cheapest `BitType` that the resize path reports as unsupported, used
+/// only to build an `ImageOperationNotImplemented` value in tests.
+fn depth_of_first_supported() -> zune_core::bit_depth::BitType {
+    zune_core::bit_depth::BitType::U8
+}
+
+#[test]
+fn a_size_limit_constructor_names_the_path_and_format() {
+    let error = input_size_limit(
+        &jpeg_path(),
+        ImageFormatId::Jpeg,
+        Some((65_500, 65_500)),
+        limit_violation(),
+    );
+
+    assert_eq!(error.direction(), Direction::Input);
+    assert_eq!(error.kind(), "input.size-limit");
+    assert_eq!(error.path(), jpeg_path());
+
+    let text = error.to_string();
+    assert!(text.contains("too large"), "unexpected message: {text}");
+    assert!(text.contains("65500x65500"), "unexpected message: {text}");
+}
+
+#[test]
+fn an_output_size_limit_constructor_reports_the_output_side() {
+    let error = output_size_limit(&jpeg_path(), ImageFormatId::Jpeg, limit_violation());
+
+    assert_eq!(error.direction(), Direction::Output);
+    assert_eq!(error.kind(), "output.size-limit");
+}
+
+#[test]
+fn every_error_renders_its_hint_on_a_following_line() {
+    // The hint is separate from the message line so a log capture can grep one
+    // line per failure and still show the advice.
+    let error = input_size_limit(
+        &jpeg_path(),
+        ImageFormatId::Jpeg,
+        Some((65_500, 65_500)),
+        limit_violation(),
+    );
+
+    let hint = error.hint().expect("a size violation always suggests a fix");
+    assert!(
+        hint.contains("shrink"),
+        "hint should name the action: {hint}"
+    );
+    // The message itself must not already contain the hint, or `log` would
+    // print the advice twice.
+    assert!(
+        !error.to_string().contains(&hint),
+        "the hint must not be duplicated in the message"
+    );
+}
+
+#[test]
+fn an_error_without_a_hint_still_formats() {
+    let error = RimageError::Output(OutputError::Io {
+        path: PathBuf::from("out.png"),
+        cause: std::io::Error::other("disk on fire"),
+    });
+
+    assert!(error.hint().is_none());
+    assert_eq!(error.kind(), "output.io");
+}

--- a/src/error/tests.rs
+++ b/src/error/tests.rs
@@ -102,14 +102,83 @@ fn an_unknown_extension_is_reported_as_a_generic_image() {
 }
 
 #[test]
-fn classify_output_declines_rather_than_guessing_the_format() {
+fn classify_output_routes_an_encode_error_with_the_path_extension_format() {
     let error = ImageErrors::EncodeErrors(ImgEncodeErrors::ImageEncodeErrors(
         "webp encoding failed".to_string(),
     ));
 
-    // Documented contract: an encoder failure cannot be attributed to a format
-    // from the value alone, so it is left unclassified on purpose.
-    assert!(classify_output(&jpeg_path(), &error).is_none());
+    // The output path extension is authoritative: the encoder picks it, so the
+    // format tag is reliable even though the error value does not carry it.
+    let classified = classify_output(&jpeg_path(), &error).unwrap();
+
+    assert_eq!(classified.direction(), Direction::Output);
+    assert_eq!(classified.kind(), "output.encode");
+    let message = classified.to_string();
+    assert!(message.contains("photo.jpg"), "{message}");
+    assert!(message.contains("jpeg"), "{message}");
+    assert!(message.contains("webp encoding failed"), "{message}");
+}
+
+#[test]
+fn classify_output_routes_an_io_error_to_output_io() {
+    let error = ImageErrors::IoError(std::io::Error::new(
+        std::io::ErrorKind::StorageFull,
+        "No space left on device",
+    ));
+
+    let classified = classify_output(&jpeg_path(), &error).unwrap();
+
+    assert_eq!(classified.kind(), "output.io");
+    assert!(classified.to_string().contains("photo.jpg"));
+}
+
+#[test]
+fn output_encode_error_uses_the_encoder_name_for_the_format_tag() {
+    let error = ImageErrors::EncodeErrors(ImgEncodeErrors::ImageEncodeErrors(
+        "encode failed".to_string(),
+    ));
+
+    // `mozjpeg` writes `.jpg`, so the format tag is `jpeg` even though the
+    // encoder name does not contain "jpeg" literally.
+    let classified = output_encode_error(&jpeg_path(), "mozjpeg", &error);
+
+    assert_eq!(classified.kind(), "output.encode");
+    let message = classified.to_string();
+    assert!(message.contains("jpeg"), "{message}");
+    assert!(message.contains("encode failed"), "{message}");
+}
+
+#[test]
+fn output_io_error_preserves_the_io_kind_for_hint_routing() {
+    let error = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "denied");
+
+    let classified = output_io_error(&PathBuf::from("readonly/out.png"), &error);
+
+    assert_eq!(classified.kind(), "output.io");
+    assert_eq!(classified.path(), Path::new("readonly/out.png"));
+    // PermissionDenied errors get a hint, so the user knows what to fix.
+    assert!(classified.hint().unwrap().contains("permission"));
+}
+
+#[test]
+fn output_io_error_without_a_specific_kind_has_no_hint() {
+    let error = std::io::Error::other("disk on fire");
+
+    let classified = output_io_error(&PathBuf::from("out.png"), &error);
+
+    assert_eq!(classified.kind(), "output.io");
+    assert!(classified.hint().is_none());
+}
+
+#[test]
+fn output_io_error_storage_full_has_a_hint() {
+    let error = std::io::Error::new(std::io::ErrorKind::StorageFull, "disk full");
+
+    let classified = output_io_error(&PathBuf::from("out.png"), &error);
+
+    assert_eq!(classified.kind(), "output.io");
+    let hint = classified.hint().expect("StorageFull must produce a hint");
+    assert!(hint.contains("free up space"), "{hint}");
 }
 
 #[cfg(feature = "svg")]

--- a/src/exit.rs
+++ b/src/exit.rs
@@ -1,0 +1,368 @@
+//! Process exit codes.
+//!
+//! rimage's failure modes are distinct enough that a caller (a build script, a
+//! CI job, a shell wrapper) benefits from telling them apart without parsing
+//! stderr. The codes below are the contract that makes that possible; they are
+//! stable, and adding a new one is a breaking change.
+//!
+//! The values follow the conventional Unix convention of `0` for success and a
+//! small non-zero number for each category. `1` is deliberately not used for a
+//! specific meaning: it is what the runtime reports when the process dies from
+//! a signal or an abort, so reusing it would make a crash indistinguishable
+//! from a handled failure.
+
+/// How the process ended.
+///
+/// Ordered from "everything worked" to "some of it did not", which is also the
+/// order of increasing severity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ExitCode {
+    /// Every input was processed.
+    Success = 0,
+    /// The command line, configuration, or output layout was unusable.
+    ///
+    /// Nothing was attempted: a bad argument, an empty file set, a `--resize`
+    /// value the format cannot satisfy, two inputs mapping to one output.
+    Usage = 2,
+    /// Reading or decoding at least one input failed, and nothing was written.
+    Input = 3,
+    /// Encoding or writing at least one output failed, and nothing was written.
+    ///
+    /// The input was read successfully; the failure happened afterwards.
+    Output = 4,
+    /// Some files were written, others failed.
+    ///
+    /// Distinguishing this from [`ExitCode::Input`] / [`ExitCode::Output`]
+    /// matters: a partial run has already modified the user's files, so a
+    /// wrapper must not treat it as a clean no-op retry.
+    Partial = 5,
+}
+
+impl ExitCode {
+    /// The numeric value a shell will observe.
+    pub const fn as_u8(self) -> u8 {
+        self as u8
+    }
+}
+
+/// The running verdict for a multi-file run.
+///
+/// Kept separate from [`ExitCode`] because two things about a run are not
+/// expressible by folding over per-file exit codes alone:
+///
+/// 1. [`ExitCode::Partial`] needs to remember that *some* file succeeded at
+///    some point. A fold that only keeps the last failure cannot tell a clean
+///    total failure from a run that wrote half its outputs.
+/// 2. Whether *any* file has been considered yet is genuinely a distinct
+///    state, even though it currently reports the same code as a full success.
+///    Conflating them would make "no files" look like "all files worked".
+///
+/// The lattice is not totally ordered. [`RunState::InputFailed`] and
+/// [`RunState::OutputFailed`] are *incomparable*: either alone means nothing
+/// was written, but together they mean some files were written and some were
+/// not. Forcing a single rank order would have to give one of them precedence
+/// and would report a partial run as a clean failure.
+///
+/// Use [`RunState::start`] then [`RunState::record`] per file; read the code
+/// with [`RunState::exit_code`]. The type is `Copy`, so it can be accumulated
+/// behind a mutex in the worker threads and folded once at the end.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum RunState {
+    /// No file has been recorded yet.
+    #[default]
+    Idle,
+    /// Every file recorded so far was written, and at least one was.
+    Succeeded,
+    /// At least one input failed; no output has been written.
+    InputFailed,
+    /// At least one output failed; nothing was written successfully.
+    OutputFailed,
+    /// A success and a failure, or a failure on each side: a partial run.
+    Mixed,
+    /// A verdict decided outside the per-file loop, which passes through.
+    ///
+    /// Used for the configuration failures discovered before any file is
+    /// touched (a bad argument, a colliding output path, a `--resize` the
+    /// format cannot satisfy). It overrides the per-file state because those
+    /// failures mean no file was processed at all.
+    Fatal(ExitCode),
+}
+
+impl RunState {
+    /// The state of a run that has not looked at any file yet.
+    pub const fn start() -> Self {
+        RunState::Idle
+    }
+
+    /// Record the outcome of one file.
+    pub const fn record(self, file: ExitCode) -> Self {
+        let next = match file {
+            ExitCode::Success => RunState::Succeeded,
+            ExitCode::Input => RunState::InputFailed,
+            ExitCode::Output => RunState::OutputFailed,
+            // A per-file outcome is never one of these. Propagating the raw
+            // value keeps the run's own verdict visible rather than silently
+            // downgrading it.
+            other => RunState::Fatal(other),
+        };
+
+        self.merge(next)
+    }
+
+    /// Join this state with another.
+    ///
+    /// Written as a table because the lattice has more states than the exit
+    /// code does, and the table is what defines which combination reports
+    /// which code. The join is commutative and associative, so results may be
+    /// folded in any order.
+    pub const fn merge(self, next: RunState) -> Self {
+        use RunState::*;
+
+        match (self, next) {
+            // Idle is the identity element.
+            (Idle, other) | (other, Idle) => other,
+
+            // A verdict decided outside the loop outranks per-file detail.
+            (Fatal(code), _) | (_, Fatal(code)) => Fatal(code),
+
+            // Two of the same class stay that class.
+            (Succeeded, Succeeded) => Succeeded,
+            (InputFailed, InputFailed) => InputFailed,
+            (OutputFailed, OutputFailed) => OutputFailed,
+
+            // A success next to a failure is the case the whole type exists
+            // for: the run wrote something and failed at something.
+            (Succeeded, InputFailed | OutputFailed) | (InputFailed | OutputFailed, Succeeded) => {
+                Mixed
+            }
+
+            // The two failure sides are incomparable, so joining them is also
+            // mixed: an input failure means that file produced no output while
+            // an output failure means another file at least got that far.
+            (InputFailed, OutputFailed) | (OutputFailed, InputFailed) => Mixed,
+
+            (Mixed, _) | (_, Mixed) => Mixed,
+        }
+    }
+
+    /// The exit code this state reports.
+    pub const fn exit_code(self) -> ExitCode {
+        match self {
+            RunState::Idle | RunState::Succeeded => ExitCode::Success,
+            RunState::InputFailed => ExitCode::Input,
+            RunState::OutputFailed => ExitCode::Output,
+            RunState::Mixed => ExitCode::Partial,
+            RunState::Fatal(code) => code,
+        }
+    }
+}
+
+impl std::process::Termination for RunState {
+    fn report(self) -> std::process::ExitCode {
+        std::process::ExitCode::from(self.exit_code().as_u8())
+    }
+}
+
+impl std::fmt::Display for ExitCode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let description = match self {
+            ExitCode::Success => "success",
+            ExitCode::Usage => "usage error",
+            ExitCode::Input => "input error",
+            ExitCode::Output => "output error",
+            ExitCode::Partial => "partial success",
+        };
+
+        write!(f, "{description} (exit {})", self.as_u8())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ExitCode, RunState};
+
+    #[test]
+    fn values_are_the_documented_contract() {
+        assert_eq!(ExitCode::Success.as_u8(), 0);
+        assert_eq!(ExitCode::Usage.as_u8(), 2);
+        assert_eq!(ExitCode::Input.as_u8(), 3);
+        assert_eq!(ExitCode::Output.as_u8(), 4);
+        assert_eq!(ExitCode::Partial.as_u8(), 5);
+    }
+
+    #[test]
+    fn nothing_recorded_is_success() {
+        assert_eq!(RunState::start().exit_code(), ExitCode::Success);
+    }
+
+    #[test]
+    fn all_files_succeeding_is_success() {
+        let state = RunState::start()
+            .record(ExitCode::Success)
+            .record(ExitCode::Success);
+
+        assert_eq!(state.exit_code(), ExitCode::Success);
+    }
+
+    #[test]
+    fn every_file_failing_on_input_is_an_input_error() {
+        let state = RunState::start()
+            .record(ExitCode::Input)
+            .record(ExitCode::Input);
+
+        assert_eq!(state.exit_code(), ExitCode::Input);
+    }
+
+    #[test]
+    fn every_file_failing_on_output_is_an_output_error() {
+        let state = RunState::start()
+            .record(ExitCode::Output)
+            .record(ExitCode::Output);
+
+        assert_eq!(state.exit_code(), ExitCode::Output);
+    }
+
+    #[test]
+    fn a_success_anywhere_makes_a_failure_partial() {
+        // This is the case the type exists for: the user's files were modified,
+        // so a wrapper must not retry the run as if it had been a no-op.
+        for failure in [ExitCode::Input, ExitCode::Output] {
+            for order in [
+                [ExitCode::Success, failure, ExitCode::Success],
+                [failure, ExitCode::Success, ExitCode::Success],
+                [ExitCode::Success, ExitCode::Success, failure],
+            ] {
+                let state = order.iter().fold(RunState::start(), |state, code| {
+                    state.record(*code)
+                });
+
+                assert_eq!(
+                    state.exit_code(),
+                    ExitCode::Partial,
+                    "success + {failure} in {order:?} must be partial"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn failures_on_both_sides_are_partial() {
+        let state = RunState::start()
+            .record(ExitCode::Input)
+            .record(ExitCode::Output);
+
+        assert_eq!(state.exit_code(), ExitCode::Partial);
+
+        let reversed = RunState::start()
+            .record(ExitCode::Output)
+            .record(ExitCode::Input);
+
+        assert_eq!(reversed.exit_code(), ExitCode::Partial);
+        assert_eq!(state, reversed);
+    }
+
+    #[test]
+    fn a_fatal_code_survives_later_per_file_results() {
+        let state = RunState::start()
+            .record(ExitCode::Usage)
+            .record(ExitCode::Success)
+            .record(ExitCode::Input);
+
+        assert_eq!(state.exit_code(), ExitCode::Usage);
+    }
+
+    #[test]
+    fn no_per_file_outcome_may_produce_usage_or_partial() {
+        // `Partial` and `Usage` are whole-run verdicts. If a record call ever
+        // produced them from a per-file code, the distinction would collapse.
+        for code in [ExitCode::Success, ExitCode::Input, ExitCode::Output] {
+            let state = RunState::start().record(code);
+            assert!(
+                !matches!(state, RunState::Mixed | RunState::Fatal(_)),
+                "recording a single {code} must not decide the whole run"
+            );
+        }
+    }
+
+    #[test]
+    fn merge_is_commutative() {
+        let states = [
+            RunState::Idle,
+            RunState::Succeeded,
+            RunState::InputFailed,
+            RunState::OutputFailed,
+            RunState::Mixed,
+            RunState::Fatal(ExitCode::Usage),
+        ];
+
+        for left in states {
+            for right in states {
+                assert_eq!(
+                    left.merge(right),
+                    right.merge(left),
+                    "{left:?} merged with {right:?} must not depend on order"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn merge_is_associative() {
+        let states = [
+            RunState::Idle,
+            RunState::Succeeded,
+            RunState::InputFailed,
+            RunState::OutputFailed,
+            RunState::Mixed,
+            RunState::Fatal(ExitCode::Usage),
+        ];
+
+        for a in states {
+            for b in states {
+                for c in states {
+                    assert_eq!(
+                        a.merge(b).merge(c),
+                        a.merge(b.merge(c)),
+                        "{a:?}, {b:?}, {c:?} must merge associatively"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn folding_is_independent_of_order_for_every_permutation() {
+        let files = [
+            ExitCode::Success,
+            ExitCode::Input,
+            ExitCode::Output,
+            ExitCode::Success,
+        ];
+
+        let expected = files
+            .iter()
+            .fold(RunState::start(), |state, code| state.record(*code));
+
+        assert_eq!(expected.exit_code(), ExitCode::Partial);
+
+        // Every rotation of the same multiset must agree, which is what lets a
+        // parallel CLI fold partial results in completion order.
+        for rotation in 0..files.len() {
+            let state = files
+                .iter()
+                .cycle()
+                .skip(rotation)
+                .take(files.len())
+                .fold(RunState::start(), |state, code| state.record(*code));
+
+            assert_eq!(state, expected, "rotation {rotation} disagreed");
+        }
+    }
+
+    #[test]
+    fn display_names_the_class_and_the_number() {
+        assert_eq!(ExitCode::Input.to_string(), "input error (exit 3)");
+        assert_eq!(ExitCode::Partial.to_string(), "partial success (exit 5)");
+    }
+}

--- a/src/exit.rs
+++ b/src/exit.rs
@@ -7,9 +7,11 @@
 //!
 //! The values follow the conventional Unix convention of `0` for success and a
 //! small non-zero number for each category. `1` is deliberately not used for a
-//! specific meaning: it is what the runtime reports when the process dies from
-//! a signal or an abort, so reusing it would make a crash indistinguishable
-//! from a handled failure.
+//! specific meaning: it is the generic "something failed" code countless tools
+//! already emit, so reusing it would make a handled failure indistinguishable
+//! from an unhandled one. (Crashes never produce `1` anyway: a Rust panic
+//! exits as `101`, and a signal death is reported by the shell as `128+SIG` —
+//! `134` for the abort that `panic = "abort"` raises.)
 
 /// How the process ended.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,9 +19,14 @@ Rimage is a powerful Rust image optimization library extending `zune_image` crat
 |--------------|---------|---------|
 | jpeg         | -       | mozjpeg |
 | png          | -       | oxipng  |
-| avif         | libavif | ravif   |
+| avif         | dav1d   | ravif   |
 | webp         | webp    | webp    |
 | svg          | resvg   | -       |
+
+> AVIF decoding requires a system-installed `dav1d` (>= 1.3.0) found through
+> pkg-config and only handles still images: grid collages and animated
+> sequences are rejected, 10/12-bit sources are converted to 8-bit output, and
+> ICC profiles are not applied.
 
 ## Usage
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,5 +141,12 @@ pub mod limits;
 /// involved. See [`error::RimageError`].
 pub mod error;
 
+/// Exit codes reported to the shell.
+///
+/// A caller can distinguish a clean success, a usage error, a failure reading
+/// an input, a failure writing an output, and a run that only partly succeeded
+/// without parsing stderr. See [`exit::ExitCode`].
+pub mod exit;
+
 #[cfg(test)]
 mod test_utils;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,5 +134,12 @@ pub mod codecs;
 /// [`limits::SystemBudget`] and [`limits::LimitSet`].
 pub mod limits;
 
+/// Structured, side-tagged pipeline errors.
+///
+/// Wraps [`zune_image::errors::ImageErrors`] so a failure can say whether it
+/// happened reading the input or writing the output, and which format was
+/// involved. See [`error::RimageError`].
+pub mod error;
+
 #[cfg(test)]
 mod test_utils;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,5 +126,13 @@ pub mod operations;
 /// All additional codecs for the zune_image
 pub mod codecs;
 
+/// Runtime-derived image size limits.
+///
+/// Deciding whether an image is too large to process is a property of the
+/// machine, not of the source code, so the ceiling is derived from the format's
+/// own published limits intersected with the memory actually available. See
+/// [`limits::SystemBudget`] and [`limits::LimitSet`].
+pub mod limits;
+
 #[cfg(test)]
 mod test_utils;

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -382,6 +382,12 @@ pub fn free_space_at(path: &Path) -> Option<u64> {
         .map(|disk| disk.available_space())
 }
 
+/// Free bytes on the volume holding `path`, if it can be determined.
+///
+/// Without the `limits` feature there is nothing to measure, because the
+/// platform query lives behind it. This always reports "unknown", which is
+/// the same answer the enabled version gives for a volume it cannot
+/// enumerate — callers must not read it as "no space left".
 #[cfg(not(feature = "limits"))]
 pub fn free_space_at(_path: &Path) -> Option<u64> {
     None

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -1,0 +1,579 @@
+//! Runtime-derived image size limits.
+//!
+//! rimage decodes a whole image into an interleaved pixel buffer, keeps one or
+//! more copies alive through resize / quantize, and then hands another copy to
+//! the encoder. Peak memory therefore scales with the pixel count, which means
+//! the largest acceptable image is a property of the *machine*, not a constant
+//! baked into the source.
+//!
+//! This module derives that ceiling at runtime from three independent sources:
+//!
+//! 1. [`format_caps`] — dimensions a format itself declares as hard limits.
+//!    Only values with an authoritative, citable source are listed here.
+//! 2. [`SystemBudget`] — memory available to this process, divided by the
+//!    concurrency and the peak number of live pixel buffers.
+//! 3. [`LimitSet::for_output`] — free space on the destination volume, which
+//!    bounds the size of the file that can be written.
+//!
+//! The effective limit is the intersection of the three. No fixed pixel
+//! threshold is hardcoded; the only hardcoded numbers are the `format_caps`
+//! values that the format specifications themselves mandate, plus the
+//! documented estimates in [`PipelineCost`].
+
+use std::path::Path;
+
+use zune_core::{bit_depth::BitDepth, colorspace::ColorSpace};
+
+/// Upper bound on a single dimension, and on the total pixel count, declared by
+/// a format rather than derived from system resources.
+///
+/// A value of [`u64::MAX`] means the format publishes no limit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FormatCaps {
+    /// Maximum width or height, in pixels.
+    pub max_side: u64,
+    /// Maximum `width * height`, in pixels.
+    pub max_pixels: u64,
+    /// Human-readable origin of these values, for error messages.
+    pub source: &'static str,
+}
+
+impl FormatCaps {
+    /// No published limit.
+    pub const UNBOUNDED: Self = Self {
+        max_side: u64::MAX,
+        max_pixels: u64::MAX,
+        source: "no published limit",
+    };
+}
+
+/// Dimensions a format declares as hard limits.
+///
+/// Only values backed by an authoritative statement are listed. Everything
+/// else falls back to [`FormatCaps::UNBOUNDED`] and is bounded purely by the
+/// runtime memory budget, so a library that merely *happens* to reject a size
+/// today does not get frozen into the source.
+///
+/// # Sources
+///
+/// - WebP: `WEBP_MAX_DIMENSION` in libwebp's `src/webp/encode.h`, documented as
+///   the inclusive maximum width/height. This is the codec's own published
+///   constant, so it is safe to encode here.
+/// - AVIF: the AV1 bitstream limit for a coded image, stated in the AVIF
+///   specification (Profiles Overview) as 65536x65536 at `seq_level_idx=31`.
+///   This bounds what a decoder must accept; it is *not* a promise that the
+///   encoder will succeed at that size, so the memory budget still applies.
+/// - JPEG: libjpeg-derived implementations refuse dimensions above 65500 to
+///   avoid 16-bit overflow. The value is an implementation constant with no
+///   specification behind it, but it is a hard refusal rather than a quality
+///   trade-off, so it is enforced as an encoder capability.
+/// - Anything absent from this table is unbounded here and left to the memory
+///   budget plus the codec's own error reporting.
+pub const fn format_caps(format: ImageFormatId) -> FormatCaps {
+    match format {
+        ImageFormatId::WebP => FormatCaps {
+            max_side: 16383,
+            max_pixels: u64::MAX,
+            source: "libwebp WEBP_MAX_DIMENSION",
+        },
+        ImageFormatId::Avif => FormatCaps {
+            max_side: 65536,
+            max_pixels: u64::MAX,
+            source: "AVIF spec: AV1 coded image limit at seq_level_idx=31",
+        },
+        // libjpeg-derived encoders abort above this to prevent overflow.
+        ImageFormatId::Jpeg => FormatCaps {
+            max_side: 65500,
+            max_pixels: u64::MAX,
+            source: "libjpeg JPEG_MAX_DIMENSION",
+        },
+        _ => FormatCaps::UNBOUNDED,
+    }
+}
+
+/// Format identity used for limit lookup.
+///
+/// Kept as a small standalone enum so this module does not depend on the
+/// encoder dispatch types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImageFormatId {
+    /// JPEG, via `mozjpeg`.
+    Jpeg,
+    /// PNG, via `oxipng` / `imagequant`.
+    Png,
+    /// WebP, via `libwebp`.
+    WebP,
+    /// AVIF, via `ravif`.
+    Avif,
+    /// TIFF, via the `tiff` crate.
+    Tiff,
+    /// SVG, rasterised via `resvg` / `tiny-skia`.
+    Svg,
+    /// A format with no specific handling; treated as unconstrained.
+    Other,
+}
+
+impl ImageFormatId {
+    /// Canonical lowercase name, used in messages.
+    pub const fn name(self) -> &'static str {
+        match self {
+            ImageFormatId::Jpeg => "jpeg",
+            ImageFormatId::Png => "png",
+            ImageFormatId::WebP => "webp",
+            ImageFormatId::Avif => "avif",
+            ImageFormatId::Tiff => "tiff",
+            ImageFormatId::Svg => "svg",
+            ImageFormatId::Other => "image",
+        }
+    }
+
+    /// Map a file extension to a format identity.
+    pub fn from_extension(ext: &str) -> Self {
+        if ext.eq_ignore_ascii_case("jpg") || ext.eq_ignore_ascii_case("jpeg") {
+            ImageFormatId::Jpeg
+        } else if ext.eq_ignore_ascii_case("png") {
+            ImageFormatId::Png
+        } else if ext.eq_ignore_ascii_case("webp") {
+            ImageFormatId::WebP
+        } else if ext.eq_ignore_ascii_case("avif") {
+            ImageFormatId::Avif
+        } else if ext.eq_ignore_ascii_case("tif") || ext.eq_ignore_ascii_case("tiff") {
+            ImageFormatId::Tiff
+        } else if ext.eq_ignore_ascii_case("svg") || ext.eq_ignore_ascii_case("svgz") {
+            ImageFormatId::Svg
+        } else {
+            ImageFormatId::Other
+        }
+    }
+}
+
+/// Fraction of the reported free memory this process is willing to spend.
+///
+/// `available_memory()` reports memory the kernel could hand out *right now*.
+/// It is not a promise: other processes compete for it, the page cache is
+/// reclaimable but not instant, and rimage's own peak is a short spike that
+/// arrives after several allocations have already succeeded. Spending all of it
+/// invites the OOM killer (or, on Windows, a swap storm) instead of a clean
+/// error, so claim at most half by default.
+const MEMORY_SAFETY_NUM: u64 = 1;
+const MEMORY_SAFETY_DEN: u64 = 2;
+
+/// Largest contiguous allocation assumed to be obtainable on a 32-bit process.
+///
+/// A `Vec<u8>` needs one contiguous virtual range. On 32-bit targets the
+/// address space is 2 GiB (4 GiB with `LARGEADDRESSAWARE`), and fragmentation
+/// routinely prevents a single large block even when the free total looks
+/// sufficient — that is the difference between a failed allocation and a real
+/// OOM. Cap below the theoretical maximum to leave room for the rest of the
+/// process image.
+#[cfg(target_pointer_width = "32")]
+const ADDRESS_SPACE_CAP: u64 = 768 * 1024 * 1024;
+
+/// On 64-bit targets the address space is not the binding constraint.
+#[cfg(not(target_pointer_width = "32"))]
+const ADDRESS_SPACE_CAP: u64 = u64::MAX;
+
+/// Fallback per-image budget when the machine cannot be probed.
+///
+/// Probing fails on unsupported platforms, inside restricted sandboxes, or when
+/// a network filesystem stalls. Falling back to a fixed, conservative budget
+/// keeps the tool usable; refusing to run would be worse.
+const FALLBACK_PER_IMAGE_BYTES: u64 = 512 * 1024 * 1024;
+
+/// Bytes reserved on the destination volume for filesystem metadata and
+/// unrelated activity between the free-space check and the write.
+const DISK_RESERVE_BYTES: u64 = 100 * 1024 * 1024;
+
+/// Peak number of live full-image buffers, as a multiplier on
+/// `pixels * bytes_per_pixel`.
+///
+/// These are *estimates of the current pipeline*, not format limits. They are
+/// deliberately kept as named constants with a documented basis so they can be
+/// recalibrated from measurement rather than guessed at a call site.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PipelineCost {
+    /// Buffers alive at peak while decoding.
+    pub decode: u64,
+    /// Extra buffers introduced by `--resize`.
+    pub resize: u64,
+    /// Extra buffers introduced by `--quantization`.
+    pub quantize: u64,
+    /// Peak buffers held by the encoder itself.
+    pub encode: u64,
+}
+
+impl PipelineCost {
+    /// Cost of decoding plus encoding with no preprocessing.
+    ///
+    /// `decode` is 3: for the SVG path this is verified directly from the code
+    /// (premultiplied pixmap, straight-alpha interleaved copy, and the
+    /// deinterleaved channel buffers). Other decoders are assumed to be no
+    /// worse, so 3 is a floor rather than a measurement.
+    ///
+    /// `encode` differs per codec. Entero-coding and blocking encoders
+    /// (`oxipng`, `ravif`) build substantially more scratch state than
+    /// DCT-based ones (`mozjpeg`).
+    pub const fn new(decode: u64, resize: u64, quantize: u64, encode: u64) -> Self {
+        Self {
+            decode,
+            resize,
+            quantize,
+            encode,
+        }
+    }
+
+    /// Total live buffers at peak.
+    pub const fn total(&self) -> u64 {
+        self.decode + self.resize + self.quantize + self.encode
+    }
+
+    /// Cost for an encoder chosen by format identity.
+    ///
+    /// The encode multipliers are estimates with LOW confidence; they exist to
+    /// keep the derived limit in the right order of magnitude, not to promise a
+    /// precise figure. Lower `--speed`/higher effort settings raise them.
+    pub const fn for_encoder(format: ImageFormatId) -> Self {
+        let encode = match format {
+            // DCT-based, one coefficient buffer per component.
+            ImageFormatId::Jpeg => 3,
+            // Deflate/filter search keeps several filtered scanline sets.
+            ImageFormatId::Png => 12,
+            // AV1 partitions and mode decision keep large scratch planes.
+            ImageFormatId::Avif => 16,
+            // Prediction/filter loops over a full plane.
+            ImageFormatId::WebP => 6,
+            _ => 8,
+        };
+        Self::new(3, 0, 0, encode)
+    }
+}
+
+/// Runtime-probed view of the resources available to this process.
+///
+/// Probed once and cached, because `sysinfo` refreshes touch the whole process
+/// table and free memory is only needed to size a budget, not to track changes.
+#[derive(Debug, Clone, Copy)]
+pub struct SystemBudget {
+    /// Free memory in bytes, or 0 when the platform could not be probed.
+    pub available_memory: u64,
+    /// Largest byte allocation assumed obtainable in one contiguous range.
+    pub address_cap: u64,
+    /// Number of images processed simultaneously.
+    pub concurrency: usize,
+}
+
+impl SystemBudget {
+    /// Probe the current system.
+    ///
+    /// `concurrency` is the number of images the caller processes at once; it
+    /// divides the budget because every concurrent image holds its own buffers.
+    pub fn probe(concurrency: usize) -> Self {
+        Self {
+            available_memory: probe_available_memory(),
+            address_cap: ADDRESS_SPACE_CAP,
+            concurrency: concurrency.max(1),
+        }
+    }
+
+    /// Budget for one image, in bytes.
+    ///
+    /// Falls back to [`FALLBACK_PER_IMAGE_BYTES`] when the machine could not be
+    /// probed. Never returns 0: callers divide by this value.
+    pub fn per_image_bytes(&self) -> u64 {
+        if self.available_memory == 0 {
+            return FALLBACK_PER_IMAGE_BYTES;
+        }
+
+        let usable = (self.available_memory / MEMORY_SAFETY_DEN) * MEMORY_SAFETY_NUM;
+
+        // `probe()` normalises this, but the struct is `pub` and this method is
+        // the divisor for every pixel budget, so guard against a hand-built
+        // zero rather than risk a division panic.
+        let concurrency = self.concurrency.max(1) as u64;
+
+        (usable.min(self.address_cap) / concurrency).max(1)
+    }
+
+    /// Whether the reported figure came from a real probe.
+    pub fn is_probed(&self) -> bool {
+        self.available_memory != 0
+    }
+}
+
+/// Query free memory, preferring a container-aware source.
+///
+/// On Linux, `/proc/meminfo` reports the *host's* memory and ignores any cgroup
+/// limit, so a container sees far more than it may actually use. cgroup limits
+/// are therefore consulted first and take the smaller of the two.
+#[cfg(feature = "limits")]
+fn probe_available_memory() -> u64 {
+    use sysinfo::{MemoryRefreshKind, System};
+
+    let mut system = System::new();
+    system.refresh_memory_specifics(MemoryRefreshKind::nothing().with_ram());
+
+    // `cgroup_limits()` is Linux-only and returns `None` elsewhere.
+    match system.cgroup_limits() {
+        Some(limits) if limits.total_memory > 0 => {
+            limits.free_memory.min(system.available_memory())
+        }
+        _ => system.available_memory(),
+    }
+}
+
+#[cfg(not(feature = "limits"))]
+fn probe_available_memory() -> u64 {
+    0
+}
+
+/// Free bytes on the volume holding `path`, if it can be determined.
+///
+/// Resolved by longest mount-point prefix so the answer reflects the volume the
+/// output actually lands on, not the working directory. Returns `None` when the
+/// path does not exist yet, is on an unenumerated volume, or the platform
+/// cannot report it; callers must treat that as "unknown", not "zero".
+#[cfg(feature = "limits")]
+pub fn free_space_at(path: &Path) -> Option<u64> {
+    use sysinfo::Disks;
+
+    let target = path.canonicalize().ok()?;
+
+    Disks::new_with_refreshed_list()
+        .list()
+        .iter()
+        .filter(|disk| target.starts_with(disk.mount_point()))
+        .max_by_key(|disk| disk.mount_point().as_os_str().len())
+        .map(|disk| disk.available_space())
+}
+
+#[cfg(not(feature = "limits"))]
+pub fn free_space_at(_path: &Path) -> Option<u64> {
+    None
+}
+
+/// A resolved set of limits for one decode or encode operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LimitSet {
+    /// Maximum width in pixels.
+    pub max_width: u64,
+    /// Maximum height in pixels.
+    pub max_height: u64,
+    /// Maximum `width * height` in pixels.
+    pub max_pixels: u64,
+    /// Maximum input or output size in bytes, when known.
+    pub max_bytes: u64,
+    /// Which constraint produced the tightest `max_pixels`, for messages.
+    pub binding: Binding,
+}
+
+/// Which of the three sources ended up being the tightest constraint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Binding {
+    /// A dimension limit declared by the format.
+    Format,
+    /// The memory budget derived from system resources.
+    Memory,
+    /// Free space on the destination volume.
+    Disk,
+    /// Nothing constrained the operation.
+    None,
+}
+
+impl Binding {
+    /// Human-readable explanation, used in error messages.
+    pub const fn describe(self) -> &'static str {
+        match self {
+            Binding::Format => "the format's own dimension limit",
+            Binding::Memory => "the available memory budget",
+            Binding::Disk => "free space on the destination volume",
+            Binding::None => "no limit",
+        }
+    }
+}
+
+impl LimitSet {
+    /// Limits for reading an image of the given format.
+    ///
+    /// The pixel ceiling is whichever of the format's published limit and the
+    /// memory budget is smaller. A single side may still pass the side check
+    /// while the product fails, which is why `max_pixels` is tracked
+    /// separately: callers that only know one dimension must not assume the
+    /// other is unconstrained.
+    pub fn for_input(
+        format: ImageFormatId,
+        depth: BitDepth,
+        colorspace: ColorSpace,
+        budget: &SystemBudget,
+        cost: PipelineCost,
+    ) -> Self {
+        let caps = format_caps(format);
+        let bytes_per_pixel = bytes_per_pixel(depth, colorspace);
+
+        let budget_bytes = budget.per_image_bytes();
+        let budget_pixels = budget_bytes / (bytes_per_pixel * cost.total().max(1));
+
+        // A format may publish a per-side limit without a pixel limit (and
+        // libjpeg is lossy, so memory is no guide either). Since every sample
+        // still has to be held somewhere, a square of `max_side` is the
+        // smallest rectangle that reaches the side ceiling; anything with a
+        // larger area is necessarily wider or taller than `max_side`. Deriving
+        // this keeps `max_pixels` meaningful instead of leaving it at `u64::MAX`.
+        let format_pixels = caps
+            .max_side
+            .saturating_mul(caps.max_side)
+            .min(caps.max_pixels);
+
+        let (max_pixels, binding) = if format_pixels <= budget_pixels {
+            (format_pixels, Binding::Format)
+        } else {
+            (budget_pixels, Binding::Memory)
+        };
+
+        Self {
+            max_width: caps.max_side,
+            max_height: caps.max_side,
+            max_pixels,
+            max_bytes: budget_bytes.saturating_mul(cost.total().max(1)),
+            binding,
+        }
+    }
+
+    /// Limits for writing an image of the given format to `output`.
+    ///
+    /// Adds the destination volume's free space on top of the input limits, so
+    /// a huge image is rejected before it is encoded rather than after a
+    /// partial write.
+    pub fn for_output(
+        format: ImageFormatId,
+        depth: BitDepth,
+        colorspace: ColorSpace,
+        budget: &SystemBudget,
+        cost: PipelineCost,
+        output: &Path,
+    ) -> Self {
+        let mut limits = Self::for_input(format, depth, colorspace, budget, cost);
+
+        if let Some(free) = free_space_at(output) {
+            let usable = free.saturating_sub(DISK_RESERVE_BYTES);
+            // A lossless encoder can expand its input, and a lossy one still
+            // needs headroom for the container and metadata. Require the volume
+            // to hold twice the decoded budget when that is achievable.
+            let allowed = usable / 2;
+            if allowed < limits.max_bytes {
+                limits.max_bytes = allowed;
+                limits.binding = Binding::Disk;
+            }
+        }
+
+        limits
+    }
+
+    /// Check a concrete `width x height` pair.
+    ///
+    /// Returns the constraint that was violated, so the caller can name it in
+    /// the error message instead of reporting a bare boolean.
+    pub fn check(&self, width: u64, height: u64) -> Result<(), LimitViolation> {
+        // Saturating arithmetic throughout: a `width * height` that overflows
+        // `u64` is not a value to panic on, it is an input to reject.
+        let pixels = width.saturating_mul(height);
+        if pixels > self.max_pixels {
+            return Err(LimitViolation {
+                kind: ViolationKind::Pixels,
+                actual: pixels,
+                allowed: self.max_pixels,
+                binding: self.binding,
+            });
+        }
+
+        if width > self.max_width {
+            return Err(LimitViolation {
+                kind: ViolationKind::Width,
+                actual: width,
+                allowed: self.max_width,
+                binding: Binding::Format,
+            });
+        }
+
+        if height > self.max_height {
+            return Err(LimitViolation {
+                kind: ViolationKind::Height,
+                actual: height,
+                allowed: self.max_height,
+                binding: Binding::Format,
+            });
+        }
+
+        Ok(())
+    }
+
+    /// Largest square side that satisfies the pixel ceiling.
+    ///
+    /// Used to suggest a concrete `--resize` value in error messages.
+    pub fn suggested_side(&self) -> u64 {
+        let by_pixels = integer_sqrt(self.max_pixels);
+        by_pixels.min(self.max_width).min(self.max_height).max(1)
+    }
+}
+
+/// Which measurement exceeded its limit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ViolationKind {
+    /// Width alone.
+    Width,
+    /// Height alone.
+    Height,
+    /// `width * height`.
+    Pixels,
+}
+
+/// A concrete limit that was exceeded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LimitViolation {
+    /// What was measured.
+    pub kind: ViolationKind,
+    /// The offending value.
+    pub actual: u64,
+    /// The ceiling it exceeded.
+    pub allowed: u64,
+    /// Which source produced the ceiling.
+    pub binding: Binding,
+}
+
+/// Bytes needed per pixel for a bit depth and colour space.
+pub fn bytes_per_pixel(depth: BitDepth, colorspace: ColorSpace) -> u64 {
+    let components = colorspace.num_components() as u64;
+    let bytes_per_component = match depth {
+        BitDepth::Eight => 1,
+        BitDepth::Sixteen => 2,
+        // Float images are stored as 32-bit samples.
+        BitDepth::Float32 => 4,
+        // Both `Unknown` and any variant added upstream describe samples we
+        // cannot size precisely; one byte per component is the floor, so the
+        // resulting budget is never an over-estimate.
+        _ => 1,
+    };
+
+    (components * bytes_per_component).max(1)
+}
+
+/// Integer square root by Newton's method.
+///
+/// `u64::isqrt` would do, but staying explicit keeps the MSRV story simple and
+/// the rounding behaviour obvious.
+fn integer_sqrt(value: u64) -> u64 {
+    if value < 2 {
+        return value;
+    }
+
+    let mut guess = 1u64 << ((64 - value.leading_zeros()) / 2 + 1);
+    loop {
+        let next = (guess + value / guess) / 2;
+        if next >= guess {
+            return guess;
+        }
+        guess = next;
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -63,10 +63,15 @@ impl FormatCaps {
 ///   specification (Profiles Overview) as 65536x65536 at `seq_level_idx=31`.
 ///   This bounds what a decoder must accept; it is *not* a promise that the
 ///   encoder will succeed at that size, so the memory budget still applies.
-/// - JPEG: libjpeg-derived implementations refuse dimensions above 65500 to
-///   avoid 16-bit overflow. The value is an implementation constant with no
-///   specification behind it, but it is a hard refusal rather than a quality
-///   trade-off, so it is enforced as an encoder capability.
+/// - JPEG and PNG: the zune decoders reject anything above the `max_width` /
+///   `max_height` in their `DecoderOptions`, which defaults to 16384 and is
+///   documented as respected by *all* decoders. This is deliberately not the
+///   larger figure the underlying codecs advertise (libjpeg's
+///   `JPEG_MAX_DIMENSION` is 65500): a limit that the decoder refuses before
+///   the codec is reached is the one a pre-check has to agree with, or the
+///   check passes a file that is then rejected further down with a worse
+///   message. Both decoders read the header before allocating, so 16384 is
+///   the size at which the pipeline stops, measured rather than guessed.
 /// - Anything absent from this table is unbounded here and left to the memory
 ///   budget plus the codec's own error reporting.
 pub const fn format_caps(format: ImageFormatId) -> FormatCaps {
@@ -81,15 +86,29 @@ pub const fn format_caps(format: ImageFormatId) -> FormatCaps {
             max_pixels: u64::MAX,
             source: "AVIF spec: AV1 coded image limit at seq_level_idx=31",
         },
-        // libjpeg-derived encoders abort above this to prevent overflow.
+        // The zune decoder's own ceiling, which it applies before the codec
+        // ever runs; see the module comment above.
         ImageFormatId::Jpeg => FormatCaps {
-            max_side: 65500,
+            max_side: DECODER_SIDE_LIMIT,
             max_pixels: u64::MAX,
-            source: "libjpeg JPEG_MAX_DIMENSION",
+            source: "zune-jpeg DecoderOptions::max_width default",
+        },
+        ImageFormatId::Png => FormatCaps {
+            max_side: DECODER_SIDE_LIMIT,
+            max_pixels: u64::MAX,
+            source: "zune-png DecoderOptions::max_width default",
         },
         _ => FormatCaps::UNBOUNDED,
     }
 }
+
+/// Side limit the zune decoders apply by default.
+///
+/// `zune_core::options::DecoderOptions` documents `max_width` and `max_height`
+/// as 16384 and "respected by all decoders". Both `zune-jpeg` and `zune-png`
+/// check it against the header before allocating, so it is a real ceiling
+/// rather than a suggestion.
+const DECODER_SIDE_LIMIT: u64 = 16384;
 
 /// Format identity used for limit lookup.
 ///

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -629,23 +629,12 @@ pub fn bytes_per_pixel(depth: BitDepth, colorspace: ColorSpace) -> u64 {
     (components * bytes_per_component).max(1)
 }
 
-/// Integer square root by Newton's method.
+/// Integer square root.
 ///
-/// `u64::isqrt` would do, but staying explicit keeps the MSRV story simple and
-/// the rounding behaviour obvious.
+/// Delegates to `u64::isqrt`, which has been stable since Rust 1.79 and
+/// the project's MSRV (1.95.0) is well above that.
 fn integer_sqrt(value: u64) -> u64 {
-    if value < 2 {
-        return value;
-    }
-
-    let mut guess = 1u64 << ((64 - value.leading_zeros()) / 2 + 1);
-    loop {
-        let next = (guess + value / guess) / 2;
-        if next >= guess {
-            return guess;
-        }
-        guess = next;
-    }
+    value.isqrt()
 }
 
 #[cfg(test)]

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -145,6 +145,23 @@ impl ImageFormatId {
             ImageFormatId::Other
         }
     }
+
+    /// Map a CLI encoder name to a format identity.
+    ///
+    /// These are the subcommand names, which do not always match the file
+    /// extension: `mozjpeg` writes a `.jpg`, and `oxipng` writes a `.png`.
+    /// Output limits must be looked up by what will actually be written, so
+    /// the encoder name is the right key here rather than the path suffix.
+    pub fn from_encoder_name(name: &str) -> Self {
+        match name {
+            "mozjpeg" | "jpeg" => ImageFormatId::Jpeg,
+            "oxipng" | "png" => ImageFormatId::Png,
+            "webp" => ImageFormatId::WebP,
+            "avif" => ImageFormatId::Avif,
+            "tiff" => ImageFormatId::Tiff,
+            _ => ImageFormatId::Other,
+        }
+    }
 }
 
 /// Fraction of the reported free memory this process is willing to spend.
@@ -364,6 +381,14 @@ pub struct LimitSet {
     pub max_bytes: u64,
     /// Which constraint produced the tightest `max_pixels`, for messages.
     pub binding: Binding,
+    /// Which constraint produced `max_bytes`.
+    ///
+    /// Tracked separately from `binding` because the two ceilings are bounded
+    /// by different sources: the pixel ceiling is never set by free space, and
+    /// the byte ceiling is only meaningful as a disk statement when free space
+    /// is what tightened it. Collapsing them into one field made a memory
+    /// budget get reported as a disk limit.
+    pub bytes_binding: Binding,
 }
 
 /// Which of the three sources ended up being the tightest constraint.
@@ -435,6 +460,7 @@ impl LimitSet {
             max_pixels,
             max_bytes: budget_bytes.saturating_mul(cost.total().max(1)),
             binding,
+            bytes_binding: Binding::Memory,
         }
     }
 
@@ -461,7 +487,7 @@ impl LimitSet {
             let allowed = usable / 2;
             if allowed < limits.max_bytes {
                 limits.max_bytes = allowed;
-                limits.binding = Binding::Disk;
+                limits.bytes_binding = Binding::Disk;
             }
         }
 
@@ -506,6 +532,26 @@ impl LimitSet {
         Ok(())
     }
 
+    /// Check an estimated byte footprint against the byte ceiling.
+    ///
+    /// Distinct from [`LimitSet::check`] because the two ceilings answer
+    /// different questions: `check` asks whether the pixels fit in *memory*,
+    /// this asks whether the result fits on *disk*. A small-pixel image in a
+    /// pathological format can still exhaust a volume, and a huge one may fit
+    /// on disk while never surviving the decode.
+    pub fn check_bytes(&self, bytes: u64) -> Result<(), LimitViolation> {
+        if bytes > self.max_bytes {
+            return Err(LimitViolation {
+                kind: ViolationKind::Bytes,
+                actual: bytes,
+                allowed: self.max_bytes,
+                binding: self.bytes_binding,
+            });
+        }
+
+        Ok(())
+    }
+
     /// Largest square side that satisfies the pixel ceiling.
     ///
     /// Used to suggest a concrete `--resize` value in error messages.
@@ -524,6 +570,8 @@ pub enum ViolationKind {
     Height,
     /// `width * height`.
     Pixels,
+    /// An estimated byte footprint, bounded by free space on the volume.
+    Bytes,
 }
 
 /// A concrete limit that was exceeded.

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -626,7 +626,7 @@ impl LimitSet {
     ///
     /// Used to suggest a concrete `--resize` value in error messages.
     pub fn suggested_side(&self) -> u64 {
-        let by_pixels = integer_sqrt(self.max_pixels);
+        let by_pixels = self.max_pixels.isqrt();
         by_pixels.min(self.max_width).min(self.max_height).max(1)
     }
 }
@@ -672,14 +672,6 @@ pub fn bytes_per_pixel(depth: BitDepth, colorspace: ColorSpace) -> u64 {
     };
 
     (components * bytes_per_component).max(1)
-}
-
-/// Integer square root.
-///
-/// Delegates to `u64::isqrt`, which has been stable since Rust 1.79 and
-/// the project's MSRV (1.95.0) is well above that.
-fn integer_sqrt(value: u64) -> u64 {
-    value.isqrt()
 }
 
 #[cfg(test)]

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -20,7 +20,9 @@
 //! values that the format specifications themselves mandate, plus the
 //! documented estimates in [`PipelineCost`].
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
+#[cfg(feature = "limits")]
+use std::path::PathBuf;
 
 use zune_core::{bit_depth::BitDepth, colorspace::ColorSpace};
 

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -20,7 +20,7 @@
 //! values that the format specifications themselves mandate, plus the
 //! documented estimates in [`PipelineCost`].
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use zune_core::{bit_depth::BitDepth, colorspace::ColorSpace};
 
@@ -365,14 +365,18 @@ fn probe_available_memory() -> u64 {
 /// Free bytes on the volume holding `path`, if it can be determined.
 ///
 /// Resolved by longest mount-point prefix so the answer reflects the volume the
-/// output actually lands on, not the working directory. Returns `None` when the
-/// path does not exist yet, is on an unenumerated volume, or the platform
-/// cannot report it; callers must treat that as "unknown", not "zero".
+/// output actually lands on, not the working directory. `path` usually does not
+/// exist yet — it is the output being *planned* — so the lookup walks up to the
+/// nearest ancestor that does and canonicalizes that; a plain
+/// `path.canonicalize()` would fail on exactly the new-output-file case this
+/// function exists for. Returns `None` when no ancestor exists, the volume is
+/// not enumerated, or the platform cannot report it; callers must treat that
+/// as "unknown", not "zero".
 #[cfg(feature = "limits")]
 pub fn free_space_at(path: &Path) -> Option<u64> {
     use sysinfo::Disks;
 
-    let target = path.canonicalize().ok()?;
+    let target = canonicalize_existing_ancestor(path)?;
 
     Disks::new_with_refreshed_list()
         .list()
@@ -380,6 +384,45 @@ pub fn free_space_at(path: &Path) -> Option<u64> {
         .filter(|disk| target.starts_with(disk.mount_point()))
         .max_by_key(|disk| disk.mount_point().as_os_str().len())
         .map(|disk| disk.available_space())
+}
+
+/// Canonicalize the nearest ancestor of `path` that exists.
+///
+/// The verbatim (`\\?\`) prefix `canonicalize` produces on Windows is stripped
+/// because sysinfo reports mount points in the ordinary `C:\` form; comparing
+/// the verbatim form against them would never match and silently disable the
+/// free-space check on all of Windows.
+#[cfg(feature = "limits")]
+fn canonicalize_existing_ancestor(path: &Path) -> Option<PathBuf> {
+    let mut candidate = Some(path);
+    while let Some(current) = candidate {
+        if let Ok(canonical) = current.canonicalize() {
+            return Some(strip_verbatim_prefix(&canonical));
+        }
+        candidate = current.parent();
+    }
+    None
+}
+
+/// Strip the Windows verbatim (`\\?\`) prefix from a canonicalized path.
+///
+/// `\\?\UNC\server\share` is restored to the regular UNC form. Paths without
+/// the prefix — and every path on non-Windows platforms — are returned
+/// unchanged.
+#[cfg(feature = "limits")]
+fn strip_verbatim_prefix(path: &Path) -> PathBuf {
+    #[cfg(windows)]
+    {
+        if let Some(s) = path.to_str() {
+            if let Some(rest) = s.strip_prefix(r"\\?\UNC\") {
+                return PathBuf::from(format!(r"\\{rest}"));
+            }
+            if let Some(rest) = s.strip_prefix(r"\\?\") {
+                return PathBuf::from(rest);
+            }
+        }
+    }
+    path.to_path_buf()
 }
 
 /// Free bytes on the volume holding `path`, if it can be determined.

--- a/src/limits/tests.rs
+++ b/src/limits/tests.rs
@@ -1,0 +1,325 @@
+use super::*;
+
+fn budget_with(memory: u64, concurrency: usize) -> SystemBudget {
+    SystemBudget {
+        available_memory: memory,
+        address_cap: ADDRESS_SPACE_CAP,
+        concurrency,
+    }
+}
+
+#[test]
+fn webp_cap_matches_libwebp_constant() {
+    let caps = format_caps(ImageFormatId::WebP);
+    assert_eq!(caps.max_side, 16383);
+}
+
+#[test]
+fn jpeg_cap_matches_libjpeg_constant() {
+    let caps = format_caps(ImageFormatId::Jpeg);
+    assert_eq!(caps.max_side, 65500);
+}
+
+#[test]
+fn avif_cap_matches_spec() {
+    let caps = format_caps(ImageFormatId::Avif);
+    assert_eq!(caps.max_side, 65536);
+}
+
+#[test]
+fn formats_without_published_limits_are_unbounded() {
+    for format in [
+        ImageFormatId::Png,
+        ImageFormatId::Tiff,
+        ImageFormatId::Svg,
+        ImageFormatId::Other,
+    ] {
+        let caps = format_caps(format);
+        assert_eq!(
+            caps.max_side,
+            u64::MAX,
+            "{} must not claim a published dimension limit",
+            format.name()
+        );
+        assert_eq!(caps.max_pixels, u64::MAX);
+    }
+}
+
+#[test]
+fn unprobed_machine_falls_back_instead_of_failing() {
+    let budget = budget_with(0, 1);
+    assert!(!budget.is_probed());
+    assert_eq!(budget.per_image_bytes(), FALLBACK_PER_IMAGE_BYTES);
+}
+
+#[test]
+fn budget_is_halved_and_divided_by_concurrency() {
+    let budget = budget_with(8 * 1024 * 1024 * 1024, 4);
+    // Half of 8 GiB is 4 GiB, split across 4 concurrent images.
+    assert_eq!(budget.per_image_bytes(), 1024 * 1024 * 1024);
+}
+
+#[test]
+fn concurrency_of_zero_is_treated_as_one() {
+    let budget = budget_with(1024 * 1024 * 1024, 0);
+    assert_eq!(budget.per_image_bytes(), 512 * 1024 * 1024);
+}
+
+#[test]
+fn bytes_per_pixel_reflects_depth_and_colorspace() {
+    assert_eq!(bytes_per_pixel(BitDepth::Eight, ColorSpace::RGB), 3);
+    assert_eq!(bytes_per_pixel(BitDepth::Eight, ColorSpace::RGBA), 4);
+    assert_eq!(bytes_per_pixel(BitDepth::Sixteen, ColorSpace::RGBA), 8);
+    assert_eq!(bytes_per_pixel(BitDepth::Float32, ColorSpace::RGBA), 16);
+    assert_eq!(bytes_per_pixel(BitDepth::Eight, ColorSpace::Luma), 1);
+    // An unknown colour space must still produce a usable divisor.
+    assert_eq!(bytes_per_pixel(BitDepth::Unknown, ColorSpace::Unknown), 1);
+}
+
+#[test]
+fn memory_budget_binds_before_format_when_memory_is_tight() {
+    // 1 GiB total, so 512 MiB usable; RGBA8 with a 3+16 cost is 76 bytes/px.
+    let budget = budget_with(1024 * 1024 * 1024, 1);
+    let limits = LimitSet::for_input(
+        ImageFormatId::Avif,
+        BitDepth::Eight,
+        ColorSpace::RGBA,
+        &budget,
+        PipelineCost::for_encoder(ImageFormatId::Avif),
+    );
+
+    assert_eq!(limits.binding, Binding::Memory);
+    assert!(limits.max_pixels < 65536 * 65536);
+}
+
+#[test]
+fn format_cap_binds_when_memory_is_plentiful() {
+    // 1 TiB available; the WebP side limit must win.
+    let budget = budget_with(1024u64 * 1024 * 1024 * 1024, 1);
+    let limits = LimitSet::for_input(
+        ImageFormatId::WebP,
+        BitDepth::Eight,
+        ColorSpace::RGBA,
+        &budget,
+        PipelineCost::for_encoder(ImageFormatId::WebP),
+    );
+
+    assert_eq!(limits.max_width, 16383);
+    assert_eq!(limits.max_height, 16383);
+}
+
+#[test]
+fn check_reports_width_before_pixels() {
+    let limits = LimitSet {
+        max_width: 100,
+        max_height: 200,
+        max_pixels: 10_000,
+        max_bytes: u64::MAX,
+        binding: Binding::Format,
+    };
+
+    // The area passes, so only the side check can reject this input.
+    let violation = limits.check(101, 10).unwrap_err();
+    assert_eq!(violation.kind, ViolationKind::Width);
+    assert_eq!(violation.actual, 101);
+    assert_eq!(violation.allowed, 100);
+}
+
+#[test]
+fn check_reports_pixels_before_a_side() {
+    let limits = LimitSet {
+        max_width: 100,
+        max_height: 100,
+        max_pixels: 1_000,
+        max_bytes: u64::MAX,
+        binding: Binding::Memory,
+    };
+
+    // Both a side and the area are too large. The area is reported because it
+    // is the tighter description, and it carries the binding that produced it.
+    let violation = limits.check(200, 200).unwrap_err();
+    assert_eq!(violation.kind, ViolationKind::Pixels);
+    assert_eq!(violation.binding, Binding::Memory);
+}
+
+#[test]
+fn check_reports_height() {
+    let limits = LimitSet {
+        max_width: 100,
+        max_height: 200,
+        max_pixels: 10_000,
+        max_bytes: u64::MAX,
+        binding: Binding::Format,
+    };
+
+    let violation = limits.check(10, 201).unwrap_err();
+    assert_eq!(violation.kind, ViolationKind::Height);
+}
+
+#[test]
+fn check_reports_pixel_product_when_both_sides_pass() {
+    let limits = LimitSet {
+        max_width: 1000,
+        max_height: 1000,
+        max_pixels: 10_000,
+        max_bytes: u64::MAX,
+        binding: Binding::Memory,
+    };
+
+    // Each side is legal; only the product exceeds the ceiling.
+    let violation = limits.check(500, 500).unwrap_err();
+    assert_eq!(violation.kind, ViolationKind::Pixels);
+    assert_eq!(violation.actual, 250_000);
+    assert_eq!(violation.binding, Binding::Memory);
+
+    assert!(limits.check(100, 100).is_ok());
+}
+
+#[test]
+fn check_accepts_the_exact_limit() {
+    let limits = LimitSet {
+        max_width: 500,
+        max_height: 500,
+        max_pixels: 250_000,
+        max_bytes: u64::MAX,
+        binding: Binding::Format,
+    };
+
+    assert!(limits.check(500, 500).is_ok());
+}
+
+#[test]
+fn suggested_side_fits_under_every_ceiling() {
+    let limits = LimitSet {
+        max_width: 16383,
+        max_height: 16383,
+        max_pixels: 10_000_000,
+        max_bytes: u64::MAX,
+        binding: Binding::Memory,
+    };
+
+    let side = limits.suggested_side();
+    assert!(side <= limits.max_width);
+    assert!(side.saturating_mul(side) <= limits.max_pixels);
+    assert_eq!(side, 3162);
+}
+
+#[test]
+fn suggested_side_is_at_least_one() {
+    let limits = LimitSet {
+        max_width: 0,
+        max_height: 0,
+        max_pixels: 0,
+        max_bytes: 0,
+        binding: Binding::Memory,
+    };
+
+    assert_eq!(limits.suggested_side(), 1);
+}
+
+#[test]
+fn integer_sqrt_matches_known_values() {
+    assert_eq!(integer_sqrt(0), 0);
+    assert_eq!(integer_sqrt(1), 1);
+    assert_eq!(integer_sqrt(2), 1);
+    assert_eq!(integer_sqrt(4), 2);
+    assert_eq!(integer_sqrt(15), 3);
+    assert_eq!(integer_sqrt(16), 4);
+    assert_eq!(integer_sqrt(17), 4);
+    assert_eq!(integer_sqrt(10_000), 100);
+    assert_eq!(integer_sqrt(u64::MAX), 4_294_967_295);
+}
+
+#[test]
+fn pipeline_cost_sums_all_stages() {
+    let cost = PipelineCost::new(3, 2, 2, 16);
+    assert_eq!(cost.total(), 23);
+}
+
+#[test]
+fn format_extension_lookup_is_case_insensitive() {
+    assert_eq!(ImageFormatId::from_extension("JPG"), ImageFormatId::Jpeg);
+    assert_eq!(ImageFormatId::from_extension("jpeg"), ImageFormatId::Jpeg);
+    assert_eq!(ImageFormatId::from_extension("WebP"), ImageFormatId::WebP);
+    assert_eq!(ImageFormatId::from_extension("tif"), ImageFormatId::Tiff);
+    assert_eq!(ImageFormatId::from_extension("svgz"), ImageFormatId::Svg);
+    assert_eq!(ImageFormatId::from_extension("qoi"), ImageFormatId::Other);
+}
+
+#[test]
+fn binding_descriptions_are_not_empty() {
+    for binding in [
+        Binding::Format,
+        Binding::Memory,
+        Binding::Disk,
+        Binding::None,
+    ] {
+        assert!(!binding.describe().is_empty());
+    }
+}
+
+/// The theoretical check the task asks for: a 65500x65500 image must be
+/// rejected before any decoding is attempted, on every realistic memory budget.
+///
+/// 65500 is libjpeg's inclusive per-side ceiling, so neither side alone is
+/// wrong; only the area is impossible. That makes this the case where the cap
+/// has to be caught by the pixel product rather than by a side check.
+#[test]
+fn extreme_dimensions_are_rejected_by_the_jpeg_ceiling() {
+    // A square whose area is the JPEG side ceiling squared. libjpeg's own
+    // 65500x65500 ceiling is therefore exactly the largest square the format
+    // can express, and every size the task calls "extreme" is at least this big.
+    const EXTREME_SIDE: u64 = 65500;
+    const EXTREME_AREA: u64 = EXTREME_SIDE * EXTREME_SIDE;
+
+    // Anything at or above this produces the same budget, so this figure means
+    // "more memory than any process can address on 64-bit".
+    const PLENTIFUL: u64 = u64::MAX / 4 + 1;
+    const TYPICAL: u64 = 64 * 1024 * 1024 * 1024;
+
+    let limits = |memory: u64| {
+        let budget = budget_with(memory, 1);
+        LimitSet::for_input(
+            ImageFormatId::Jpeg,
+            BitDepth::Eight,
+            ColorSpace::RGB,
+            &budget,
+            PipelineCost::for_encoder(ImageFormatId::Jpeg),
+        )
+    };
+
+    // The side ceiling itself is honoured, not conflated with a pixel limit.
+    assert_eq!(limits(PLENTIFUL).max_width, EXTREME_SIDE);
+    assert!(limits(PLENTIFUL).check(EXTREME_SIDE, 1).is_ok());
+
+    // Memory is the binding constraint in practice. `max_pixels` is derived
+    // from the budget rather than restated here, so this compares the two
+    // ceilings instead of re-deriving one of them by hand.
+    let bound_by_memory = limits(TYPICAL);
+    assert!(
+        bound_by_memory.max_pixels < EXTREME_AREA,
+        "a {TYPICAL}-byte budget admitted {} pixels, which is not below \
+         the {EXTREME_AREA}-pixel extreme square",
+        bound_by_memory.max_pixels
+    );
+    let violation = bound_by_memory.check(EXTREME_SIDE, EXTREME_SIDE).unwrap_err();
+    assert_eq!(violation.kind, ViolationKind::Pixels);
+    assert_eq!(violation.binding, Binding::Memory);
+    assert!(violation.actual > violation.allowed);
+
+    // With memory taken out of the picture, the area derived from the side
+    // ceiling takes over and still rejects the extreme square.
+    let bound_by_format = limits(PLENTIFUL);
+    let violation = bound_by_format.check(EXTREME_SIDE, EXTREME_SIDE + 1).unwrap_err();
+    assert_eq!(violation.kind, ViolationKind::Pixels);
+    assert_eq!(violation.binding, Binding::Format);
+    assert_eq!(violation.allowed, EXTREME_AREA);
+
+    // The derived area must not be so tight that it rejects ordinary shapes:
+    // a 65500x2466 panorama (the largest fixture in tests/) has to pass.
+    assert!(limits(PLENTIFUL).check(EXTREME_SIDE, 2466).is_ok());
+
+    // A square that both the format and the memory budget can express is
+    // accepted, so the checks do not reject everything indiscriminately.
+    assert!(limits(TYPICAL).check(16_000, 16_000).is_ok());
+}

--- a/src/limits/tests.rs
+++ b/src/limits/tests.rs
@@ -209,19 +209,6 @@ fn suggested_side_is_at_least_one() {
 }
 
 #[test]
-fn integer_sqrt_matches_known_values() {
-    assert_eq!(integer_sqrt(0), 0);
-    assert_eq!(integer_sqrt(1), 1);
-    assert_eq!(integer_sqrt(2), 1);
-    assert_eq!(integer_sqrt(4), 2);
-    assert_eq!(integer_sqrt(15), 3);
-    assert_eq!(integer_sqrt(16), 4);
-    assert_eq!(integer_sqrt(17), 4);
-    assert_eq!(integer_sqrt(10_000), 100);
-    assert_eq!(integer_sqrt(u64::MAX), 4_294_967_295);
-}
-
-#[test]
 fn pipeline_cost_sums_all_stages() {
     let cost = PipelineCost::new(3, 2, 2, 16);
     assert_eq!(cost.total(), 23);

--- a/src/limits/tests.rs
+++ b/src/limits/tests.rs
@@ -8,6 +8,22 @@ fn budget_with(memory: u64, concurrency: usize) -> SystemBudget {
     }
 }
 
+/// Build a `LimitSet` for the `check` tests, whose subject is the pixel
+/// ceilings. The byte ceiling is left unbounded so it cannot accidentally
+/// become the thing under test.
+fn pixel_limits(
+    max_width: u64, max_height: u64, max_pixels: u64, binding: Binding,
+) -> LimitSet {
+    LimitSet {
+        max_width,
+        max_height,
+        max_pixels,
+        max_bytes: u64::MAX,
+        binding,
+        bytes_binding: Binding::Memory,
+    }
+}
+
 #[test]
 fn webp_cap_matches_libwebp_constant() {
     let caps = format_caps(ImageFormatId::WebP);
@@ -110,13 +126,7 @@ fn format_cap_binds_when_memory_is_plentiful() {
 
 #[test]
 fn check_reports_width_before_pixels() {
-    let limits = LimitSet {
-        max_width: 100,
-        max_height: 200,
-        max_pixels: 10_000,
-        max_bytes: u64::MAX,
-        binding: Binding::Format,
-    };
+    let limits = pixel_limits(100, 200, 10_000, Binding::Format);
 
     // The area passes, so only the side check can reject this input.
     let violation = limits.check(101, 10).unwrap_err();
@@ -127,13 +137,7 @@ fn check_reports_width_before_pixels() {
 
 #[test]
 fn check_reports_pixels_before_a_side() {
-    let limits = LimitSet {
-        max_width: 100,
-        max_height: 100,
-        max_pixels: 1_000,
-        max_bytes: u64::MAX,
-        binding: Binding::Memory,
-    };
+    let limits = pixel_limits(100, 100, 1_000, Binding::Memory);
 
     // Both a side and the area are too large. The area is reported because it
     // is the tighter description, and it carries the binding that produced it.
@@ -144,13 +148,7 @@ fn check_reports_pixels_before_a_side() {
 
 #[test]
 fn check_reports_height() {
-    let limits = LimitSet {
-        max_width: 100,
-        max_height: 200,
-        max_pixels: 10_000,
-        max_bytes: u64::MAX,
-        binding: Binding::Format,
-    };
+    let limits = pixel_limits(100, 200, 10_000, Binding::Format);
 
     let violation = limits.check(10, 201).unwrap_err();
     assert_eq!(violation.kind, ViolationKind::Height);
@@ -158,13 +156,7 @@ fn check_reports_height() {
 
 #[test]
 fn check_reports_pixel_product_when_both_sides_pass() {
-    let limits = LimitSet {
-        max_width: 1000,
-        max_height: 1000,
-        max_pixels: 10_000,
-        max_bytes: u64::MAX,
-        binding: Binding::Memory,
-    };
+    let limits = pixel_limits(1000, 1000, 10_000, Binding::Memory);
 
     // Each side is legal; only the product exceeds the ceiling.
     let violation = limits.check(500, 500).unwrap_err();
@@ -177,26 +169,14 @@ fn check_reports_pixel_product_when_both_sides_pass() {
 
 #[test]
 fn check_accepts_the_exact_limit() {
-    let limits = LimitSet {
-        max_width: 500,
-        max_height: 500,
-        max_pixels: 250_000,
-        max_bytes: u64::MAX,
-        binding: Binding::Format,
-    };
+    let limits = pixel_limits(500, 500, 250_000, Binding::Format);
 
     assert!(limits.check(500, 500).is_ok());
 }
 
 #[test]
 fn suggested_side_fits_under_every_ceiling() {
-    let limits = LimitSet {
-        max_width: 16383,
-        max_height: 16383,
-        max_pixels: 10_000_000,
-        max_bytes: u64::MAX,
-        binding: Binding::Memory,
-    };
+    let limits = pixel_limits(16383, 16383, 10_000_000, Binding::Memory);
 
     let side = limits.suggested_side();
     assert!(side <= limits.max_width);
@@ -206,12 +186,15 @@ fn suggested_side_fits_under_every_ceiling() {
 
 #[test]
 fn suggested_side_is_at_least_one() {
+    // Every ceiling is zero, including the byte one: the suggestion still has
+    // to be a legal size rather than zero.
     let limits = LimitSet {
         max_width: 0,
         max_height: 0,
         max_pixels: 0,
         max_bytes: 0,
         binding: Binding::Memory,
+        bytes_binding: Binding::Memory,
     };
 
     assert_eq!(limits.suggested_side(), 1);
@@ -322,4 +305,59 @@ fn extreme_dimensions_are_rejected_by_the_jpeg_ceiling() {
     // A square that both the format and the memory budget can express is
     // accepted, so the checks do not reject everything indiscriminately.
     assert!(limits(TYPICAL).check(16_000, 16_000).is_ok());
+}
+
+#[test]
+fn encoder_names_map_to_the_format_they_write() {
+    // The CLI subcommand is not the file extension: `mozjpeg` writes a `.jpg`
+    // and `oxipng` writes a `.png`. Looking output limits up by subcommand is
+    // what makes them describe the file that actually lands on disk.
+    assert_eq!(ImageFormatId::from_encoder_name("mozjpeg"), ImageFormatId::Jpeg);
+    assert_eq!(ImageFormatId::from_encoder_name("jpeg"), ImageFormatId::Jpeg);
+    assert_eq!(ImageFormatId::from_encoder_name("oxipng"), ImageFormatId::Png);
+    assert_eq!(ImageFormatId::from_encoder_name("png"), ImageFormatId::Png);
+    assert_eq!(ImageFormatId::from_encoder_name("webp"), ImageFormatId::WebP);
+    assert_eq!(ImageFormatId::from_encoder_name("avif"), ImageFormatId::Avif);
+    assert_eq!(ImageFormatId::from_encoder_name("tiff"), ImageFormatId::Tiff);
+    assert_eq!(ImageFormatId::from_encoder_name("qoi"), ImageFormatId::Other);
+}
+
+#[test]
+fn check_bytes_reports_the_byte_binding() {
+    let limits = LimitSet {
+        max_width: u64::MAX,
+        max_height: u64::MAX,
+        max_pixels: u64::MAX,
+        max_bytes: 1024,
+        binding: Binding::Format,
+        bytes_binding: Binding::Disk,
+    };
+
+    let violation = limits.check_bytes(2048).unwrap_err();
+    assert_eq!(violation.kind, ViolationKind::Bytes);
+    assert_eq!(violation.actual, 2048);
+    assert_eq!(violation.allowed, 1024);
+
+    // The byte ceiling reports *its own* binding, not the pixel one. Mixing
+    // them made a full volume report itself as a format limit.
+    assert_eq!(violation.binding, Binding::Disk);
+
+    assert!(limits.check_bytes(1024).is_ok());
+}
+
+#[test]
+fn byte_and_pixel_bindings_are_tracked_separately() {
+    // A limit set whose pixels are format-bound but whose bytes are disk-bound
+    // must answer each question with the right source.
+    let limits = LimitSet {
+        max_width: 100,
+        max_height: 100,
+        max_pixels: 10_000,
+        max_bytes: 4096,
+        binding: Binding::Format,
+        bytes_binding: Binding::Disk,
+    };
+
+    assert_eq!(limits.check(101, 1).unwrap_err().binding, Binding::Format);
+    assert_eq!(limits.check_bytes(8192).unwrap_err().binding, Binding::Disk);
 }

--- a/src/limits/tests.rs
+++ b/src/limits/tests.rs
@@ -249,6 +249,38 @@ fn binding_descriptions_are_not_empty() {
     }
 }
 
+/// The free-space probe must answer for the case it exists for: an output file
+/// that does not exist yet, in a directory that does. A bare `canonicalize` on
+/// the file itself fails here, which used to silently disable the check.
+#[cfg(feature = "limits")]
+#[test]
+fn free_space_is_found_for_a_not_yet_created_output() {
+    let missing_output = std::env::temp_dir().join(format!(
+        "rimage-limits-{}-not-created-yet/out.png",
+        std::process::id()
+    ));
+
+    let free = free_space_at(&missing_output);
+    assert!(
+        free.is_some(),
+        "free space under the temp dir must be determinable"
+    );
+    assert!(free.unwrap() > 0);
+}
+
+/// Even when several trailing components are missing, the probe walks up to
+/// the nearest existing ancestor instead of giving up.
+#[cfg(feature = "limits")]
+#[test]
+fn free_space_walks_up_past_missing_directories() {
+    let deep = std::env::temp_dir().join(format!(
+        "rimage-limits-{}/missing/deeper/out.png",
+        std::process::id()
+    ));
+
+    assert!(free_space_at(&deep).is_some());
+}
+
 /// An image beyond the decoder's ceiling must be rejected before any decoding
 /// is attempted, on every realistic memory budget.
 ///

--- a/src/limits/tests.rs
+++ b/src/limits/tests.rs
@@ -31,9 +31,22 @@ fn webp_cap_matches_libwebp_constant() {
 }
 
 #[test]
-fn jpeg_cap_matches_libjpeg_constant() {
+fn jpeg_cap_matches_the_decoder_ceiling() {
+    // Not libjpeg's 65500: the zune decoder refuses anything above its own
+    // `max_width` default before the codec runs, and a pre-check that allowed
+    // more would pass files that then fail to decode.
     let caps = format_caps(ImageFormatId::Jpeg);
-    assert_eq!(caps.max_side, 65500);
+    assert_eq!(caps.max_side, DECODER_SIDE_LIMIT);
+    assert_eq!(caps.max_side, 16384);
+}
+
+#[test]
+fn png_cap_matches_the_decoder_ceiling() {
+    // PNG publishes no side limit of its own, but the decoder applies the same
+    // default ceiling as JPEG, so the cap has to reflect that rather than
+    // leaving the format unbounded.
+    let caps = format_caps(ImageFormatId::Png);
+    assert_eq!(caps.max_side, DECODER_SIDE_LIMIT);
 }
 
 #[test]
@@ -44,12 +57,7 @@ fn avif_cap_matches_spec() {
 
 #[test]
 fn formats_without_published_limits_are_unbounded() {
-    for format in [
-        ImageFormatId::Png,
-        ImageFormatId::Tiff,
-        ImageFormatId::Svg,
-        ImageFormatId::Other,
-    ] {
+    for format in [ImageFormatId::Tiff, ImageFormatId::Svg, ImageFormatId::Other] {
         let caps = format_caps(format);
         assert_eq!(
             caps.max_side,
@@ -241,19 +249,19 @@ fn binding_descriptions_are_not_empty() {
     }
 }
 
-/// The theoretical check the task asks for: a 65500x65500 image must be
-/// rejected before any decoding is attempted, on every realistic memory budget.
+/// An image beyond the decoder's ceiling must be rejected before any decoding
+/// is attempted, on every realistic memory budget.
 ///
-/// 65500 is libjpeg's inclusive per-side ceiling, so neither side alone is
-/// wrong; only the area is impossible. That makes this the case where the cap
-/// has to be caught by the pixel product rather than by a side check.
+/// The ceiling is the zune decoder's own 16384, so a 65500x2466 image — which
+/// the underlying codecs could express — is rejected on its *width*. That is
+/// the intended behaviour: the decoder refuses it from the header anyway, and
+/// catching it here is what makes the message name a limit instead of quoting
+/// the decoder's internal one.
 #[test]
-fn extreme_dimensions_are_rejected_by_the_jpeg_ceiling() {
-    // A square whose area is the JPEG side ceiling squared. libjpeg's own
-    // 65500x65500 ceiling is therefore exactly the largest square the format
-    // can express, and every size the task calls "extreme" is at least this big.
-    const EXTREME_SIDE: u64 = 65500;
-    const EXTREME_AREA: u64 = EXTREME_SIDE * EXTREME_SIDE;
+fn dimensions_beyond_the_decoder_ceiling_are_rejected() {
+    // The largest fixture in the corpus, and the size the task calls extreme.
+    const EXTREME_WIDTH: u64 = 65500;
+    const EXTREME_HEIGHT: u64 = 2466;
 
     // Anything at or above this produces the same budget, so this figure means
     // "more memory than any process can address on 64-bit".
@@ -271,40 +279,62 @@ fn extreme_dimensions_are_rejected_by_the_jpeg_ceiling() {
         )
     };
 
-    // The side ceiling itself is honoured, not conflated with a pixel limit.
-    assert_eq!(limits(PLENTIFUL).max_width, EXTREME_SIDE);
-    assert!(limits(PLENTIFUL).check(EXTREME_SIDE, 1).is_ok());
+    // The ceiling is the decoder's, not libjpeg's larger figure.
+    assert_eq!(limits(PLENTIFUL).max_width, 16384);
+    assert!(limits(PLENTIFUL).check(16384, 1).is_ok());
 
-    // Memory is the binding constraint in practice. `max_pixels` is derived
-    // from the budget rather than restated here, so this compares the two
-    // ceilings instead of re-deriving one of them by hand.
-    let bound_by_memory = limits(TYPICAL);
-    assert!(
-        bound_by_memory.max_pixels < EXTREME_AREA,
-        "a {TYPICAL}-byte budget admitted {} pixels, which is not below \
-         the {EXTREME_AREA}-pixel extreme square",
-        bound_by_memory.max_pixels
-    );
-    let violation = bound_by_memory.check(EXTREME_SIDE, EXTREME_SIDE).unwrap_err();
-    assert_eq!(violation.kind, ViolationKind::Pixels);
-    assert_eq!(violation.binding, Binding::Memory);
-    assert!(violation.actual > violation.allowed);
-
-    // With memory taken out of the picture, the area derived from the side
-    // ceiling takes over and still rejects the extreme square.
-    let bound_by_format = limits(PLENTIFUL);
-    let violation = bound_by_format.check(EXTREME_SIDE, EXTREME_SIDE + 1).unwrap_err();
-    assert_eq!(violation.kind, ViolationKind::Pixels);
+    // The extreme panorama is rejected on its width, even with memory to spare.
+    let violation = limits(PLENTIFUL)
+        .check(EXTREME_WIDTH, EXTREME_HEIGHT)
+        .unwrap_err();
+    assert_eq!(violation.kind, ViolationKind::Width);
     assert_eq!(violation.binding, Binding::Format);
-    assert_eq!(violation.allowed, EXTREME_AREA);
 
-    // The derived area must not be so tight that it rejects ordinary shapes:
-    // a 65500x2466 panorama (the largest fixture in tests/) has to pass.
-    assert!(limits(PLENTIFUL).check(EXTREME_SIDE, 2466).is_ok());
+    // Memory is the binding constraint for large images that are within the
+    // side ceiling. `max_pixels` is derived from the budget rather than
+    // restated here, so this compares the two ceilings instead of re-deriving
+    // one of them by hand.
+    const BIG_SIDE: u64 = 16384;
+    // Small enough that the memory budget is tighter than the side ceiling,
+    // which is the state this branch is meant to exercise.
+    const CONSTRAINED: u64 = 4 * 1024 * 1024 * 1024;
+    let bound_by_memory = limits(CONSTRAINED);
+    assert!(
+        bound_by_memory.max_pixels < BIG_SIDE * BIG_SIDE,
+        "a {CONSTRAINED}-byte budget admitted {} pixels, which is not below the \
+         {}-pixel square at the side ceiling",
+        bound_by_memory.max_pixels,
+        BIG_SIDE * BIG_SIDE
+    );
+    assert_eq!(bound_by_memory.binding, Binding::Memory);
+
+    // At the side ceiling with room to spare, the format cap is what binds.
+    assert_eq!(limits(PLENTIFUL).binding, Binding::Format);
+    assert_eq!(limits(PLENTIFUL).max_pixels, BIG_SIDE * BIG_SIDE);
 
     // A square that both the format and the memory budget can express is
     // accepted, so the checks do not reject everything indiscriminately.
-    assert!(limits(TYPICAL).check(16_000, 16_000).is_ok());
+    assert!(limits(TYPICAL).check(8_000, 8_000).is_ok());
+}
+
+#[test]
+fn png_is_bounded_by_the_same_decoder_ceiling() {
+    let budget = budget_with(u64::MAX / 4 + 1, 1);
+    let limits = LimitSet::for_input(
+        ImageFormatId::Png,
+        BitDepth::Eight,
+        ColorSpace::RGBA,
+        &budget,
+        PipelineCost::for_encoder(ImageFormatId::Png),
+    );
+
+    assert_eq!(limits.max_width, DECODER_SIDE_LIMIT);
+    assert_eq!(limits.max_height, DECODER_SIDE_LIMIT);
+    assert!(limits.check(16384, 16384).is_ok());
+    assert_eq!(
+        limits.check(16385, 1).unwrap_err().kind,
+        ViolationKind::Width
+    );
 }
 
 #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -810,10 +810,14 @@ fn pretty_path(path: &Path) -> PathBuf {
 }
 
 fn main() -> std::process::ExitCode {
-    let logger = pretty_env_logger::formatted_builder()
+    // env_logger (maintained) replaces pretty_env_logger, which is
+    // unmaintained. The timestamp is dropped to match the old compact style;
+    // colored levels stay on when stderr is a terminal.
+    let logger = env_logger::Builder::new()
         .filter_level(log::LevelFilter::Warn)
         .parse_default_env()
         .filter_module("little_exif", log::LevelFilter::Off)
+        .format_timestamp(None)
         .build();
     let level = logger.filter();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,16 +36,74 @@ use crate::cli::pipeline::encoder;
 
 mod cli;
 
-macro_rules! handle_error {
-    ( $path:expr, $e:expr ) => {
+/// Report a failure and abandon the current file.
+///
+/// The `side` argument says whether the failure happened reading the input or
+/// writing the output, which is what lets the run end with a code that names
+/// the side. It is passed explicitly rather than inferred so a call site cannot
+/// be mislabelled by accident.
+///
+/// The failure is recorded on the shared [`ProcessingState`] before returning,
+/// so the end-of-run summary can count the sides separately and the process can
+/// exit with the code that matches.
+macro_rules! fail_file {
+    ( input, $state:expr, $path:expr, $e:expr ) => {
         match $e {
             Ok(v) => v,
             Err(e) => {
+                record_failure(&$state, rimage::exit::ExitCode::Input);
                 log::error!("{}: {e}", $path.display());
                 return;
             }
         }
     };
+    ( output, $state:expr, $path:expr, $e:expr ) => {
+        match $e {
+            Ok(v) => v,
+            Err(e) => {
+                record_failure(&$state, rimage::exit::ExitCode::Output);
+                log::error!("{}: {e}", $path.display());
+                return;
+            }
+        }
+    };
+}
+
+/// Report a structured pipeline failure and abandon the current file.
+///
+/// Unlike [`fail_file!`] the side comes from the error itself, and the message
+/// carries the hint the `error` module derived for it.
+macro_rules! fail_pipeline {
+    ( $state:expr, $e:expr ) => {
+        match $e {
+            Ok(v) => v,
+            Err(e) => {
+                record_structured_failure(&$state, &e);
+                return;
+            }
+        }
+    };
+}
+
+/// Refuse the current file for a reason discovered here, and abandon it.
+///
+/// The bare `return`s that used to sit on these paths logged a message but left
+/// no trace on the run, so the process still reported success. Every early exit
+/// from the worker must go through this or one of the `fail_*` macros, or the
+/// exit code stops describing what happened.
+macro_rules! refuse_file {
+    ( input, $state:expr, $path:expr, $($arg:tt)* ) => {{
+        record_failure(&$state, rimage::exit::ExitCode::Input);
+        log::error!($($arg)*);
+        let _ = &$path;
+        return;
+    }};
+    ( output, $state:expr, $path:expr, $($arg:tt)* ) => {{
+        record_failure(&$state, rimage::exit::ExitCode::Output);
+        log::error!($($arg)*);
+        let _ = &$path;
+        return;
+    }};
 }
 
 const SUPPORTS_EXIF: &[&str; 7] = &[
@@ -62,6 +120,14 @@ struct Result {
 struct ProcessingState {
     results: Vec<Result>,
     metadata: Option<Metadata>,
+    /// The verdict for the run, accumulated as each file finishes.
+    ///
+    /// Kept here rather than counted from `results.len()` at the end, because
+    /// the number of successes cannot distinguish a failure to read an input
+    /// from a failure to write an output — and those exit with different codes.
+    run: rimage::exit::RunState,
+    /// The side each failure happened on, for the end-of-run summary.
+    failures: Vec<rimage::exit::ExitCode>,
 }
 
 impl ProcessingState {
@@ -69,8 +135,47 @@ impl ProcessingState {
         Self {
             results: vec![],
             metadata: None,
+            run: rimage::exit::RunState::start(),
+            failures: vec![],
         }
     }
+
+    /// Fold the outcome of one file into the run verdict.
+    fn record(&mut self, file: rimage::exit::ExitCode) {
+        self.run = self.run.record(file);
+    }
+}
+
+/// Record a failure on the shared state.
+///
+/// Called from the worker threads, so it takes the state by reference and locks
+/// internally. Only the count and the side are kept: each failure's path was
+/// already logged at the point it happened, and repeating the list at the end
+/// would bury the summary line the reader is looking for.
+fn record_failure(state: &Arc<Mutex<ProcessingState>>, side: rimage::exit::ExitCode) {
+    let mut state = state.lock().unwrap_or_else(|e| e.into_inner());
+    state.record(side);
+    state.failures.push(side);
+}
+
+/// Record a failure that already carries its own structured message.
+///
+/// Used for the pipeline's own [`RimageError`](rimage::error::RimageError)
+/// values, which know their side and would otherwise have to be taken apart and
+/// reassembled to be logged.
+fn record_structured_failure(state: &Arc<Mutex<ProcessingState>>, error: &rimage::error::RimageError) {
+    let side = match error.direction() {
+        rimage::error::Direction::Input => rimage::exit::ExitCode::Input,
+        rimage::error::Direction::Output => rimage::exit::ExitCode::Output,
+    };
+
+    {
+        let mut state = state.lock().unwrap_or_else(|e| e.into_inner());
+        state.record(side);
+        state.failures.push(side);
+    }
+
+    error.log();
 }
 
 /// Limits concurrent image processing to prevent OOM with large images.
@@ -624,7 +729,7 @@ fn main() -> std::process::ExitCode {
                 Ok(pool) => pool,
                 Err(error) => {
                     log::error!("Failed to create image worker pool: {error}");
-                    return std::process::ExitCode::FAILURE;
+                    return std::process::ExitCode::from(rimage::exit::ExitCode::Usage.as_u8());
                 }
             };
 
@@ -648,7 +753,7 @@ fn main() -> std::process::ExitCode {
                 Ok(files) => files,
                 Err(error) => {
                     log::error!("{error}");
-                    return std::process::ExitCode::FAILURE;
+                    return std::process::ExitCode::from(rimage::exit::ExitCode::Usage.as_u8());
                 }
             };
             log::debug!("Resolved files: {files:#?}");
@@ -679,7 +784,7 @@ fn main() -> std::process::ExitCode {
                 Ok(encoder) => encoder.to_extension(),
                 Err(error) => {
                     log::error!("Failed to initialize encoder: {error}");
-                    return std::process::ExitCode::FAILURE;
+                    return std::process::ExitCode::from(rimage::exit::ExitCode::Usage.as_u8());
                 }
             };
             let paths = match get_paths(files, out_dir, suffix, recursive) {
@@ -692,11 +797,11 @@ fn main() -> std::process::ExitCode {
                     .collect::<Vec<_>>(),
                 Ok(_) => {
                     log::error!("No input files found. Check the file paths.");
-                    return std::process::ExitCode::FAILURE;
+                    return std::process::ExitCode::from(rimage::exit::ExitCode::Usage.as_u8());
                 }
                 Err(error) => {
                     log::error!("{error}");
-                    return std::process::ExitCode::FAILURE;
+                    return std::process::ExitCode::from(rimage::exit::ExitCode::Usage.as_u8());
                 }
             };
             let file_count = paths.len() as u64;
@@ -720,14 +825,14 @@ fn main() -> std::process::ExitCode {
                         "Multiple input files resolve to the same output path: {}",
                         output.display()
                     );
-                    return std::process::ExitCode::FAILURE;
+                    return std::process::ExitCode::from(rimage::exit::ExitCode::Usage.as_u8());
                 }
                 if input_key != output_key && input_paths.contains(&output_key) {
                     log::error!(
                         "Output path would overwrite another input file: {}",
                         output.display()
                     );
-                    return std::process::ExitCode::FAILURE;
+                    return std::process::ExitCode::from(rimage::exit::ExitCode::Usage.as_u8());
                 }
             }
             if output_metadata {
@@ -737,7 +842,7 @@ fn main() -> std::process::ExitCode {
                         "Metadata path conflicts with an input or output image: {}",
                         metadata_path.display()
                     );
-                    return std::process::ExitCode::FAILURE;
+                    return std::process::ExitCode::from(rimage::exit::ExitCode::Usage.as_u8());
                 }
             }
 
@@ -768,8 +873,8 @@ fn main() -> std::process::ExitCode {
                         pb.set_message(format!("{}", input.display()));
                         pb.enable_steady_tick(Duration::from_millis(100));
 
-                        // Advance progress bars on all exit paths (including early
-                        // returns from handle_error!).
+                        // Advance progress bars on all exit paths (including the
+                        // early returns from the `fail_file!` calls below).
                         let _finish = FinishGuard {
                             pb: pb.clone(),
                             pb_main: pb_main.clone(),
@@ -785,14 +890,16 @@ fn main() -> std::process::ExitCode {
                         if let Some(backup_path) = &backup_path
                             && paths_equivalent(&output, backup_path)
                         {
-                            log::error!(
+                            refuse_file!(
+                                input,
+                                state,
+                                input,
                                 "{}: output path {} is the same as the --backup path {}; \
                                  use a different --suffix or drop --backup",
                                 input.display(),
                                 output.display(),
                                 backup_path.display()
                             );
-                            return;
                         }
                         // A backup left by an earlier run preserves the
                         // original image; refuse to overwrite or delete it.
@@ -800,29 +907,33 @@ fn main() -> std::process::ExitCode {
                         if let Some(backup_path) = &backup_path {
                             match fs::symlink_metadata(backup_path) {
                                 Ok(_) => {
-                                    log::error!(
+                                    refuse_file!(
+                                        input,
+                                        state,
+                                        input,
                                         "{}: --backup destination already exists: {}; \
                                          refusing to overwrite it",
                                         input.display(),
                                         backup_path.display()
                                     );
-                                    return;
                                 }
                                 Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
                                 Err(error) => {
-                                    log::error!(
+                                    refuse_file!(
+                                        input,
+                                        state,
+                                        input,
                                         "{}: cannot inspect --backup destination {}: {error}",
                                         input.display(),
                                         backup_path.display()
                                     );
-                                    return;
                                 }
                             }
                         }
 
                         let mut ops: Vec<Box<dyn OperationsTrait>> = Vec::new();
 
-                        let input_size = handle_error!(input, input.metadata()).len();
+                        let input_size = fail_file!(input, state, input, input.metadata()).len();
                         let input_format = get_file_extension(&input);
                         let input_modified = get_file_modified_time(&input);
 
@@ -832,7 +943,7 @@ fn main() -> std::process::ExitCode {
                                 ext.eq_ignore_ascii_case("svg") || ext.eq_ignore_ascii_case("svgz")
                             });
 
-                        let mut img = handle_error!(input, decode(&input, matches));
+                        let mut img = fail_pipeline!(state, decode(&input, matches));
 
                         // Preserve JPEG metadata directly from the source file.
                         // EXIF is copied as a raw APP1 segment instead of being
@@ -903,7 +1014,7 @@ fn main() -> std::process::ExitCode {
                         let original_bit_depth = img.depth();
 
                         let mut available_encoder =
-                            handle_error!(input, encoder(subcommand, matches));
+                            fail_file!(input, state, input, encoder(subcommand, matches));
                         let output_format = available_encoder.to_extension().to_string();
 
                         available_encoder.set_jfif_density(jfif_density);
@@ -930,31 +1041,37 @@ fn main() -> std::process::ExitCode {
                             });
 
                         for op in ops {
-                            handle_error!(input, op.execute(&mut img));
+                            fail_file!(input, state, input, op.execute(&mut img));
                         }
 
                         pb.set_style(sty_aux_encode.clone());
 
-                        handle_error!(
+                        fail_file!(
+                            output,
+                            state,
                             output,
                             prepare_output_parent(&output, output_root.as_deref())
                         );
                         let (temporary, output_file) =
-                            handle_error!(output, TemporaryOutput::new(&output));
+                            fail_file!(output, state, output, TemporaryOutput::new(&output));
 
-                        handle_error!(output, available_encoder.encode(&img, output_file));
+                        fail_file!(output, state, output, available_encoder.encode(&img, output_file));
 
-                        if output_format == "jpg" {
-                            if let Some(raw_exif) = raw_exif_app1 {
-                                handle_error!(
-                                    temporary.path,
-                                    insert_jpeg_exif_app1(&temporary.path, &raw_exif)
-                                );
-                            }
+                        if output_format == "jpg"
+                            && let Some(raw_exif) = raw_exif_app1
+                        {
+                            fail_file!(
+                                output,
+                                state,
+                                temporary.path,
+                                insert_jpeg_exif_app1(&temporary.path, &raw_exif)
+                            );
                         }
 
                         if let Some(actual_metadata) = exif_metadata {
-                            handle_error!(
+                            fail_file!(
+                                output,
+                                state,
                                 temporary.path,
                                 actual_metadata.write_to_file(&temporary.path)
                             );
@@ -962,34 +1079,37 @@ fn main() -> std::process::ExitCode {
 
                         if let Some(backup_path) = backup_path.as_deref() {
                             if let Err(error) = create_backup(&input, backup_path) {
-                                log::error!("{}: {error}", input.display());
-                                return;
+                                refuse_file!(output, state, output, "{}: {error}", input.display());
                             }
                             if let Err(error) = temporary.publish(&output) {
                                 if let Err(cleanup_error) = fs::remove_file(backup_path) {
-                                    log::error!(
+                                    refuse_file!(
+                                        output,
+                                        state,
+                                        output,
                                         "{}: publish failed ({error}); removing the new backup also failed: {cleanup_error}",
                                         output.display()
                                     );
                                 } else {
-                                    log::error!("{}: {error}", output.display());
+                                    refuse_file!(output, state, output, "{}: {error}", output.display());
                                 }
-                                return;
                             }
                             if output_path_key(&input) != output_path_key(&output)
                                 && let Err(error) = fs::remove_file(&input)
                             {
-                                log::error!(
+                                refuse_file!(
+                                    output,
+                                    state,
+                                    output,
                                     "{}: output was published and backup created, but the original input could not be removed: {error}",
                                     input.display()
                                 );
-                                return;
                             }
                         } else {
-                            handle_error!(output, temporary.publish(&output));
+                            fail_file!(output, state, output, temporary.publish(&output));
                         }
 
-                        let output_size = handle_error!(output, output.metadata()).len();
+                        let output_size = fail_file!(output, state, output, output.metadata()).len();
                         let processing_time = image_start_time.elapsed().as_millis();
                         let compression_ratio = size_ratio(output_size, input_size);
                         let space_saved = space_saved(input_size, output_size);
@@ -1131,16 +1251,25 @@ fn main() -> std::process::ExitCode {
             } else {
                 "RUST_LOG=debug"
             };
-            let succeeded = state.results.len() as u64;
-            if succeeded < file_count {
+            let failed = state.failures.len() as u64;
+            if failed > 0 {
+                // Split the count by side so the summary says which half of the
+                // pipeline the failures were in, matching the exit code.
+                let input_failures = state
+                    .failures
+                    .iter()
+                    .filter(|side| **side == rimage::exit::ExitCode::Input)
+                    .count() as u64;
+                let output_failures = failed - input_failures;
+
                 log::error!(
-                    "{}/{} file(s) failed. Run with `{}` for details.",
-                    file_count - succeeded,
-                    file_count,
-                    rust_log_hint
+                    "{failed}/{file_count} file(s) failed ({input_failures} reading, \
+                     {output_failures} writing). Run with `{rust_log_hint}` for details."
                 );
-                return std::process::ExitCode::FAILURE;
             }
+
+            // Snapshot the verdict before consuming `state.metadata` below.
+            let run = state.run;
 
             if output_metadata && let Some(metadata) = state.metadata.as_ref() {
                 match serde_json::to_string_pretty(metadata) {
@@ -1154,7 +1283,7 @@ fn main() -> std::process::ExitCode {
                                 "Failed to create metadata directory {}: {error}",
                                 parent.display()
                             );
-                            return std::process::ExitCode::FAILURE;
+                            return report_metadata_failure(run);
                         }
                         match TemporaryOutput::new(&metadata_path) {
                             Ok((temporary, mut file)) => {
@@ -1167,7 +1296,7 @@ fn main() -> std::process::ExitCode {
                                         "Failed to write metadata {}: {error}",
                                         metadata_path.display()
                                     );
-                                    return std::process::ExitCode::FAILURE;
+                                    return report_metadata_failure(run);
                                 }
                             }
                             Err(error) => {
@@ -1175,20 +1304,37 @@ fn main() -> std::process::ExitCode {
                                     "Failed to create metadata output {}: {error}",
                                     metadata_path.display()
                                 );
-                                return std::process::ExitCode::FAILURE;
+                                return report_metadata_failure(run);
                             }
                         }
                     }
                     Err(error) => {
                         log::error!("Failed to serialize metadata: {error}");
-                        return std::process::ExitCode::FAILURE;
+                        return report_metadata_failure(run);
                     }
                 }
             }
+
+            std::process::ExitCode::from(run.exit_code().as_u8())
         }
         None => unreachable!("clap ensures a subcommand is always provided"),
     }
-    std::process::ExitCode::SUCCESS
+}
+
+/// Exit after a failure to write the `--metadata` summary.
+///
+/// The images themselves were already written, so this must not report a clean
+/// failure: the run produced everything the user asked for except the summary,
+/// which is a partial result. It is folded in as an output failure so the
+/// reported code reflects that most of the work succeeded.
+fn report_metadata_failure(
+    run: rimage::exit::RunState,
+) -> std::process::ExitCode {
+    std::process::ExitCode::from(
+        run.record(rimage::exit::ExitCode::Output)
+            .exit_code()
+            .as_u8(),
+    )
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1482,19 +1482,13 @@ mod tests {
     use super::*;
 
     fn test_base() -> PathBuf {
-        if cfg!(windows) {
-            PathBuf::from(r"D:\projects\rimage")
-        } else {
-            PathBuf::from("/projects/rimage")
-        }
+        // Use the crate root (CARGO_MANIFEST_DIR) instead of a hardcoded
+        // path that only works on one developer's machine.
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
     }
 
     fn test_base_src() -> PathBuf {
-        if cfg!(windows) {
-            PathBuf::from(r"D:\projects\rimage\src")
-        } else {
-            PathBuf::from("/projects/rimage/src")
-        }
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src")
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -845,7 +845,7 @@ fn main() -> std::process::ExitCode {
 
     match matches.subcommand() {
         Some((subcommand, matches)) => {
-            let threads = matches.get_one::<u8>("threads").copied().unwrap_or(1) as usize;
+            let threads = matches.get_one::<u16>("threads").copied().unwrap_or(1) as usize;
 
             // Hidden diagnostic: print the runtime-derived limits and exit
             // before touching any files. Used to understand why an image was

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ use serde::{Deserialize, Serialize};
 use zune_core::{bit_depth::BitDepth, colorspace::ColorSpace};
 use zune_image::{
     core_filters::{colorspace::ColorspaceConv, depth::Depth},
+    image::Image,
     traits::OperationsTrait,
 };
 use zune_imageprocs::auto_orient::AutoOrient;
@@ -366,6 +367,61 @@ fn size_ratio(output_size: u64, input_size: u64) -> f64 {
     } else {
         output_size as f64 / input_size as f64
     }
+}
+
+/// Refuse to write `img` when the destination volume cannot hold the result.
+///
+/// Returns the failure wrapped for the caller's side — an unwritable output —
+/// because a full volume is a property of the destination, not of the image.
+///
+/// The estimate deliberately uses the *decoded* footprint rather than a
+/// compressed-size guess: it is the one number this code can know without
+/// encoding first, and it is an upper bound for lossy formats and the right
+/// order of magnitude for lossless ones, which is what a pre-flight check
+/// needs. A volume with room for the decoded pixels will hold any sane
+/// encoding of them.
+#[cfg(feature = "limits")]
+fn check_output_limits(
+    output: &Path, img: &Image, encoder_name: &str,
+) -> std::result::Result<(), rimage::error::RimageError> {
+    use rimage::limits::{ImageFormatId, LimitSet, PipelineCost, SystemBudget, bytes_per_pixel};
+
+    let format = ImageFormatId::from_encoder_name(encoder_name);
+
+    // Only formats with a byte-relevant ceiling need the probe. For everything
+    // else `for_output` still yields the pixel limits, whose byte half is the
+    // memory budget rather than free space, and comparing against that would
+    // reject an image that fits on disk merely because it is near the memory
+    // ceiling — the exact case the decoder already decided.
+    let Some(_free) = rimage::limits::free_space_at(output) else {
+        return Ok(());
+    };
+    let budget = SystemBudget::probe(1);
+    let limits = LimitSet::for_output(
+        format,
+        img.depth(),
+        img.colorspace(),
+        &budget,
+        PipelineCost::for_encoder(format),
+        output,
+    );
+
+    // The byte ceiling only describes *this volume* when free space was the
+    // binding constraint. Otherwise it is the memory budget in disguise, and
+    // rejecting on it would duplicate the decode-time check under a message
+    // about disk space.
+    if limits.bytes_binding != rimage::limits::Binding::Disk {
+        return Ok(());
+    }
+
+    let (width, height) = img.dimensions();
+    let footprint = (width as u64)
+        .saturating_mul(height as u64)
+        .saturating_mul(bytes_per_pixel(img.depth(), img.colorspace()));
+
+    limits
+        .check_bytes(footprint)
+        .map_err(|violation| rimage::error::output_size_limit(output, format, violation))
 }
 
 fn space_saved(input_size: u64, output_size: u64) -> i64 {
@@ -1045,6 +1101,16 @@ fn main() -> std::process::ExitCode {
                         }
 
                         pb.set_style(sty_aux_encode.clone());
+
+                        // Reject an output the destination volume cannot hold
+                        // *before* encoding into a temporary file. The encode
+                        // itself is the expensive part, and a volume that fills
+                        // up mid-write leaves a truncated temporary behind. The
+                        // estimate is the decoded footprint, which is the right
+                        // order of magnitude for both lossless expansion and
+                        // lossy output plus container overhead.
+                        #[cfg(feature = "limits")]
+                        fail_pipeline!(state, check_output_limits(&output, &img, subcommand));
 
                         fail_file!(
                             output,

--- a/src/main.rs
+++ b/src/main.rs
@@ -825,10 +825,20 @@ fn main() -> std::process::ExitCode {
     let sty_aux_operations = ProgressStyle::with_template("{spinner:.yellow} {msg}").unwrap();
     let sty_aux_encode = ProgressStyle::with_template("{spinner:.green} {msg}").unwrap();
 
-    LogWrapper::new(multi.clone(), logger).try_init().unwrap();
+    // try_init may fail if a logger is already installed (e.g. in test
+    // harnesses). Discard the error rather than panicking: the worst case
+    // is that our log filter is not applied, which is non-fatal.
+    let _ = LogWrapper::new(multi.clone(), logger).try_init();
     log::set_max_level(level);
 
-    let current_dir = std::env::current_dir().unwrap_or_default();
+    let current_dir = std::env::current_dir().unwrap_or_else(|error| {
+        // current_dir fails when the CWD was deleted or is inaccessible.
+        // An empty PathBuf causes subsequent path joins to produce relative
+        // paths, which at least does not crash; log the cause so the user
+        // can diagnose the real problem.
+        log::error!("Cannot determine current directory: {error}; using relative paths");
+        PathBuf::new()
+    });
     let matches = cli().get_matches_from(std::env::args());
 
     let state: Arc<Mutex<ProcessingState>> = Arc::new(Mutex::new(ProcessingState::new()));
@@ -1125,7 +1135,7 @@ fn main() -> std::process::ExitCode {
                         // Extract zune-image properties
                         let (w, h) = img.dimensions();
                         let pixel_count = (w as u64) * (h as u64);
-                        let aspect_ratio = w as f64 / h as f64;
+                        let aspect_ratio = if h == 0 { 0.0 } else { w as f64 / h as f64 };
                         let colorspace = img.colorspace();
                         let is_animated = img.is_animated();
                         let frame_count = img.frames_len();

--- a/src/main.rs
+++ b/src/main.rs
@@ -515,6 +515,94 @@ fn colorspace_to_string(colorspace: &ColorSpace) -> String {
     }
 }
 
+/// Print the runtime-derived size limits and exit.
+///
+/// A hidden diagnostic that shows the probed system memory, the per-format
+/// dimension and pixel ceilings, and which source is the binding constraint.
+/// Used to understand why an image was rejected and to calibrate the pipeline
+/// cost estimates.
+#[cfg(feature = "limits")]
+fn print_limits(subcommand: &str, threads: usize) -> std::process::ExitCode {
+    use rimage::error::human_bytes;
+    use rimage::limits::{
+        ImageFormatId, LimitSet, PipelineCost, SystemBudget,
+        bytes_per_pixel,
+    };
+
+    let format = ImageFormatId::from_encoder_name(subcommand);
+    let budget = SystemBudget::probe(threads);
+    let cost = PipelineCost::for_encoder(format);
+    let depth = zune_core::bit_depth::BitDepth::Eight;
+    let colorspace = zune_core::colorspace::ColorSpace::RGBA;
+    let bpp = bytes_per_pixel(depth, colorspace);
+
+    println!("rimage runtime limits");
+    println!("─────────────────────");
+    println!();
+    println!("Encoder:    {subcommand} ({})", format.name());
+    println!("Concurrency: {threads} image(s) at once");
+    println!();
+    println!("System budget");
+    println!("  Available memory:    {}", human_bytes(budget.available_memory));
+    println!("  Address space cap:   {}", human_bytes(budget.address_cap));
+    println!("  Probe status:        {}", if budget.is_probed() { "ok" } else { "fallback (512 MiB)" });
+    println!("  Per-image bytes:     {}", human_bytes(budget.per_image_bytes()));
+    println!();
+
+    let caps = rimage::limits::format_caps(format);
+    println!("Format caps ({})", caps.source);
+    println!("  Max side:   {}", caps.max_side);
+    let max_pixels_str = if caps.max_pixels == u64::MAX {
+        "unbounded".to_string()
+    } else {
+        caps.max_pixels.to_string()
+    };
+    println!("  Max pixels: {max_pixels_str}");
+    println!();
+
+    println!("Pipeline cost");
+    println!("  Decode:   {}×", cost.decode);
+    println!("  Resize:   {}×", cost.resize);
+    println!("  Quantize: {}×", cost.quantize);
+    println!("  Encode:   {}×", cost.encode);
+    println!("  Total:    {}× (× {} B/px = {} B/px)",
+        cost.total(), bpp, cost.total() * bpp);
+    println!();
+
+    let limits = LimitSet::for_input(format, depth, colorspace, &budget, cost);
+    println!("Effective input limits");
+    println!("  Max width:   {}", limits.max_width);
+    println!("  Max height:  {}", limits.max_height);
+    println!("  Max pixels:  {} (≈ {}²)",
+        limits.max_pixels,
+        (limits.max_pixels as f64).sqrt() as u64);
+    println!("  Max bytes:   {}", human_bytes(limits.max_bytes));
+    println!("  Binding:     {}", binding_str(limits.binding));
+    println!("  Byte binding: {}", binding_str(limits.bytes_binding));
+    println!();
+    println!("  Suggested --resize side: {}", limits.suggested_side());
+
+    std::process::ExitCode::SUCCESS
+}
+
+#[cfg(not(feature = "limits"))]
+fn print_limits(_subcommand: &str, _threads: usize) -> std::process::ExitCode {
+    eprintln!("--print-limits requires the 'limits' feature to be enabled at build time.");
+    eprintln!("Rebuild with: cargo b -r --features limits");
+    std::process::ExitCode::from(rimage::exit::ExitCode::Usage.as_u8())
+}
+
+#[cfg(feature = "limits")]
+fn binding_str(binding: rimage::limits::Binding) -> &'static str {
+    use rimage::limits::Binding;
+    match binding {
+        Binding::Format => "format limit",
+        Binding::Memory => "memory budget",
+        Binding::Disk => "disk free space",
+        Binding::None => "none",
+    }
+}
+
 /// Normalize a user-provided file path into its canonical absolute form.
 ///
 /// Handles:
@@ -748,6 +836,14 @@ fn main() -> std::process::ExitCode {
     match matches.subcommand() {
         Some((subcommand, matches)) => {
             let threads = matches.get_one::<u8>("threads").copied().unwrap_or(1) as usize;
+
+            // Hidden diagnostic: print the runtime-derived limits and exit
+            // before touching any files. Used to understand why an image was
+            // rejected and to calibrate the pipeline cost estimates.
+            if matches.get_flag("print-limits") {
+                return print_limits(subcommand, threads);
+            }
+
             let thread_pool = match rayon::ThreadPoolBuilder::new().num_threads(threads).build() {
                 Ok(pool) => pool,
                 Err(error) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1112,35 +1112,27 @@ fn main() -> std::process::ExitCode {
                         #[cfg(feature = "limits")]
                         fail_pipeline!(state, check_output_limits(&output, &img, subcommand));
 
-                        fail_file!(
-                            output,
-                            state,
-                            output,
-                            prepare_output_parent(&output, output_root.as_deref())
-                        );
+                        fail_pipeline!(state, prepare_output_parent(&output, output_root.as_deref())
+                            .map_err(|e| rimage::error::output_io_error(&output, &e)));
                         let (temporary, output_file) =
-                            fail_file!(output, state, output, TemporaryOutput::new(&output));
+                            fail_pipeline!(state, TemporaryOutput::new(&output)
+                                .map_err(|e| rimage::error::output_io_error(&output, &e)));
 
-                        fail_file!(output, state, output, available_encoder.encode(&img, output_file));
+                        fail_pipeline!(state, available_encoder
+                            .encode(&img, output_file)
+                            .map_err(|e| rimage::error::output_encode_error(&output, subcommand, &e)));
 
                         if output_format == "jpg"
                             && let Some(raw_exif) = raw_exif_app1
                         {
-                            fail_file!(
-                                output,
-                                state,
-                                temporary.path,
-                                insert_jpeg_exif_app1(&temporary.path, &raw_exif)
-                            );
+                            fail_pipeline!(state, insert_jpeg_exif_app1(&temporary.path, &raw_exif)
+                                .map_err(|e| rimage::error::output_io_error(&temporary.path, &e)));
                         }
 
                         if let Some(actual_metadata) = exif_metadata {
-                            fail_file!(
-                                output,
-                                state,
-                                temporary.path,
-                                actual_metadata.write_to_file(&temporary.path)
-                            );
+                            fail_pipeline!(state, actual_metadata
+                                .write_to_file(&temporary.path)
+                                .map_err(|e| rimage::error::output_io_error(&temporary.path, &e)));
                         }
 
                         if let Some(backup_path) = backup_path.as_deref() {
@@ -1172,10 +1164,14 @@ fn main() -> std::process::ExitCode {
                                 );
                             }
                         } else {
-                            fail_file!(output, state, output, temporary.publish(&output));
+                            fail_pipeline!(state, temporary
+                                .publish(&output)
+                                .map_err(|e| rimage::error::output_io_error(&output, &e)));
                         }
 
-                        let output_size = fail_file!(output, state, output, output.metadata()).len();
+                        let output_size = fail_pipeline!(state, output
+                            .metadata()
+                            .map_err(|e| rimage::error::output_io_error(&output, &e))).len();
                         let processing_time = image_start_time.elapsed().as_millis();
                         let compression_ratio = size_ratio(output_size, input_size);
                         let space_saved = space_saved(input_size, output_size);

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,43 +37,10 @@ use crate::cli::pipeline::encoder;
 
 mod cli;
 
-/// Report a failure and abandon the current file.
-///
-/// The `side` argument says whether the failure happened reading the input or
-/// writing the output, which is what lets the run end with a code that names
-/// the side. It is passed explicitly rather than inferred so a call site cannot
-/// be mislabelled by accident.
-///
-/// The failure is recorded on the shared [`ProcessingState`] before returning,
-/// so the end-of-run summary can count the sides separately and the process can
-/// exit with the code that matches.
-macro_rules! fail_file {
-    ( input, $state:expr, $path:expr, $e:expr ) => {
-        match $e {
-            Ok(v) => v,
-            Err(e) => {
-                record_failure(&$state, rimage::exit::ExitCode::Input);
-                log::error!("{}: {e}", $path.display());
-                return;
-            }
-        }
-    };
-    ( output, $state:expr, $path:expr, $e:expr ) => {
-        match $e {
-            Ok(v) => v,
-            Err(e) => {
-                record_failure(&$state, rimage::exit::ExitCode::Output);
-                log::error!("{}: {e}", $path.display());
-                return;
-            }
-        }
-    };
-}
-
 /// Report a structured pipeline failure and abandon the current file.
 ///
-/// Unlike [`fail_file!`] the side comes from the error itself, and the message
-/// carries the hint the `error` module derived for it.
+/// The side comes from the error itself (`RimageError::direction`), and the
+/// message carries the hint the `error` module derived for it.
 macro_rules! fail_pipeline {
     ( $state:expr, $e:expr ) => {
         match $e {
@@ -930,7 +897,7 @@ fn main() -> std::process::ExitCode {
                         pb.enable_steady_tick(Duration::from_millis(100));
 
                         // Advance progress bars on all exit paths (including the
-                        // early returns from the `fail_file!` calls below).
+                        // early returns from the `fail_pipeline!` calls below).
                         let _finish = FinishGuard {
                             pb: pb.clone(),
                             pb_main: pb_main.clone(),
@@ -989,7 +956,9 @@ fn main() -> std::process::ExitCode {
 
                         let mut ops: Vec<Box<dyn OperationsTrait>> = Vec::new();
 
-                        let input_size = fail_file!(input, state, input, input.metadata()).len();
+                        let input_size = fail_pipeline!(state, input
+                            .metadata()
+                            .map_err(|e| rimage::error::input_open_error(&input, &e))).len();
                         let input_format = get_file_extension(&input);
                         let input_modified = get_file_modified_time(&input);
 
@@ -1070,7 +1039,8 @@ fn main() -> std::process::ExitCode {
                         let original_bit_depth = img.depth();
 
                         let mut available_encoder =
-                            fail_file!(input, state, input, encoder(subcommand, matches));
+                            fail_pipeline!(state, encoder(subcommand, matches)
+                                .map_err(|e| rimage::error::input_config_error(&input, subcommand, &e)));
                         let output_format = available_encoder.to_extension().to_string();
 
                         available_encoder.set_jfif_density(jfif_density);
@@ -1097,7 +1067,9 @@ fn main() -> std::process::ExitCode {
                             });
 
                         for op in ops {
-                            fail_file!(input, state, input, op.execute(&mut img));
+                            fail_pipeline!(state, op
+                                .execute(&mut img)
+                                .map_err(|e| rimage::error::input_operation_error(&input, &e)));
                         }
 
                         pb.set_style(sty_aux_encode.clone());

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,10 @@ use std::{
 use cli::{
     cli,
     pipeline::{decode, operations},
-    utils::paths::{expand_file_lists, get_paths, paths_equivalent},
+    utils::{
+        jpeg::{insert_jpeg_exif_app1, read_jpeg_source_metadata},
+        paths::{expand_file_lists, get_paths, paths_equivalent},
+    },
 };
 use console::{Term, style};
 use indicatif::{DecimalBytes, MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle};
@@ -830,11 +833,60 @@ fn main() -> std::process::ExitCode {
                             });
 
                         let mut img = handle_error!(input, decode(&input, matches));
-                        let exif_metadata: Option<ExifMetadata> = ExifMetadata::new_from_path(&input)
-                            .ok()
-                            .filter(|_| {
-                                !strip_metadata && SUPPORTS_EXIF.contains(&subcommand)
-                            });
+
+                        // Preserve JPEG metadata directly from the source file.
+                        // EXIF is copied as a raw APP1 segment instead of being
+                        // decoded and re-encoded: little_exif rejects valid JPEGs
+                        // that store ExifVersion as STRING rather than UNDEF.
+                        let jpeg_source_metadata = if strip_metadata {
+                            None
+                        } else {
+                            match read_jpeg_source_metadata(&input) {
+                                Ok(metadata) => metadata,
+                                Err(error) => {
+                                    log::warn!(
+                                        "{}: failed to read source JPEG metadata: {error}",
+                                        input.display()
+                                    );
+                                    None
+                                }
+                            }
+                        };
+
+                        let (jfif_density, raw_exif_app1, source_is_jpeg) =
+                            match jpeg_source_metadata {
+                                Some(metadata) => (
+                                    metadata.jfif_density,
+                                    metadata.exif_app1,
+                                    true,
+                                ),
+                                None => (None, None, false),
+                            };
+
+                        let exif_metadata: Option<ExifMetadata> = if source_is_jpeg
+                            || strip_metadata
+                            || !SUPPORTS_EXIF.contains(&subcommand)
+                        {
+                            None
+                        } else {
+                            match ExifMetadata::new_from_path(&input) {
+                                Ok(metadata) => Some(metadata),
+                                Err(error)
+                                    if error
+                                        .to_string()
+                                        .contains("No EXIF data found") =>
+                                {
+                                    None
+                                }
+                                Err(error) => {
+                                    log::warn!(
+                                        "{}: failed to read EXIF metadata: {error}",
+                                        input.display()
+                                    );
+                                    None
+                                }
+                            }
+                        };
 
                         pb.set_style(sty_aux_operations.clone());
 
@@ -853,6 +905,8 @@ fn main() -> std::process::ExitCode {
                         let mut available_encoder =
                             handle_error!(input, encoder(subcommand, matches));
                         let output_format = available_encoder.to_extension().to_string();
+
+                        available_encoder.set_jfif_density(jfif_density);
 
                         if strip_metadata || !SUPPORTS_ICC.contains(&subcommand) {
                             ops.push(Box::new(ApplySRGB));
@@ -889,6 +943,15 @@ fn main() -> std::process::ExitCode {
                             handle_error!(output, TemporaryOutput::new(&output));
 
                         handle_error!(output, available_encoder.encode(&img, output_file));
+
+                        if output_format == "jpg" {
+                            if let Some(raw_exif) = raw_exif_app1 {
+                                handle_error!(
+                                    temporary.path,
+                                    insert_jpeg_exif_app1(&temporary.path, &raw_exif)
+                                );
+                            }
+                        }
 
                         if let Some(actual_metadata) = exif_metadata {
                             handle_error!(

--- a/src/operations/icc/mod.rs
+++ b/src/operations/icc/mod.rs
@@ -10,6 +10,12 @@ use zune_image::{
 
 /// Apply icc profile
 pub struct ApplyICC {
+    // The Mutex is broader than the single `&profile` borrow `Transform::new`
+    // needs, but lcms2's `Transform<'a>` is lifetime-bound to the profiles
+    // it was built from, so the guard cannot be released while the transform
+    // is alive. In this program each worker constructs its own `ApplySRGB`
+    // instance, so the lock is never contended; it exists only so a shared
+    // instance stays sound across threads.
     profile: Mutex<Profile<GlobalContext>>,
 }
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,3 +1,8 @@
+// Fixtures shared by the codec encoder tests. Which of them are used depends
+// on which codec features are enabled, so every one of them is unused in some
+// configurations — that is expected, not a defect to report.
+#![allow(dead_code)]
+
 use zune_core::{
     bit_depth::{BitDepth, BitType},
     colorspace::ColorSpace,


### PR DESCRIPTION
## Summary

This branch does three things that depend on each other, plus a sweep of build, path-handling and dependency debt.

1. **"Is this image too large" stops being a source-code constant.** It was previously decided by magic numbers scattered across the code, and only discovered *after* the pixel buffer was allocated. It is now derived at runtime from the intersection of three independent sources — the format's own hard cap, the memory available to the process, and free space on the destination volume — and oversized inputs are rejected from their file header, before anything is allocated.
2. **Failures become machine-readable.** Previously "failed to read" and "failed to write" were both a `String` inside one flat enum, naming neither direction nor format. Every error now carries a side, a format, a stable `kind()` slug and an optional `hint`, and the process exit code distinguishes the failure classes.
3. **Nothing panics in place under `panic = "abort"`.** The release profile uses `panic = "abort"`, so a panic in any worker thread kills the whole process, strands temp files and loses the run's exit code. This branch systematically removes `unwrap` / `assert` / unchecked arithmetic from the codec paths, the pipeline and `main`.

## 1. Runtime-derived size ceilings (`limits` module)

A new `limits`-feature-gated `src/limits/` derives the ceiling from the intersection of three sources:

| Source | Content |
| --- | --- |
| Declared by the format | WebP `16383` (libwebp `encode.h`), AVIF `65536` (AV1 coded-image limit); JPEG / PNG derive from the `16384` the decoder actually enforces |
| Process memory budget | `sysinfo` (cgroup-aware) ÷ `--threads` ÷ peak live pixel buffers |
| Destination volume | checked before writing; the estimate is the decoded footprint, the only size known before encoding and an upper bound for lossy output |

- `8b9fa2f` creates the module. Only values with an authoritative, citable source are listed; everything else stays `UNBOUNDED`, so "a library that happens to reject a size today" never gets frozen into the source. `for_input` derives an area ceiling from the per-side cap as `max_side²`, and `per_image_bytes` guards its divisor because the struct is public and a zero concurrency would panic in a method every pixel budget divides by.
- `b2915f9` wires the limits into **every** decode and encode path: WebP gains a libwebp bitstream-features probe (tightest published cap, most likely to be hit); SVG render targets are bounded by the probed budget (`SvgOptions::pixel_budget` becomes injectable, `None` keeps the old constant); the output volume is checked before encoding rather than after a partial write. Two latent defects fall out of routing the budget through the CLI: the divisor was an `RIMAGE_THREADS` environment variable **that nothing ever sets**, so it was always 1 while up to N images were in flight — it is now `--threads`, the value the worker pool is sized from; and `LimitSet` now tracks `bytes_binding` separately from `binding`, so a memory-derived byte ceiling is no longer reported as a disk limit whenever free space happens to look tighter.
- `a19ad70` corrects the JPEG / PNG ceiling source. The pre-check must agree with what the decoder enforces, not the larger encoder-side constant libjpeg can express (`65500`): zune-jpeg and zune-png compare the header against a `DecoderOptions` default of `16384` before allocating, so the old value admitted files the decoder then refused further down, surfacing as the decoder's internal message instead of one naming a limit. The existing extreme-dimension test is rewritten around the largest corpus fixture (65500×2466) and around the two ceilings being compared with each other instead of restated by hand.
- `b4e7275` fixes `free_space_at`, which canonicalized the output path itself — failing for exactly the case the disk pre-check exists for, a brand-new output file — and then silently dropped the disk constraint. On Windows it was worse: canonicalize yields a verbatim `\\?\` path while `sysinfo` reports mount points in the ordinary form, so the prefix match never succeeded and the check was dead on the whole platform. It now walks up to the nearest existing ancestor before canonicalizing and strips the verbatim prefix.
- `576d904` / `b79e30e` / `d03a662` drop the hand-written Newton `integer_sqrt` in favour of `u64::isqrt` (MSRV is now 1.95.0), including the wrapper that remained after the refactor and the conformance test that then only re-tested the stdlib.
- `ad056ea` moves the `PathBuf` import behind the `limits` gate, clearing the one warning the no-default-features build exposed.
- `e264789` adds a hidden `--print-limits` diagnostic: it reports the budget, the per-format caps, the per-stage cost multipliers, and both pixel and byte ceilings with the source that produced each, then exits without touching a file. It is hidden because it exists to diagnose a rejection and to calibrate the cost estimates, not for everyday use; `FILES` becomes optional when it is passed.

## 2. Pre-decode header checks

A ceiling is only useful if it applies **before** the allocation it is meant to prevent — a 200 KB JPEG can be gigabytes of pixels, and discovering that inside the codec means discovering it after the memory is committed, with no `catch_unwind` to recover under `panic = "abort"`.

- `e66b1f0` adds `check_input_limits`: it reads a bounded 64 KiB prefix and compares the declared dimensions against `LimitSet::for_input` first, so rejecting a huge image costs a few kilobytes of I/O however large the image is. The first version covers JPEG only — the one format with a published per-side limit that a header read settles cheaply.
- `0264987` extends the pre-check to PNG (IHDR at a fixed offset), AVIF (walking the ISO-BMFF container chain to the `ispe` box) and TIFF (both byte orders, both SHORT and LONG value widths), extracting the JPEG path into its own function so all four read as one table of "how to ask a header how big it is". Every probe returns `None` when the expected structure is absent rather than defaulting to a size, so a file that is not actually of that format, or is malformed, falls back to decoding instead of being rejected on a misread number.
- `d39fb97` lets an oversized SVG surface as a structured failure. The render target is sized from `--resize` rather than read from the file, so it produced a plain decode error with no hint and no `input.size-limit` kind. `ImageErrors` is an external enum this crate cannot extend and has no "too large" variant, so the only available channel is the message string: the decoder stamps a stable marker plus the dimensions and both pixel counts, and `classify_input` turns that back into `InputError::SizeLimit`. Matching a marker rather than the human-readable prose makes it robust to rewording; a message without the marker still degrades to `input.decode`, so an unrecognised failure is never silently reinterpreted as a size limit.

## 3. Structured errors, run state, exit codes

- `cc17430` adds `RimageError`, which **wraps** rather than replaces `zune_image::errors::ImageErrors` — additive, so nothing that already handles the upstream type breaks, and `Error::source()` / `Display` keep existing `{error}` call sites printing something equivalent. Input failures are classified fully (`Open`, `Decode`, `UnsupportedFormat`, `SizeLimit`, `InvalidResize`), with `UnsupportedFormat` separating the two cases the upstream enum conflates: a decoder missing from the build versus one that does not exist at all, since the advice differs. Output classification deliberately stops at "not classified" — that premise is revisited in `957ed7d`. Two incidental fixes: `ImageErrors`' `Debug` uses `writeln!` at every level, so nested variants carry *several* trailing newlines (trimming all of them, not one, is what keeps a log line a single line); and the resize arm of `classify_input` propagated a missing context as `None`, silently losing the whole error.
- `45daf71` wires in exit codes: `0` success, `2` usage, `3` input, `4` output, `5` partial. `1` stays unused because the runtime reports it for a signal or abort, and reusing it would make a crash look like a handled failure. The run verdict is a `RunState`, not a fold that keeps the last exit code — the latter cannot express that *some* file succeeded (which is what makes a run partial, and what a wrapper must not retry as a no-op) or that no file has been considered yet, and the underlying lattice is not totally ordered (an input failure and an output failure are incomparable: either alone means nothing was written, but together they mean some files were). Hence an explicit join table, verified commutative and associative by test so parallel workers can fold in completion order. Every early exit records itself: six guards that only logged — `--backup` collisions, publish failures — used to return silently and leave the process reporting success, which is how three existing tests caught the change; `refuse_file!` exists so that class of exit cannot be forgotten again. Failures are reported through `RimageError::log`, which keeps the one-line `path: message` shape and appends a `hint:` line plus the stable `kind()` slug.
- `957ed7d` completes output-side classification by overturning the earlier premise: the output path's extension is chosen by the encoder, so unlike an input path it is always ours — `.jpg` means jpeg, `.png` means png — which makes it an authoritative source for the format tag even though the error value carries none. `ImageErrors::IoError` is routed to `OutputError::Io` rather than `Encode`, because those are directory creation, temp-file allocation and publish failures that surfaced during encoding; calling them encoder failures would send the user to the codec settings for a disk problem. The seven output call sites migrate from `fail_file!(output, ...)` to `fail_pipeline!`, so the side comes from the error instead of being declared at the call site.
- `75b8eb1` completes the input side and **removes `fail_file!`**. `InputError::Configuration` is new because `encoder()` refusing a CLI value is not a decode failure — the file was read successfully; what failed is matching configuration to the encoder's capabilities, and labelling it a decode error points the user at a file that was never the problem. With the last call site migrated, every early return in the worker derives its side from the error rather than stating it, so mislabelling one goes from "avoided by convention" to "impossible by construction".
- `9903c02` / `1d68996` make `classify_input` infallible — the doc comment claiming `None` for "files we cannot describe" described an implementation that no longer existed — deleting a forced `expect()`, a dead fallback and a `clone_for_report` helper that duplicated `clone_image_errors`.
- `8798ce8` fixes the output-side hint (the fallback for `OutputError::Encode` was input-side advice — "check that the file is not truncated or corrupt" — attached to a failure that by definition happened after the input decoded fine), and folds in the fix for the failure log line printing the path twice (every `Display` variant already names the file; for the path-less `InvalidResize` the prefix was a bare `": "`).
- `0f4ec90` corrects the exit-code rationale in the comment: a signal death surfaces as 128+SIG (134 for abort) and a Rust panic exits as 101, so `1` is merely the generic failure code shared by countless tools — which is the real reason to avoid it.

## 4. Hardening under `panic = "abort"`

**AVIF** — *not compile-verified locally: dav1d is unavailable on this machine, so the avif feature is covered by CI.*

- `267aced` fixes three memory-safety issues in the decoder: an allocation made without overflow protection (the multiplication can silently wrap on 32-bit targets or with extremely large dimensions, producing an undersized buffer that subsequent writes overflow), and unchecked indexing of two dav1d planes (a corrupted bitstream or mismatched stride would panic the process, taking down the pipeline instead of reporting a decode failure). All three now use checked arithmetic or bounds-checked slicing and return a neutral fallback or a structured error.
- `5daa16d` turns the identity-matrix and alpha-merge loops, which indexed dav1d planes directly, and the 16-bit monochrome path, which sliced them with range indexing, into a single up-front plane-size check that fails the decode. `used_bits` is clamped to `8..=16` (below 8 the `used-8` shifts in the range expansion underflow, above 16 the `1<<used` shifts overflow) as defence in depth, since dav1d only reports 8/10/12.
- `68cdf2a` validates the pixel buffer before handing it to ravif: `as_rgb()` / `as_rgba()` panic on a buffer whose length is not a multiple of the channel count, and ravif trusts the dimensions it is given.

**Other codec paths**

- `6acb3b0` mozjpeg: the CLI restricts quality to `1..=100` but the public `MozJpegOptions` accepts any `f32`, and mozjpeg's internal range assertion panics on the rest. Validate before entering the FFI, with `Range::contains` ruling out NaN for free. Also preserves `&'static str` panic payloads from the mozjpeg catch (only `String` payloads kept their message), documents that `set_pixel_density` is consumed by one encode, drops a colorspace arm identical to the wildcard, and removes a now-unused `mem` import.
- `2ff9515` webp: `WebPConfig::new()` can fail when libwebp initialisation fails, and both the library `Default` impl and the CLI pipeline unwrapped it. The optional config is now stored in the encoder and reported at encode time.
- `d577c21` jpeg: `insert_jpeg_exif_app1` bounded the payload at `u16::MAX` and then added 2 for the length field's own bytes, so a 65534- or 65535-byte payload overflowed the segment length — a panic in debug and a wrapped length producing a malformed JPEG in release. Validate against the true ceiling (`u16::MAX - 2`) before touching the file and pin both boundaries with tests.
- `741408a` svg: `Vec::with_capacity(w * h * 4)` can overflow `usize` on 32-bit targets or with extremely large render targets; the pixel budget check operates in `u64` and does not account for the 32-bit `usize` limit, so this is the last line of defence.
- `bf1fc9e` webp and svg decoders `read_to_end` the whole source with no size limit, so a hostile multi-gigabyte file would exhaust memory before any format check ran — the CLI's limits pre-check only covers CLI callers. Both reads are capped at 256 MiB. The tiff decoder trusted the file's declared dimensions and let `read_image` allocate them, with only the tiff crate's own looser checks as a backstop: images above 100 MP are now rejected before the allocation, and an unrecognised colour type becomes a decode error rather than being encoded as `ColorSpace::Unknown`.
- `a6c0dcd` oxipng and webp cast `usize` dimensions to `u32` for their FFI entry points, silently truncating a >4 Gpx image on a 64-bit host and handing the backend wrong dimensions with the full buffer. Validated with `u32::try_from`.
- `fbb2806` animated WebP and APNG were fully decoded and then discarded, so peak memory was proportional to the frame count — exactly what the size limits are trying to bound. WebP now tries libwebp's still entry point first and keeps the animation decoder only for files that reject it (which also removes the unconditional `MODE_RGBA`, so a file without an alpha channel now decodes as `RGB`; the test asserting `RGBA` was encoding the old behaviour, not a requirement). PNG and JPEG XL go through `DecoderOptions`, which turns off the animated paths; the maximum dimensions are deliberately left at the library default rather than pinned to a second constant that could disagree with `rimage::limits`.

**Pipeline and `main`**

- `f8afcca` replaces an `assert!` in the premultiply position-sensitive logic with a warning and a skip — under `panic = "abort"` it terminated the entire process for what is ultimately a user-facing argument-ordering conflict — and folds in the replacement of five `matches.indices_of("arg").unwrap()` call sites with a defensive `flatten` that degrades to an empty iterator and documents that the pairing is optional rather than load-bearing.
- `8ccf897` hardens three `main()` paths: `aspect_ratio` divided `w/h` as `f64`, producing `inf` when `h == 0` and writing it into JSON metadata as the invalid `Infinity`; `try_init().unwrap()` panics if a global logger was already installed (e.g. in test harnesses); and `current_dir().unwrap_or_default()` silently returned an empty `PathBuf` on failure, now logging the error so the real cause is diagnosable.

## 5. Paths and CLI argument handling

- `0a79a59` stops mangling legitimate `file.list` entries: every line was unconditionally stripped of surrounding quotes and trailing backslashes, which rewrites real Unix file names (`dir\` and `"odd` are valid), and the U+FFFD warning could never fire honestly because `read_to_string` already guarantees valid UTF-8. The list was also read with no size bound. Now only a matched pair of surrounding quotes is stripped, only trailing `/` is dropped, the dead warning is gone, the list is capped at 64 MiB, and the silent root-escape clamp in `normalize_lexically` is escalated from debug to warn since it rewrites where output lands.
- `32a8b99` rejects output names Windows would silently rewrite: Win32 strips trailing dots and spaces, so `out.` or `out ` is written as `out` — a different file than the one the summary reports — and the same normalisation turns `CON .png` into the reserved `CON` device, which the reserved-name check missed because it split on the first dot without trimming.
- `f30967b` rejects degenerate resize values at parse time: the `@` and `%` forms accepted any `f32` (`@0`, `@-2`, `@nan`, `@inf`, `0%`, `-5%` all parsed), and NaN or a negative factor casts to a zero target while infinity saturates to `usize::MAX`, so the failure only surfaced deep inside the resize operation with a message detached from the input. The `WxH` form also accepted zero dimensions (`0x100`) even though `parse_length` rejects a zero length for every anchored form — two halves of the same parser held to different rules.
- `07f5c3b` improves the `WxH` error messages (`x100` / `100x` no longer produce a bare `ParseIntError`) and fixes a `more that` → `more than` typo.
- `b033b5b` parses `--threads` as `u16` rather than `u8`, whose range upper bound was the machine's core count: on hardware with more than 255 cores the flag could never use them all.

## 6. Build, CI and cross-platform

- `b57dd63` removes hardcoded MSVC `14.51.36231` / SDK `10.0.26100.0` from `ci/msvc-env.sh` (they only work on one machine; anywhere else the script failed with "missing directory" and needed manual editing). It now auto-detects the highest-versioned MSVC tools directory across VS editions and the highest-versioned Windows SDK with both `Lib` and `bin`, with `RIMAGE_MSVC_ROOT` / `RIMAGE_SDK_VER` overrides for non-standard layouts.
- `cb81d24` makes the same script work on ARM64 hosts, where the native toolchain lives under `Hostarm64` rather than the hardcoded `Hostx64/x64`. The architecture is parameterised (`RIMAGE_ARCH`, defaulting to x64 because Git Bash itself is x64-only), with a fallback to the x64-hosted cross tools that Windows on ARM runs emulated. The version auto-detection, which claimed to pick the highest MSVC version but actually stopped at the first edition directory containing any toolchain, now gathers and sorts every edition's tools tree.
- `648d8c1` pins the dav1d clone to a verified commit (`3060ebf8`, what 1.5.1 resolved to) in both the musl cross image and `build-dav1d.sh`, since upstream can re-point a tag. The script also gains a usage check (a missing prefix previously surfaced as an unbound variable) and drops the GNU-only `realpath` dependency so the cross-file path resolves on macOS too.
- `eca8cc9` build script: `CARGO_CFG_TARGET_OS` uses `unwrap_or_default`; an empty string never equals `"windows"`, so the fallback correctly skips the Windows resource step.
- `4e8271f` declares the build script's real inputs so Cargo stops re-running the resource compilation whenever any file in the package changes.
- `8b93a0c` test fixtures use `env!("CARGO_MANIFEST_DIR")` instead of hardcoded `D://projects//rimage` and `/projects/rimage`, which only worked on the original developer's machine.
- `449f687` fixes three feature-gating gaps that made non-default builds fail or warn: `AvailableEncoders::encode` matched the MozJpeg/OxiPng/Webp variants without their `#[cfg]` attributes, so any build with one of those codecs disabled hit a hard `E0599` — including the all-zune-codecs build, which had no workaround; `decode_with_fallback` opened its `File` under a `cfg` that forgot tiff, so a tiff-only build referenced an undeclared variable; and the `Seek`/`SeekFrom` import and the fallback's parameters warned whenever all fallback decoders were off. A build with no optional codecs now compiles with zero warnings.
- `7206caa` clears the two remaining warnings outside the normal feature set, which survived precisely because neither shows up in a default build: the `test_utils` image fixtures are unused without any codec feature (the module allows `dead_code` rather than cfg-gating each fixture, since which one is used is a function of the enabled features), and the `limits`-disabled `free_space_at` stub carried no documentation for the fact that its "unknown" answer must not be read as "no space left".
- `4bef112` generates the help epilogue from the enabled features — the static `after_help` table listed avif, svg, tiff, oxipng and both preprocessing operations unconditionally, so a trimmed build advertised subcommands that do not exist.

## 7. Dependencies, docs and lint

- `766a29d` drops the unused `thiserror`: `src/error.rs` hand-writes every `Display` and `std::error::Error` impl and never derives, so the crate was compiled on every `limits` build without a single reference. `sysinfo` stays — it is the only implementation of the cgroup-aware memory probe and the mount-point lookup the size limits depend on.
- `a98df32` replaces the years-unmaintained `pretty_env_logger` 0.5 with `env_logger`; the timestamp is disabled to keep the compact single-line style and colour stays on when stderr is a terminal.
- Documentation: `c8b567f` subsample introduction, `cd0156d` why the SVG intrinsic size is stored unrounded (the decode-time scale factor needs the exact size, 100/99.6 rather than 100/100), `83d8aaf` documents the accepted `--subsample` values 3 and 4, `3fc2afe` why the ICC profile lock spans the transform (lcms2's `Transform<'a>` is lifetime-bound to the profiles it was built from, and each worker builds its own `ApplySRGB`, so the lock is never contended), `0f4ec90` the exit-code rationale.
- Lint and tests: `81cb63a` collapses the repeated metadata segment checks into match guards (`cargo clippy --all-targets -- -D warnings` goes clean, which it was not before); `1d68996` also builds the help codec table as an array literal (`vec_init_then_push`), uses the entry API for the un-premultiply slot (`map_entry`) and drops a blanket `allow(unused_imports)` in `preprocessors`; `5e55c64` covers the JPEG metadata scanner with synthetic JPEGs, including the guard that keeps the first APP0/APP1 copy (confirmed to fail with the guard removed) and the XMP-in-APP1 case that stops a bare APP1 marker from claiming the EXIF slot; `fe640b0` drops the unneeded `unsafe` in the AVIF `ftyp` fixture.
- Carried over from the branch point: `c8b567f` subsample docs, `01bdc7b` colorspace RGB fix, `08e3b39` raw EXIF copy and DPI info, `f0ff21a` pre-release version bump.
- `9891550` sets the version back to `0.13.0`, closing out the pre-release bump.

## Behaviour changes and compatibility

- **The public API change is additive.** `RimageError` wraps rather than replaces `ImageErrors`; `Error::source()` carries the original value and `Display` renders it, so existing `{error}` call sites keep printing something equivalent.
- **MSRV is 1.95.0** (`rust-version`), raised by `sysinfo` behind the `limits` feature.
- **Behaviour changes a caller can observe**: exit codes go from `0/1` to `0/2/3/4/5`, with `1` explicitly reserved for crashes, so wrappers keying off the exit code need updating; `--threads` now actually participates in the memory-budget divisor; a WebP without an alpha channel decodes as `RGB` instead of `RGBA`; animated inputs are decoded as their first frame only.
- **Known-untested area**: the three AVIF commits build on a `dav1d` dependency unavailable on the development machine, so they were not compile-verified locally and are covered by CI.

## Testing and verification

- New or rewritten tests: the `RunState` join table's commutativity and associativity; the JPEG metadata scanner including the reverse-check on the duplicate-segment guard; both EXIF APP1 boundaries; the extreme-dimension case rewritten around the 65500×2466 fixture and the two ceilings compared with each other.
- Warning checks run across feature combinations, covering at least the default set, `--no-default-features --features limits`, and `--no-default-features` — the latter two being the ones that expose the `limits` stub documentation and the `test_utils` fixtures.
- `cargo clippy --all-targets -- -D warnings` is clean, including in the codec-trimmed and no-codec configurations.